### PR TITLE
feat: add CSS 3D cake with animated wedges

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -13,3 +13,4 @@
 - [ ] Wire flavors UI to DB
 - [ ] Add visibility model and guards
 - [ ] Add AI coach stub endpoint/action
+- 2025-08-18: Added CSS-based 3D cake with animated wedges linked to navigation boxes.

--- a/components/cake/cake-3d.tsx
+++ b/components/cake/cake-3d.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { slices } from './slices';
+
+interface Cake3DProps {
+  activeSlug: string | null;
+  userId: string | number;
+}
+
+export function Cake3D({ activeSlug, userId }: Cake3DProps) {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handler = () => setReduced(media.matches);
+    setReduced(media.matches);
+    media.addEventListener('change', handler);
+    return () => media.removeEventListener('change', handler);
+  }, []);
+
+  const distance = reduced ? 12 : 40;
+  const scaleActive = reduced ? 1.02 : 1.06;
+  const transition = reduced
+    ? 'transform 200ms ease-out'
+    : 'transform 260ms cubic-bezier(0.34,1.56,0.64,1)';
+
+  return (
+    <div
+      className="relative h-64 w-64 [perspective:800px]"
+      data-active-slice={activeSlug ?? 'none'}
+    >
+      <div
+        className="absolute left-1/2 top-1/2 h-64 w-64 -translate-x-1/2 -translate-y-1/2 [transform-style:preserve-3d]"
+        style={{ transform: 'rotateX(-35deg)' }}
+      >
+        {slices.map((slice, i) => {
+          const rotate = i * 60;
+          const mid = rotate + 30;
+          const rad = (mid * Math.PI) / 180;
+          const isActive = activeSlug === slice.slug;
+          const dx = isActive ? Math.cos(rad) * distance : 0;
+          const dz = isActive ? Math.sin(rad) * distance : 0;
+          const scale = isActive ? scaleActive : 1;
+
+          return (
+            <div
+              key={slice.slug}
+              id={`cak3seg-${slice.slug}-${userId}`}
+              aria-hidden
+              className="pointer-events-none absolute inset-0 flex items-center justify-center"
+              style={{
+                transform: `translate3d(${dx}px,0,${dz}px) scale(${scale})`,
+                transition,
+              }}
+            >
+              <div
+                className="pointer-events-none absolute left-1/2 top-1/2 h-1/2 w-1/2 -translate-x-full -translate-y-full origin-bottom-left rounded-br-[100%] shadow-md"
+                style={{
+                  transform: `rotate(${rotate}deg)` ,
+                  backgroundColor: slice.color,
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -1,128 +1,41 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { t } from '@/lib/i18n';
-
-function IconBase({ children, ...props }: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      {...props}
-    >
-      {children}
-    </svg>
-  );
-}
-
-const CalendarIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <IconBase {...props}>
-    <rect x="3" y="4" width="18" height="18" rx="2" />
-    <line x1="16" y1="2" x2="16" y2="6" />
-    <line x1="8" y1="2" x2="8" y2="6" />
-    <line x1="3" y1="10" x2="21" y2="10" />
-  </IconBase>
-);
-
-const SwirlIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <IconBase {...props}>
-    <path d="M21 12a9 9 0 1 1-6-8.5" />
-  </IconBase>
-);
-
-const FlaskIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <IconBase {...props}>
-    <path d="M10 2h4" />
-    <path d="M12 2v10" />
-    <path d="M8.5 11.5h7L19 22H5l3.5-10.5z" />
-  </IconBase>
-);
-
-const StarIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <IconBase {...props}>
-    <polygon points="12 2 15 9 22 9 17 14 19 21 12 17 5 21 7 14 2 9 9 9 12 2" />
-  </IconBase>
-);
-
-const UsersIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <IconBase {...props}>
-    <circle cx="9" cy="7" r="4" />
-    <circle cx="17" cy="7" r="4" />
-    <path d="M2 21a7 7 0 0 1 14 0" />
-    <path d="M10 21a7 7 0 0 1 14 0" />
-  </IconBase>
-);
-
-const EyeIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <IconBase {...props}>
-    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8" />
-    <circle cx="12" cy="12" r="3" />
-  </IconBase>
-);
-
-interface Slice {
-  key: string;
-  href: string;
-  Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-  color: string;
-}
-
-const slices: Slice[] = [
-  { key: 'planning', href: '/planning', Icon: CalendarIcon, color: 'var(--planning)' },
-  { key: 'flavors', href: '/flavors', Icon: SwirlIcon, color: 'var(--flavors)' },
-  { key: 'ingredients', href: '/ingredients', Icon: FlaskIcon, color: 'var(--ingredients)' },
-  { key: 'review', href: '/review', Icon: StarIcon, color: 'var(--review)' },
-  { key: 'people', href: '/people', Icon: UsersIcon, color: 'var(--people)' },
-  { key: 'visibility', href: '/visibility', Icon: EyeIcon, color: 'var(--visibility)' },
-];
+import { slices } from './slices';
+import { Cake3D } from './cake-3d';
 
 export function CakeNavigation() {
   const router = useRouter();
+  const [activeSlug, setActiveSlug] = useState<string | null>(null);
+  const userId = '42';
 
   return (
     <div className="flex flex-col items-center gap-8">
-      <div className="relative h-64 w-64 rounded-full bg-[var(--surface)] shadow-md">
-        {slices.map((slice, i) => {
-          const rotate = i * 60;
-          return (
-            <button
-              key={slice.key}
-              aria-label={t(`nav.${slice.key}`)}
-              onClick={() => router.push(slice.href)}
-              style={{
-                transform: `rotate(${rotate}deg)`,
-                backgroundColor: slice.color,
-              }}
-              className="absolute left-1/2 top-1/2 h-1/2 w-1/2 -translate-x-full -translate-y-full origin-bottom-left rounded-br-[100%] p-2 text-[var(--text)] transition-transform duration-200 ease-out hover:scale-[1.03] active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
-            >
-              <div
-                className="flex h-full w-full flex-col items-center justify-center gap-1"
-                style={{ transform: `rotate(-${rotate}deg)` }}
-              >
-                <slice.Icon className="h-5 w-5" />
-                <span className="text-xs">{t(`nav.${slice.key}`)}</span>
-              </div>
-            </button>
-          );
-        })}
-      </div>
+      <Cake3D activeSlug={activeSlug} userId={userId} />
       <nav className="grid w-full max-w-md grid-cols-2 gap-2 sm:grid-cols-3">
         {slices.map((slice) => (
           <button
-            key={slice.key}
-            aria-label={t(`nav.${slice.key}`)}
+            key={slice.slug}
+            id={`n4vbox-${slice.slug}-${userId}`}
+            aria-label={t(`nav.${slice.slug}`)}
             onClick={() => router.push(slice.href)}
+            onMouseEnter={() => setActiveSlug(slice.slug)}
+            onMouseLeave={() => setActiveSlug(null)}
+            onFocus={() => setActiveSlug(slice.slug)}
+            onBlur={() => setActiveSlug(null)}
             className="flex items-center justify-center gap-2 rounded border bg-[var(--surface)] p-4 text-sm text-[var(--text)] transition-transform duration-200 hover:scale-[1.03] active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
           >
             <slice.Icon className="h-4 w-4" />
-            {t(`nav.${slice.key}`)}
+            {t(`nav.${slice.slug}`)}
           </button>
         ))}
       </nav>
+      <p className="sr-only" aria-live="polite">
+        {activeSlug ? `${t(`nav.${activeSlug}`)} slice highlighted` : ''}
+      </p>
     </div>
   );
 }
