### PR TITLE
fix: improve cake centering and elevation

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -15,3 +15,4 @@
 - [ ] Add AI coach stub endpoint/action
 - 2025-08-18: Added CSS-based 3D cake with animated wedges linked to navigation boxes.
 - 2025-08-18: Centered cake layout, added in-slice labels and direct slice navigation with stable IDs.
+- 2025-08-18: Repositioned cake higher with responsive offset and optical left nudge; navigation boxes remain centered.

--- a/components/cake/cake-3d.tsx
+++ b/components/cake/cake-3d.tsx
@@ -31,6 +31,7 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
   const baseSize = 256; // px
   const cakeScale = 1.3;
   const radius = baseSize / 2;
+  const leftNudge = radius * 0.1;
   const labelRadius = radius * 0.58;
   const labelFont = Math.max(10, radius * 0.18);
 
@@ -41,8 +42,10 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
       data-active-slice={activeSlug ?? 'none'}
     >
       <div
-        className="absolute left-1/2 top-1/2 h-full w-full -translate-x-1/2 -translate-y-1/2 [transform-style:preserve-3d]"
-        style={{ transform: `rotateX(-16deg) scale(${cakeScale})` }}
+        className="absolute left-1/2 top-1/2 h-full w-full [transform-style:preserve-3d]"
+        style={{
+          transform: `translate(calc(-50% - ${leftNudge}px), -50%) rotateX(-16deg) scale(${cakeScale})`,
+        }}
       >
         {slices.map((slice, i) => {
           const rotate = i * 60;

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { t } from '@/lib/i18n';
 import { slices } from './slices';
@@ -9,18 +9,32 @@ import { Cake3D } from './cake-3d';
 export function CakeNavigation() {
   const router = useRouter();
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
+  const [offsetVh, setOffsetVh] = useState(-18);
   const userId = '42';
+
+  useEffect(() => {
+    const computeOffset = () => {
+      const vh = window.innerHeight;
+      let val = -18;
+      if (vh < 720) val = -16;
+      else if (vh > 900) val = -20;
+      setOffsetVh(val);
+    };
+    computeOffset();
+    window.addEventListener('resize', computeOffset);
+    return () => window.removeEventListener('resize', computeOffset);
+  }, []);
 
   return (
     <div
-      className="grid w-full place-items-center"
+      className="grid w-full justify-items-center"
       style={{ minHeight: 'calc(100vh - 64px)' }}
     >
       <div
         className="grid w-full place-items-center"
         style={{
-          height: 'clamp(360px,46vh,640px)',
-          transform: 'translateY(-4vh)',
+          height: 'clamp(420px,54vh,720px)',
+          transform: `translateY(${offsetVh}vh)`,
         }}
       >
         <Cake3D activeSlug={activeSlug} userId={userId} />


### PR DESCRIPTION
## Summary
- center cake horizontally and shift it higher in the viewport
- nudge cake group left to balance tilt while keeping light boxes centered

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a49a8a3c832a87828bf6ee6da0ea