### PR TITLE
feat: add interactive 3d cake

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -6,8 +6,10 @@
 
 - 2025-08-17: Replaced auth wrapper with NextAuth factory to fix runtime error.
 - 2025-08-17: Switched to getServerSession helper and direct NextAuth route handler to resolve "auth is not a function" error.
+- 2025-08-17: Added 3D cake component with animated wedges and keyboard-accessible light boxes.
 
 ## Follow-ups
+
 - [ ] Add OAuth (Google) + DB adapter for NextAuth
 - [ ] Implement onboarding for Signature Ethos + Credo
 - [ ] Wire flavors UI to DB

--- a/components/cake/cake-3d.tsx
+++ b/components/cake/cake-3d.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { ContactShadows, OrbitControls } from '@react-three/drei';
+import { a, useSpring } from '@react-spring/three';
+import * as THREE from 'three';
+
+const slices = [
+  { slug: 'planning', color: 'var(--planning)' },
+  { slug: 'flavors', color: 'var(--flavors)' },
+  { slug: 'ingredients', color: 'var(--ingredients)' },
+  { slug: 'review', color: 'var(--review)' },
+  { slug: 'people', color: 'var(--people)' },
+  { slug: 'visibility', color: 'var(--visibility)' },
+];
+
+function usePrefersReducedMotion() {
+  const [prefers, setPrefers] = useState(false);
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const listener = () => setPrefers(media.matches);
+    listener();
+    media.addEventListener('change', listener);
+    return () => media.removeEventListener('change', listener);
+  }, []);
+  return prefers;
+}
+
+interface WedgeProps {
+  geometry: THREE.CylinderGeometry;
+  color: string;
+  dir: [number, number, number];
+  active: boolean;
+  id: string;
+  reduced: boolean;
+}
+
+function Wedge({ geometry, color, dir, active, id, reduced }: WedgeProps) {
+  const distance = reduced ? 0.12 : 0.32;
+  const scale = reduced ? 1.02 : 1.06;
+  const { position, scale: s } = useSpring({
+    position: active ? dir.map((d) => d * distance) : [0, 0, 0],
+    scale: active ? scale : 1,
+    config: reduced
+      ? { tension: 200, friction: 25 }
+      : { mass: 1, tension: 240, friction: 16 },
+  });
+
+  return (
+    <a.mesh
+      id={id}
+      geometry={geometry}
+      castShadow
+      receiveShadow
+      position={position as any}
+      scale={s as any}
+      material-color={color}
+      material-metalness={0.05}
+      material-roughness={0.6}
+    />
+  );
+}
+
+function CakeSVG({
+  activeSlug,
+  userId,
+  reduced,
+}: {
+  activeSlug: string | null;
+  userId: string | number;
+  reduced: boolean;
+}) {
+  const radius = 100;
+  const gap = 0.04;
+  const step = (Math.PI * 2) / 6;
+  return (
+    <svg
+      viewBox="-110 -110 220 220"
+      className="h-64 w-64"
+      aria-hidden="true"
+      data-active-slice={activeSlug ?? 'none'}
+    >
+      <defs>
+        <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%">
+          <feDropShadow dx="0" dy="2" stdDeviation="2" floodOpacity="0.3" />
+        </filter>
+      </defs>
+      {slices.map((slice, i) => {
+        const thetaStart = i * step;
+        const thetaLength = step - gap;
+        const mid = thetaStart + thetaLength / 2;
+        const x1 = radius * Math.cos(thetaStart);
+        const y1 = radius * Math.sin(thetaStart);
+        const x2 = radius * Math.cos(thetaStart + thetaLength);
+        const y2 = radius * Math.sin(thetaStart + thetaLength);
+        const large = thetaLength > Math.PI ? 1 : 0;
+        const d = `M0 0 L${x1} ${y1} A${radius} ${radius} 0 ${large} 1 ${x2} ${y2} Z`;
+        const dir = [Math.cos(mid), Math.sin(mid)];
+        const amp = reduced ? 8 : 20;
+        const translate =
+          activeSlug === slice.slug
+            ? `translate(${dir[0] * amp}, ${dir[1] * amp})`
+            : '';
+        return (
+          <path
+            key={slice.slug}
+            id={`cak3seg-${slice.slug}-${userId}`}
+            d={d}
+            fill={slice.color}
+            transform={translate}
+            filter={activeSlug === slice.slug ? 'url(#shadow)' : undefined}
+            style={{ transition: 'transform 0.25s ease-out' }}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+interface Cake3DProps {
+  activeSlug: string | null;
+  userId: string | number;
+}
+
+export function Cake3D({ activeSlug, userId }: Cake3DProps) {
+  const [webgl, setWebgl] = useState(false);
+  const reduced = usePrefersReducedMotion();
+
+  useEffect(() => {
+    try {
+      const canvas = document.createElement('canvas');
+      const gl =
+        canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+      setWebgl(!!gl);
+    } catch {
+      setWebgl(false);
+    }
+  }, []);
+
+  const radius = 1.5;
+  const height = 0.36;
+  const gap = 0.03;
+  const step = (Math.PI * 2) / 6;
+
+  const wedges = useMemo(() => {
+    return slices.map((slice, i) => {
+      const thetaStart = i * step;
+      const thetaLength = step - gap;
+      const mid = thetaStart + thetaLength / 2;
+      const geometry = new THREE.CylinderGeometry(
+        radius,
+        radius,
+        height,
+        64,
+        1,
+        false,
+        thetaStart,
+        thetaLength,
+      );
+      const dir: [number, number, number] = [Math.cos(mid), 0, Math.sin(mid)];
+      return { ...slice, geometry, dir };
+    });
+  }, [gap, height, radius, step]);
+
+  if (!webgl) {
+    return (
+      <CakeSVG activeSlug={activeSlug} userId={userId} reduced={reduced} />
+    );
+  }
+
+  return (
+    <Canvas
+      className="h-64 w-64 pointer-events-none"
+      shadows
+      camera={{ position: [0, 2.5, 4], fov: 40 }}
+      data-active-slice={activeSlug ?? 'none'}
+    >
+      <ambientLight intensity={0.6} />
+      <directionalLight
+        position={[5, 5, 5]}
+        intensity={1}
+        castShadow
+        shadow-mapSize={[1024, 1024]}
+      />
+      <group rotation={[-0.28, 0, 0]}>
+        {wedges.map((w) => (
+          <Wedge
+            key={w.slug}
+            id={`cak3seg-${w.slug}-${userId}`}
+            geometry={w.geometry}
+            color={w.color}
+            dir={w.dir}
+            active={activeSlug === w.slug}
+            reduced={reduced}
+          />
+        ))}
+      </group>
+      <ContactShadows
+        position={[0, -height / 2, 0]}
+        opacity={0.4}
+        scale={4}
+        blur={2}
+        far={2}
+      />
+      <OrbitControls enabled={false} />
+    </Canvas>
+  );
+}

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useState } from 'react';
+import { Cake3D } from './cake-3d';
 import { t } from '@/lib/i18n';
 
 function IconBase({ children, ...props }: React.SVGProps<SVGSVGElement>) {
@@ -72,50 +75,57 @@ interface Slice {
 }
 
 const slices: Slice[] = [
-  { key: 'planning', href: '/planning', Icon: CalendarIcon, color: 'var(--planning)' },
-  { key: 'flavors', href: '/flavors', Icon: SwirlIcon, color: 'var(--flavors)' },
-  { key: 'ingredients', href: '/ingredients', Icon: FlaskIcon, color: 'var(--ingredients)' },
+  {
+    key: 'planning',
+    href: '/planning',
+    Icon: CalendarIcon,
+    color: 'var(--planning)',
+  },
+  {
+    key: 'flavors',
+    href: '/flavors',
+    Icon: SwirlIcon,
+    color: 'var(--flavors)',
+  },
+  {
+    key: 'ingredients',
+    href: '/ingredients',
+    Icon: FlaskIcon,
+    color: 'var(--ingredients)',
+  },
   { key: 'review', href: '/review', Icon: StarIcon, color: 'var(--review)' },
   { key: 'people', href: '/people', Icon: UsersIcon, color: 'var(--people)' },
-  { key: 'visibility', href: '/visibility', Icon: EyeIcon, color: 'var(--visibility)' },
+  {
+    key: 'visibility',
+    href: '/visibility',
+    Icon: EyeIcon,
+    color: 'var(--visibility)',
+  },
 ];
 
 export function CakeNavigation() {
   const router = useRouter();
+  const { data: session } = useSession();
+  const userId = (session?.user as any)?.id ?? '0';
+  const [activeSlug, setActiveSlug] = useState<string | null>(null);
 
   return (
     <div className="flex flex-col items-center gap-8">
-      <div className="relative h-64 w-64 rounded-full bg-[var(--surface)] shadow-md">
-        {slices.map((slice, i) => {
-          const rotate = i * 60;
-          return (
-            <button
-              key={slice.key}
-              aria-label={t(`nav.${slice.key}`)}
-              onClick={() => router.push(slice.href)}
-              style={{
-                transform: `rotate(${rotate}deg)`,
-                backgroundColor: slice.color,
-              }}
-              className="absolute left-1/2 top-1/2 h-1/2 w-1/2 -translate-x-full -translate-y-full origin-bottom-left rounded-br-[100%] p-2 text-[var(--text)] transition-transform duration-200 ease-out hover:scale-[1.03] active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
-            >
-              <div
-                className="flex h-full w-full flex-col items-center justify-center gap-1"
-                style={{ transform: `rotate(-${rotate}deg)` }}
-              >
-                <slice.Icon className="h-5 w-5" />
-                <span className="text-xs">{t(`nav.${slice.key}`)}</span>
-              </div>
-            </button>
-          );
-        })}
-      </div>
+      <Cake3D activeSlug={activeSlug} userId={userId} />
+      <p aria-live="polite" className="sr-only">
+        {activeSlug ? `${t(`nav.${activeSlug}`)} slice highlighted` : ''}
+      </p>
       <nav className="grid w-full max-w-md grid-cols-2 gap-2 sm:grid-cols-3">
         {slices.map((slice) => (
           <button
             key={slice.key}
+            id={`n4vbox-${slice.key}-${userId}`}
             aria-label={t(`nav.${slice.key}`)}
             onClick={() => router.push(slice.href)}
+            onMouseEnter={() => setActiveSlug(slice.key)}
+            onMouseLeave={() => setActiveSlug(null)}
+            onFocus={() => setActiveSlug(slice.key)}
+            onBlur={() => setActiveSlug(null)}
             className="flex items-center justify-center gap-2 rounded border bg-[var(--surface)] p-4 text-sm text-[var(--text)] transition-transform duration-200 hover:scale-[1.03] active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
           >
             <slice.Icon className="h-4 w-4" />

--- a/package.json
+++ b/package.json
@@ -22,7 +22,11 @@
     "react": "19.1.1",
     "react-dom": "19.1.1",
     "tailwind-merge": "^2.2.2",
-    "tailwindcss": "^3.4.1"
+    "tailwindcss": "^3.4.1",
+    "three": "^0.165.0",
+    "@react-three/fiber": "^8.15.16",
+    "@react-three/drei": "^9.114.2",
+    "@react-spring/three": "^9.7.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0",


### PR DESCRIPTION
## Summary
- add `Cake3D` component rendering six wedges with springs and SVG fallback
- wire dashboard light boxes to animate matching wedge and announce active slice
- document change in update log and add required 3D dependencies

## Testing
- `pnpm lint`
- `pnpm tsc` *(fails: Cannot find module '@react-three/fiber')*
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a18f018510832abbd4f1e14cba54a7