+

--- a/components/cake/slices.tsx
+++ b/components/cake/slices.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+function IconBase({ children, ...props }: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export const CalendarIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <IconBase {...props}>
+    <rect x="3" y="4" width="18" height="18" rx="2" />
+    <line x1="16" y1="2" x2="16" y2="6" />
+    <line x1="8" y1="2" x2="8" y2="6" />
+    <line x1="3" y1="10" x2="21" y2="10" />
+  </IconBase>
+);
+
+export const SwirlIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <IconBase {...props}>
+    <path d="M21 12a9 9 0 1 1-6-8.5" />
+  </IconBase>
+);
+
+export const FlaskIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <IconBase {...props}>
+    <path d="M10 2h4" />
+    <path d="M12 2v10" />
+    <path d="M8.5 11.5h7L19 22H5l3.5-10.5z" />
+  </IconBase>
+);
+
+export const StarIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <IconBase {...props}>
+    <polygon points="12 2 15 9 22 9 17 14 19 21 12 17 5 21 7 14 2 9 9 9 12 2" />
+  </IconBase>
+);
+
+export const UsersIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <IconBase {...props}>
+    <circle cx="9" cy="7" r="4" />
+    <circle cx="17" cy="7" r="4" />
+    <path d="M2 21a7 7 0 0 1 14 0" />
+    <path d="M10 21a7 7 0 0 1 14 0" />
+  </IconBase>
+);
+
+export const EyeIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <IconBase {...props}>
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8" />
+    <circle cx="12" cy="12" r="3" />
+  </IconBase>
+);
+
+export interface Slice {
+  slug: string;
+  href: string;
+  Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  color: string;
+}
+
+export const slices: Slice[] = [
+  { slug: 'planning', href: '/planning', Icon: CalendarIcon, color: 'var(--planning)' },
+  { slug: 'flavors', href: '/flavors', Icon: SwirlIcon, color: 'var(--flavors)' },
+  { slug: 'ingredients', href: '/ingredients', Icon: FlaskIcon, color: 'var(--ingredients)' },
+  { slug: 'review', href: '/review', Icon: StarIcon, color: 'var(--review)' },
+  { slug: 'people', href: '/people', Icon: UsersIcon, color: 'var(--people)' },
+  { slug: 'visibility', href: '/visibility', Icon: EyeIcon, color: 'var(--visibility)' },
+];
+


### PR DESCRIPTION
## Summary
- render a CSS-based 3D cake with six wedges and reduced-motion support
- link light box hover/focus to wedge animations and announce active slice for screen readers
- centralize slice definitions and document update

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a18f018510832abbd4f1e14cba54a7