### PR TITLE
fix: center 3D cake higher in viewport

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -8,6 +8,7 @@
 - 2025-08-17: Switched to getServerSession helper and direct NextAuth route handler to resolve "auth is not a function" error.
 
 ## Follow-ups
+
 - [ ] Add OAuth (Google) + DB adapter for NextAuth
 - [ ] Implement onboarding for Signature Ethos + Credo
 - [ ] Wire flavors UI to DB
@@ -15,3 +16,4 @@
 - [ ] Add AI coach stub endpoint/action
 - 2025-08-18: Added CSS-based 3D cake with animated wedges linked to navigation boxes.
 - 2025-08-18: Centered cake layout, added in-slice labels and direct slice navigation with stable IDs.
+- 2025-08-18: Raised and horizontally centered the cake with responsive offset and optical left nudge, keeping light boxes centered.

--- a/components/cake/cake-3d.tsx
+++ b/components/cake/cake-3d.tsx
@@ -33,6 +33,7 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
   const radius = baseSize / 2;
   const labelRadius = radius * 0.58;
   const labelFont = Math.max(10, radius * 0.18);
+  const nudgeX = -radius * 0.1;
 
   return (
     <div
@@ -42,7 +43,9 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
     >
       <div
         className="absolute left-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 [transform-style:preserve-3d]"
-        style={{ transform: `rotateX(-16deg) scale(${cakeScale})` }}
+        style={{
+          transform: `translateX(${nudgeX}px) rotateX(-16deg) scale(${cakeScale})`,
+        }}
       >
         {slices.map((slice, i) => {
           const rotate = i * 60;
@@ -76,7 +79,7 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
               <div
                 className="absolute left-1/2 top-1/2 h-1/2 w-1/2 -translate-x-full -translate-y-full origin-bottom-left rounded-br-[100%] shadow-md"
                 style={{
-                  transform: `rotate(${rotate}deg)` ,
+                  transform: `rotate(${rotate}deg)`,
                   backgroundColor: slice.color,
                 }}
               >
@@ -87,7 +90,7 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
                     fontSize: `${labelFont}px`,
                     left: '50%',
                     bottom: '50%',
-                    transform: `translate(${labelRadius}px, -50%) rotate(${-rotate}deg)` ,
+                    transform: `translate(${labelRadius}px, -50%) rotate(${-rotate}deg)`,
                   }}
                 >
                   {t(`nav.${slice.slug}`)}
@@ -100,4 +103,3 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
     </div>
   );
 }
-

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { t } from '@/lib/i18n';
 import { slices } from './slices';
@@ -9,18 +9,31 @@ import { Cake3D } from './cake-3d';
 export function CakeNavigation() {
   const router = useRouter();
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
+  const [offsetVh, setOffsetVh] = useState(-18);
   const userId = '42';
+
+  useEffect(() => {
+    const updateOffset = () => {
+      const vh = window.innerHeight;
+      if (vh < 720) setOffsetVh(-16);
+      else if (vh > 900) setOffsetVh(-20);
+      else setOffsetVh(-18);
+    };
+    updateOffset();
+    window.addEventListener('resize', updateOffset);
+    return () => window.removeEventListener('resize', updateOffset);
+  }, []);
 
   return (
     <div
-      className="grid w-full place-items-center"
+      className="grid w-full justify-items-center"
       style={{ minHeight: 'calc(100vh - 64px)' }}
     >
       <div
         className="grid w-full place-items-center"
         style={{
-          height: 'clamp(360px,46vh,640px)',
-          transform: 'translateY(-4vh)',
+          height: 'clamp(420px,54vh,720px)',
+          transform: `translateY(${offsetVh}vh)`,
         }}
       >
         <Cake3D activeSlug={activeSlug} userId={userId} />
@@ -55,4 +68,3 @@ export function CakeNavigation() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- center cake horizontally with grid layout and offset
- shift cake upward with responsive translateY
- nudge cake group left for optical balance

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a49a8a3c832a87828bf6ee6da0ea