### PR TITLE
feat: refine cake navigation layout

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -6,3 +6,5 @@ Examples:
 - `u53r{userId}` → user record (e.g., `u53r42`).
 - `f7avour{flavorId}-{userId}` → flavor owned by a user (e.g., `f7avour12-42`).
 - `f7avourde5cr{flavorId}-{userId}` → description field for a flavor (e.g., `f7avourde5cr12-42`).
+- `cak3seg-{slug}-{userId}` → cake slice group element (e.g., `cak3seg-planning-42`).
+- `cak3lbl-{slug}-{userId}` → cake slice label element (e.g., `cak3lbl-planning-42`).

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -14,3 +14,4 @@
 - [ ] Add visibility model and guards
 - [ ] Add AI coach stub endpoint/action
 - 2025-08-18: Added CSS-based 3D cake with animated wedges linked to navigation boxes.
+- 2025-08-18: Centered cake, lowered nav boxes, added labels, enlarged cake, and enabled slice click navigation.

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -15,7 +15,7 @@ export default async function AppLayout({
 
   return (
     <html lang="en">
-      <body>
+      <body className="flex min-h-screen flex-col">
         <nav className="flex items-center justify-between border-b p-4">
           <ul className="flex gap-4">
             <li><Link href="/">Cake</Link></li>
@@ -30,7 +30,7 @@ export default async function AppLayout({
             <Button type="submit">Sign out</Button>
           </form>
         </nav>
-        <main className="p-4">{children}</main>
+        <main className="flex flex-1 flex-col p-4">{children}</main>
       </body>
     </html>
   );

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -3,7 +3,7 @@ import { t } from '@/lib/i18n';
 
 export default function DashboardPage() {
   return (
-    <section className="flex flex-col items-center justify-center gap-8">
+    <section className="flex flex-1 flex-col">
       <h1 className="sr-only">{t('nav.cake')}</h1>
       <CakeNavigation />
     </section>

--- a/components/cake/cake-3d.tsx
+++ b/components/cake/cake-3d.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { t } from '@/lib/i18n';
 import { slices } from './slices';
 
 interface Cake3DProps {
   activeSlug: string | null;
   userId: string | number;
+  onSliceClick?: (slug: string) => void;
 }
 
-export function Cake3D({ activeSlug, userId }: Cake3DProps) {
+export function Cake3D({ activeSlug, userId, onSliceClick }: Cake3DProps) {
   const [reduced, setReduced] = useState(false);
 
   useEffect(() => {
@@ -19,19 +21,25 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
     return () => media.removeEventListener('change', handler);
   }, []);
 
-  const distance = reduced ? 12 : 40;
+  const distance = reduced ? 15 : 50;
   const scaleActive = reduced ? 1.02 : 1.06;
   const transition = reduced
     ? 'transform 200ms ease-out'
     : 'transform 260ms cubic-bezier(0.34,1.56,0.64,1)';
 
+  const size = 320; // px
+  const radius = size / 2;
+  const labelOffset = radius * 0.72;
+  const fontSize = radius * 0.18;
+  const maxLabelWidth = radius * 0.8;
+
   return (
     <div
-      className="relative h-64 w-64 [perspective:800px]"
+      className="relative h-80 w-80 [perspective:800px]"
       data-active-slice={activeSlug ?? 'none'}
     >
       <div
-        className="absolute left-1/2 top-1/2 h-64 w-64 -translate-x-1/2 -translate-y-1/2 [transform-style:preserve-3d]"
+        className="absolute left-1/2 top-1/2 h-80 w-80 -translate-x-1/2 -translate-y-1/2 [transform-style:preserve-3d]"
         style={{ transform: 'rotateX(-35deg)' }}
       >
         {slices.map((slice, i) => {
@@ -42,25 +50,50 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
           const dx = isActive ? Math.cos(rad) * distance : 0;
           const dz = isActive ? Math.sin(rad) * distance : 0;
           const scale = isActive ? scaleActive : 1;
+          const label = t(`nav.${slice.slug}`);
 
           return (
             <div
               key={slice.slug}
               id={`cak3seg-${slice.slug}-${userId}`}
-              aria-hidden
-              className="pointer-events-none absolute inset-0 flex items-center justify-center"
+              className="absolute inset-0 flex items-center justify-center"
               style={{
                 transform: `translate3d(${dx}px,0,${dz}px) scale(${scale})`,
                 transition,
               }}
             >
               <div
-                className="pointer-events-none absolute left-1/2 top-1/2 h-1/2 w-1/2 -translate-x-full -translate-y-full origin-bottom-left rounded-br-[100%] shadow-md"
+                className="pointer-events-none absolute left-1/2 top-1/2 h-1/2 w-1/2 -translate-x-full -translate-y-full origin-bottom-left rounded-br-[100%] shadow-lg"
                 style={{
-                  transform: `rotate(${rotate}deg)` ,
+                  transform: `rotate(${rotate}deg)`,
                   backgroundColor: slice.color,
                 }}
               />
+              <button
+                className="absolute left-1/2 top-1/2 h-1/2 w-1/2 -translate-x-full -translate-y-full origin-bottom-left rounded-br-[100%] bg-transparent cursor-pointer focus:outline-none"
+                style={{ transform: `rotate(${rotate}deg)` }}
+                aria-label={label}
+                onClick={() => onSliceClick?.(slice.slug)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onSliceClick?.(slice.slug);
+                  }
+                }}
+              />
+              <span
+                id={`cak3lbl-${slice.slug}-${userId}`}
+                className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 select-none text-center font-medium text-[var(--text)]"
+                style={{
+                  transform: `rotate(${mid}deg) translateY(-${labelOffset}px) rotate(${-mid}deg)`,
+                  fontSize: `${fontSize}px`,
+                  maxWidth: `${maxLabelWidth}px`,
+                  lineHeight: '1.1',
+                  textShadow: '0 0 2px rgba(0,0,0,0.4)',
+                }}
+              >
+                {label}
+              </span>
             </div>
           );
         })}

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -9,12 +9,28 @@ import { Cake3D } from './cake-3d';
 export function CakeNavigation() {
   const router = useRouter();
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
+  const [announcement, setAnnouncement] = useState('');
   const userId = '42';
 
+  const handleSliceClick = (slug: string) => {
+    const slice = slices.find((s) => s.slug === slug);
+    if (slice) {
+      router.push(slice.href);
+      const label = t(`nav.${slice.slug}`);
+      setAnnouncement(`${label} opened`);
+    }
+  };
+
   return (
-    <div className="flex flex-col items-center gap-8">
-      <Cake3D activeSlug={activeSlug} userId={userId} />
-      <nav className="grid w-full max-w-md grid-cols-2 gap-2 sm:grid-cols-3">
+    <div className="flex flex-1 flex-col">
+      <div className="flex flex-1 items-center justify-center">
+        <Cake3D
+          activeSlug={activeSlug}
+          userId={userId}
+          onSliceClick={handleSliceClick}
+        />
+      </div>
+      <nav className="mt-[clamp(48px,8vh,120px)] grid w-full max-w-md grid-cols-2 gap-2 sm:grid-cols-3">
         {slices.map((slice) => (
           <button
             key={slice.slug}
@@ -35,6 +51,7 @@ export function CakeNavigation() {
       <p className="sr-only" aria-live="polite">
         {activeSlug ? `${t(`nav.${activeSlug}`)} slice highlighted` : ''}
       </p>
+      <p className="sr-only" aria-live="polite">{announcement}</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- center cake and push navigation boxes lower
- enlarge cake with on-cake labels and click navigation

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a1921dff7c832aaa69ff3a691ae237