### PR TITLE
Center cake layout and add slice labels

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -6,3 +6,6 @@ Examples:
 - `u53r{userId}` → user record (e.g., `u53r42`).
 - `f7avour{flavorId}-{userId}` → flavor owned by a user (e.g., `f7avour12-42`).
 - `f7avourde5cr{flavorId}-{userId}` → description field for a flavor (e.g., `f7avourde5cr12-42`).
+- `n4vbox-{slug}-{userId}` → dashboard navigation box (e.g., `n4vbox-planning-42`).
+- `cak3seg-{slug}-{userId}` → cake slice group (e.g., `cak3seg-planning-42`).
+- `cak3lbl-{slug}-{userId}` → cake slice label (e.g., `cak3lbl-planning-42`).

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -14,3 +14,5 @@
 - [ ] Add visibility model and guards
 - [ ] Add AI coach stub endpoint/action
 - 2025-08-18: Added CSS-based 3D cake with animated wedges linked to navigation boxes.
+
+- 2025-08-19: Centered cake and boxes layout, added internal slice labels and clickable slice navigation with stable IDs.

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -3,9 +3,9 @@ import { t } from '@/lib/i18n';
 
 export default function DashboardPage() {
   return (
-    <section className="flex flex-col items-center justify-center gap-8">
+    <>
       <h1 className="sr-only">{t('nav.cake')}</h1>
       <CakeNavigation />
-    </section>
+    </>
   );
 }

--- a/components/cake/cake-3d.tsx
+++ b/components/cake/cake-3d.tsx
@@ -1,15 +1,19 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { t } from '@/lib/i18n';
 import { slices } from './slices';
 
 interface Cake3DProps {
   activeSlug: string | null;
   userId: string | number;
+  onNavigate?: (href: string, slug: string) => void;
 }
 
-export function Cake3D({ activeSlug, userId }: Cake3DProps) {
+export function Cake3D({ activeSlug, userId, onNavigate }: Cake3DProps) {
   const [reduced, setReduced] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     const media = window.matchMedia('(prefers-reduced-motion: reduce)');
@@ -19,7 +23,7 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
     return () => media.removeEventListener('change', handler);
   }, []);
 
-  const distance = reduced ? 12 : 40;
+  const distance = reduced ? 16 : 40;
   const scaleActive = reduced ? 1.02 : 1.06;
   const transition = reduced
     ? 'transform 200ms ease-out'
@@ -32,7 +36,7 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
     >
       <div
         className="absolute left-1/2 top-1/2 h-64 w-64 -translate-x-1/2 -translate-y-1/2 [transform-style:preserve-3d]"
-        style={{ transform: 'rotateX(-35deg)' }}
+        style={{ transform: 'rotateX(-35deg) scale(1.3)' }}
       >
         {slices.map((slice, i) => {
           const rotate = i * 60;
@@ -42,25 +46,58 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
           const dx = isActive ? Math.cos(rad) * distance : 0;
           const dz = isActive ? Math.sin(rad) * distance : 0;
           const scale = isActive ? scaleActive : 1;
+          const radius = 128;
+          const labelRadius = radius * 0.58;
+          const labelSize = Math.min(radius * 0.18, 24);
+          const lx = Math.cos(rad) * labelRadius;
+          const lz = Math.sin(rad) * labelRadius;
+
+          function navigate() {
+            if (onNavigate) onNavigate(slice.href, slice.slug);
+            else router.push(slice.href);
+          }
 
           return (
             <div
               key={slice.slug}
-              id={`cak3seg-${slice.slug}-${userId}`}
-              aria-hidden
-              className="pointer-events-none absolute inset-0 flex items-center justify-center"
+              className="absolute inset-0 flex items-center justify-center"
               style={{
                 transform: `translate3d(${dx}px,0,${dz}px) scale(${scale})`,
                 transition,
               }}
             >
-              <div
-                className="pointer-events-none absolute left-1/2 top-1/2 h-1/2 w-1/2 -translate-x-full -translate-y-full origin-bottom-left rounded-br-[100%] shadow-md"
+              <button
+                id={`cak3seg-${slice.slug}-${userId}`}
+                aria-label={t(`nav.${slice.slug}`)}
+                role="link"
+                tabIndex={0}
+                onClick={navigate}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    navigate();
+                  }
+                }}
+                className="relative block h-1/2 w-1/2 -translate-x-full -translate-y-full origin-bottom-left rounded-br-[100%] shadow-md cursor-pointer"
                 style={{
-                  transform: `rotate(${rotate}deg)` ,
+                  transform: `rotate(${rotate}deg) translateZ(1px)`,
                   backgroundColor: slice.color,
                 }}
-              />
+              >
+                <span
+                  id={`cak3lbl-${slice.slug}-${userId}`}
+                  className="pointer-events-none absolute whitespace-nowrap rounded px-1 py-px text-center text-neutral-900 dark:text-neutral-100"
+                  style={{
+                    left: '50%',
+                    top: '50%',
+                    transform: `translate(-50%,-50%) translate3d(${lx}px,-20px,${lz}px) rotateX(35deg)`,
+                    fontSize: `${labelSize}px`,
+                    backgroundColor: 'rgba(0,0,0,0.12)',
+                  }}
+                >
+                  {t(`nav.${slice.slug}`)}
+                </span>
+              </button>
             </div>
           );
         })}

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -9,18 +9,29 @@ import { Cake3D } from './cake-3d';
 export function CakeNavigation() {
   const router = useRouter();
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
+  const [announce, setAnnounce] = useState('');
   const userId = '42';
 
+  function handleNavigate(href: string, slug: string) {
+    router.push(href);
+    setAnnounce(`${t(`nav.${slug}`)} opened`);
+  }
+
   return (
-    <div className="flex flex-col items-center gap-8">
-      <Cake3D activeSlug={activeSlug} userId={userId} />
-      <nav className="grid w-full max-w-md grid-cols-2 gap-2 sm:grid-cols-3">
+    <section
+      className="grid w-full min-h-[calc(100vh-64px)] place-items-center"
+      data-active-slice={activeSlug ?? 'none'}
+    >
+      <div className="grid w-full place-items-center [height:clamp(360px,46vh,640px)] [transform:translateY(-4vh)]">
+        <Cake3D activeSlug={activeSlug} userId={userId} onNavigate={handleNavigate} />
+      </div>
+      <nav className="mt-[clamp(32px,6vh,96px)] grid justify-center justify-items-center gap-3 grid-cols-2 sm:grid-cols-3 xl:grid-cols-6 mx-auto">
         {slices.map((slice) => (
           <button
             key={slice.slug}
             id={`n4vbox-${slice.slug}-${userId}`}
             aria-label={t(`nav.${slice.slug}`)}
-            onClick={() => router.push(slice.href)}
+            onClick={() => handleNavigate(slice.href, slice.slug)}
             onMouseEnter={() => setActiveSlug(slice.slug)}
             onMouseLeave={() => setActiveSlug(null)}
             onFocus={() => setActiveSlug(slice.slug)}
@@ -35,7 +46,8 @@ export function CakeNavigation() {
       <p className="sr-only" aria-live="polite">
         {activeSlug ? `${t(`nav.${activeSlug}`)} slice highlighted` : ''}
       </p>
-    </div>
+      <p className="sr-only" aria-live="polite">{announce}</p>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary
- Center cake and navigation boxes in responsive grid layout
- Add internal labels and clickable hit areas for each cake slice
- Document stable ID scheme for cake and navigation elements

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a19615ca20832a9f888db2960a7f71