### PR TITLE
fix: raise cake position for centering

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -8,6 +8,7 @@
 - 2025-08-17: Switched to getServerSession helper and direct NextAuth route handler to resolve "auth is not a function" error.
 
 ## Follow-ups
+
 - [ ] Add OAuth (Google) + DB adapter for NextAuth
 - [ ] Implement onboarding for Signature Ethos + Credo
 - [ ] Wire flavors UI to DB
@@ -16,3 +17,4 @@
 - 2025-08-18: Added CSS-based 3D cake with animated wedges linked to navigation boxes.
 
 - 2025-08-19: Centered cake and boxes layout, added internal slice labels and clickable slice navigation with stable IDs.
+- 2025-08-19: Raised 3D cake position to translateY(-11vh) for improved centering above navigation boxes.

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -22,8 +22,12 @@ export function CakeNavigation() {
       className="grid w-full min-h-[calc(100vh-64px)] place-items-center"
       data-active-slice={activeSlug ?? 'none'}
     >
-      <div className="grid w-full place-items-center [height:clamp(360px,46vh,640px)] [transform:translateY(-4vh)]">
-        <Cake3D activeSlug={activeSlug} userId={userId} onNavigate={handleNavigate} />
+      <div className="grid w-full place-items-center [height:clamp(360px,46vh,640px)] [transform:translateY(-11vh)]">
+        <Cake3D
+          activeSlug={activeSlug}
+          userId={userId}
+          onNavigate={handleNavigate}
+        />
       </div>
       <nav className="mt-[clamp(32px,6vh,96px)] grid justify-center justify-items-center gap-3 grid-cols-2 sm:grid-cols-3 xl:grid-cols-6 mx-auto">
         {slices.map((slice) => (
@@ -46,8 +50,9 @@ export function CakeNavigation() {
       <p className="sr-only" aria-live="polite">
         {activeSlug ? `${t(`nav.${activeSlug}`)} slice highlighted` : ''}
       </p>
-      <p className="sr-only" aria-live="polite">{announce}</p>
+      <p className="sr-only" aria-live="polite">
+        {announce}
+      </p>
     </section>
   );
 }
-


### PR DESCRIPTION
## Summary
- raise 3D cake by translating `-11vh` so it sits above the navigation boxes
- document cake positioning tweak in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 60000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68a19c2c7064832a900bc2dc3d4f5e5f