### PR TITLE
fix: adjust cake vertical offset

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -16,3 +16,4 @@
 - 2025-08-18: Added CSS-based 3D cake with animated wedges linked to navigation boxes.
 
 - 2025-08-19: Centered cake and boxes layout, added internal slice labels and clickable slice navigation with stable IDs.
+- 2025-08-19: Adjusted cake vertical offset upward by 11vh for better visual centering.

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -22,7 +22,7 @@ export function CakeNavigation() {
       className="grid w-full min-h-[calc(100vh-64px)] place-items-center"
       data-active-slice={activeSlug ?? 'none'}
     >
-      <div className="grid w-full place-items-center [height:clamp(360px,46vh,640px)] [transform:translateY(-4vh)]">
+      <div className="grid w-full place-items-center [height:clamp(360px,46vh,640px)] [transform:translateY(-11vh)]">
         <Cake3D activeSlug={activeSlug} userId={userId} onNavigate={handleNavigate} />
       </div>
       <nav className="mt-[clamp(32px,6vh,96px)] grid justify-center justify-items-center gap-3 grid-cols-2 sm:grid-cols-3 xl:grid-cols-6 mx-auto">


### PR DESCRIPTION
## Summary
- move cake row up by 11vh to visually center
- document cake position tweak

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a19c2c7064832a900bc2dc3d4f5e5f