### PR TITLE
Refine cake placement and label fit

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -6,3 +6,6 @@ Examples:
 - `u53r{userId}` → user record (e.g., `u53r42`).
 - `f7avour{flavorId}-{userId}` → flavor owned by a user (e.g., `f7avour12-42`).
 - `f7avourde5cr{flavorId}-{userId}` → description field for a flavor (e.g., `f7avourde5cr12-42`).
+- `cak3seg-{slug}-{userId}` → cake slice group (e.g., `cak3seg-planning-42`).
+- `cak3lbl-{slug}-{userId}` → cake slice label (e.g., `cak3lbl-planning-42`).
+- `n4vbox-{slug}-{userId}` → navigation light box (e.g., `n4vbox-planning-42`).

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -14,3 +14,5 @@
 - [ ] Add visibility model and guards
 - [ ] Add AI coach stub endpoint/action
 - 2025-08-18: Added CSS-based 3D cake with animated wedges linked to navigation boxes.
+- 2025-08-18: Centered cake layout, added in-slice labels and direct slice navigation with stable IDs.
+- 2025-08-18: Raised cake higher with slight left nudge and kept labels inside wedges.

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -3,7 +3,7 @@ import { t } from '@/lib/i18n';
 
 export default function DashboardPage() {
   return (
-    <section className="flex flex-col items-center justify-center gap-8">
+    <section className="w-full">
       <h1 className="sr-only">{t('nav.cake')}</h1>
       <CakeNavigation />
     </section>

--- a/components/cake/cake-3d.tsx
+++ b/components/cake/cake-3d.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { t } from '@/lib/i18n';
 import { slices } from './slices';
 
 interface Cake3DProps {
@@ -9,6 +11,7 @@ interface Cake3DProps {
 }
 
 export function Cake3D({ activeSlug, userId }: Cake3DProps) {
+  const router = useRouter();
   const [reduced, setReduced] = useState(false);
 
   useEffect(() => {
@@ -25,14 +28,26 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
     ? 'transform 200ms ease-out'
     : 'transform 260ms cubic-bezier(0.34,1.56,0.64,1)';
 
+  const baseSize = 256; // px
+  const cakeScale = 1.3;
+  const radius = baseSize / 2;
+  const nudgeX = radius * 0.08;
+  const labelRadius = radius * 0.44;
+  const labelFont = Math.min(Math.max(radius * 0.14, radius * 0.1), radius * 0.18);
+  const maxLabelWidth = radius * 0.72;
+
   return (
     <div
-      className="relative h-64 w-64 [perspective:800px]"
+      className="relative [perspective:800px]"
+      style={{ width: `${baseSize}px`, height: `${baseSize}px` }}
       data-active-slice={activeSlug ?? 'none'}
     >
       <div
-        className="absolute left-1/2 top-1/2 h-64 w-64 -translate-x-1/2 -translate-y-1/2 [transform-style:preserve-3d]"
-        style={{ transform: 'rotateX(-35deg)' }}
+        className="absolute top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 [transform-style:preserve-3d]"
+        style={{
+          transform: `rotateX(-16deg) scale(${cakeScale})`,
+          left: `calc(50% - ${nudgeX}px)`,
+        }}
       >
         {slices.map((slice, i) => {
           const rotate = i * 60;
@@ -41,27 +56,52 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
           const isActive = activeSlug === slice.slug;
           const dx = isActive ? Math.cos(rad) * distance : 0;
           const dz = isActive ? Math.sin(rad) * distance : 0;
-          const scale = isActive ? scaleActive : 1;
+          const s = isActive ? scaleActive : 1;
 
           return (
-            <div
+            <button
               key={slice.slug}
               id={`cak3seg-${slice.slug}-${userId}`}
-              aria-hidden
-              className="pointer-events-none absolute inset-0 flex items-center justify-center"
+              aria-label={t(`nav.${slice.slug}`)}
+              role="link"
+              tabIndex={0}
+              onClick={() => router.push(slice.href)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  router.push(slice.href);
+                }
+              }}
+              className="absolute inset-0 flex cursor-pointer items-center justify-center bg-transparent"
               style={{
-                transform: `translate3d(${dx}px,0,${dz}px) scale(${scale})`,
+                transform: `translate3d(${dx}px,0,${dz}px) scale(${s})`,
                 transition,
               }}
             >
               <div
-                className="pointer-events-none absolute left-1/2 top-1/2 h-1/2 w-1/2 -translate-x-full -translate-y-full origin-bottom-left rounded-br-[100%] shadow-md"
+                className="absolute left-1/2 top-1/2 h-1/2 w-1/2 -translate-x-full -translate-y-full origin-bottom-left rounded-br-[100%] shadow-md"
                 style={{
                   transform: `rotate(${rotate}deg)` ,
                   backgroundColor: slice.color,
                 }}
-              />
-            </div>
+              >
+                <span
+                  id={`cak3lbl-${slice.slug}-${userId}`}
+                  className="pointer-events-none absolute whitespace-nowrap rounded px-1 font-medium text-[var(--text)]"
+                  style={{
+                    fontSize: `${labelFont}px`,
+                    maxWidth: `${maxLabelWidth}px`,
+                    left: '50%',
+                    bottom: '50%',
+                    transform: `translate(${labelRadius}px, -50%) rotate(${-rotate}deg)` ,
+                    textShadow:
+                      '0 0 1px rgba(0,0,0,0.4),0 0 1px rgba(255,255,255,0.4)',
+                  }}
+                >
+                  {t(`nav.${slice.slug}`)}
+                </span>
+              </div>
+            </button>
           );
         })}
       </div>

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -12,9 +12,26 @@ export function CakeNavigation() {
   const userId = '42';
 
   return (
-    <div className="flex flex-col items-center gap-8">
-      <Cake3D activeSlug={activeSlug} userId={userId} />
-      <nav className="grid w-full max-w-md grid-cols-2 gap-2 sm:grid-cols-3">
+    <div
+      className="grid w-full place-items-center"
+      style={{ minHeight: 'calc(100vh - 64px)' }}
+    >
+      <div
+        className="grid w-full place-items-center"
+        style={{
+          height: 'clamp(360px,46vh,640px)',
+          transform: 'translateY(-10vh)',
+        }}
+      >
+        <Cake3D activeSlug={activeSlug} userId={userId} />
+      </div>
+      <nav
+        className="grid grid-cols-2 justify-center justify-items-center gap-3 sm:grid-cols-3 xl:grid-cols-6"
+        style={{
+          marginTop: 'clamp(32px,6vh,96px)',
+          marginInline: 'auto',
+        }}
+      >
         {slices.map((slice) => (
           <button
             key={slice.slug}


### PR DESCRIPTION
## Summary
- elevate cake row with 10vh upward shift and nudge cake left for optical centering
- tuck slice labels inside wedges with clamped font sizing and subtle outline

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a19615ca20832a9f888db2960a7f71