### PR TITLE
fix: refactor auth to use getServerSession

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # A Piece of Cake
 
 ## Development
-- `pnpm install`
-- `pnpm dev`
-- `pnpm lint`
-- `pnpm tsc --noEmit`
-- `pnpm test`
+
+1. Install dependencies with [pnpm](https://pnpm.io): `pnpm install`.
+2. Copy `.env.example` to `.env` and provide values for required variables like `NEXTAUTH_SECRET` and `GUEST_PASSWORD`.
+3. Start the development server: `pnpm dev` (runs on [http://localhost:3001](http://localhost:3001)).
+4. Lint the codebase: `pnpm lint`.
+5. Type-check without emitting files: `pnpm tsc --noEmit`.
+6. Run Playwright tests: `pnpm test`.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,6 +2,8 @@
 
 - 2025-08-16: Initial bootstrap with Next.js, Tailwind, shadcn/ui components, guest authentication, Drizzle setup, and Playwright smoke test scaffold.
 
+- 2025-08-16: Refactored authentication to use `getServerSession` for NextAuth v4, fixing runtime `auth` function error.
+
 ## Follow-ups
 - [ ] Add OAuth (Google) + DB adapter for NextAuth
 - [ ] Implement onboarding for Signature Ethos + Credo

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,6 @@
-import { handlers } from '@/lib/auth';
+import NextAuth from 'next-auth';
+import { authOptions } from '@/lib/auth';
 
-export const { GET, POST } = handlers;
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,7 +1,8 @@
-import NextAuth from 'next-auth';
+import { getServerSession, type NextAuthOptions } from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
 
-export const { auth, handlers, signIn, signOut } = NextAuth({
+// Authentication configuration shared between NextAuth route handlers and server utilities.
+export const authOptions: NextAuthOptions = {
   providers: [
     Credentials({
       name: 'Guest',
@@ -21,4 +22,12 @@ export const { auth, handlers, signIn, signOut } = NextAuth({
   pages: {
     signIn: '/signin',
   },
-});
+};
+
+/**
+ * Helper to retrieve the current session on the server.
+ * Using NextAuth v4 we need to wrap getServerSession with our config.
+ */
+export function auth() {
+  return getServerSession(authOptions);
+}


### PR DESCRIPTION
## Summary
- refactor NextAuth setup to export a server-side `auth` helper
- wire API auth route to `NextAuth` with shared options
- document env setup in the README

## Testing
- `pnpm lint` *(fails: Failed to load config "prettier" to extend from)*
- `pnpm tsc --noEmit` *(fails: Could not find a declaration file for module 'pg')*
- `pnpm test` *(fails: Timed out waiting 60000ms from config.webServer)*


------
https://chatgpt.com/codex/tasks/task_e_68a0a57eacb4832ab74ce720057c9b50