### PR TITLE
feat: compact nav boxes and hover labels

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -8,6 +8,7 @@
 - 2025-08-17: Switched to getServerSession helper and direct NextAuth route handler to resolve "auth is not a function" error.
 
 ## Follow-ups
+
 - [ ] Add OAuth (Google) + DB adapter for NextAuth
 - [ ] Implement onboarding for Signature Ethos + Credo
 - [ ] Wire flavors UI to DB
@@ -16,3 +17,4 @@
 - 2025-08-18: Added CSS-based 3D cake with animated wedges linked to navigation boxes.
 - 2025-08-18: Centered cake layout, added in-slice labels and direct slice navigation with stable IDs.
 - 2025-08-18: Repositioned cake higher with responsive offset and optical left nudge; navigation boxes remain centered.
+- 2025-08-19: Made navigation boxes compact and added hover-only slice labels driven by separate hoveredSlug state.

--- a/components/cake/cake-3d.tsx
+++ b/components/cake/cake-3d.tsx
@@ -7,10 +7,17 @@ import { slices } from './slices';
 
 interface Cake3DProps {
   activeSlug: string | null;
+  hoveredSlug: string | null;
+  setHoveredSlug: (slug: string | null) => void;
   userId: string | number;
 }
 
-export function Cake3D({ activeSlug, userId }: Cake3DProps) {
+export function Cake3D({
+  activeSlug,
+  hoveredSlug,
+  setHoveredSlug,
+  userId,
+}: Cake3DProps) {
   const router = useRouter();
   const [reduced, setReduced] = useState(false);
 
@@ -32,8 +39,16 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
   const cakeScale = 1.3;
   const radius = baseSize / 2;
   const leftNudge = radius * 0.1;
-  const labelRadius = radius * 0.58;
-  const labelFont = Math.max(10, radius * 0.18);
+  const labelFont = Math.min(22, Math.max(14, radius * 0.18));
+  const topOffset = baseSize * 0.06;
+
+  const idx = hoveredSlug
+    ? slices.findIndex((s) => s.slug === hoveredSlug)
+    : -1;
+  const mid = idx >= 0 ? idx * 60 + 30 : 0;
+  const rad = (mid * Math.PI) / 180;
+  const x = hoveredSlug ? Math.cos(rad) * radius * 0.96 : 0;
+  const y = hoveredSlug ? Math.sin(rad) * radius * 0.96 : 0;
 
   return (
     <div
@@ -70,6 +85,8 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
                   router.push(slice.href);
                 }
               }}
+              onPointerEnter={() => setHoveredSlug(slice.slug)}
+              onPointerLeave={() => setHoveredSlug(null)}
               className="absolute inset-0 flex cursor-pointer items-center justify-center bg-transparent"
               style={{
                 transform: `translate3d(${dx}px,0,${dz}px) scale(${s})`,
@@ -79,28 +96,29 @@ export function Cake3D({ activeSlug, userId }: Cake3DProps) {
               <div
                 className="absolute left-1/2 top-1/2 h-1/2 w-1/2 -translate-x-full -translate-y-full origin-bottom-left rounded-br-[100%] shadow-md"
                 style={{
-                  transform: `rotate(${rotate}deg)` ,
+                  transform: `rotate(${rotate}deg)`,
                   backgroundColor: slice.color,
                 }}
-              >
-                <span
-                  id={`cak3lbl-${slice.slug}-${userId}`}
-                  className="pointer-events-none absolute whitespace-nowrap font-medium text-[var(--text)] [text-shadow:0_0_1px_rgba(0,0,0,0.4)]"
-                  style={{
-                    fontSize: `${labelFont}px`,
-                    left: '50%',
-                    bottom: '50%',
-                    transform: `translate(${labelRadius}px, -50%) rotate(${-rotate}deg)` ,
-                  }}
-                >
-                  {t(`nav.${slice.slug}`)}
-                </span>
-              </div>
+              />
             </button>
           );
         })}
       </div>
+      <span
+        id={`cak3lbl-${hoveredSlug ?? 'none'}-${userId}`}
+        className="pointer-events-none absolute whitespace-nowrap font-normal text-[var(--text)] [text-shadow:0_0_1px_rgba(0,0,0,0.4)]"
+        style={{
+          fontSize: `${labelFont}px`,
+          left: `calc(50% + ${x - leftNudge}px)`,
+          top: `calc(50% + ${y - topOffset}px)`,
+          transform: `translate(-50%, -50%) scale(${hoveredSlug ? 1 : 0.96})`,
+          opacity: hoveredSlug ? 1 : 0,
+          transition: 'opacity 120ms ease, transform 120ms ease',
+          transitionDelay: hoveredSlug ? '80ms' : '0ms',
+        }}
+      >
+        {hoveredSlug ? t(`nav.${hoveredSlug}`) : ''}
+      </span>
     </div>
   );
 }
-

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -9,6 +9,7 @@ import { Cake3D } from './cake-3d';
 export function CakeNavigation() {
   const router = useRouter();
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
+  const [hoveredSlug, setHoveredSlug] = useState<string | null>(null);
   const [offsetVh, setOffsetVh] = useState(-18);
   const userId = '42';
 
@@ -37,7 +38,12 @@ export function CakeNavigation() {
           transform: `translateY(${offsetVh}vh)`,
         }}
       >
-        <Cake3D activeSlug={activeSlug} userId={userId} />
+        <Cake3D
+          activeSlug={activeSlug}
+          hoveredSlug={hoveredSlug}
+          setHoveredSlug={setHoveredSlug}
+          userId={userId}
+        />
       </div>
       <nav
         className="grid grid-cols-2 justify-center justify-items-center gap-3 sm:grid-cols-3 xl:grid-cols-6"
@@ -52,11 +58,23 @@ export function CakeNavigation() {
             id={`n4vbox-${slice.slug}-${userId}`}
             aria-label={t(`nav.${slice.slug}`)}
             onClick={() => router.push(slice.href)}
-            onMouseEnter={() => setActiveSlug(slice.slug)}
-            onMouseLeave={() => setActiveSlug(null)}
-            onFocus={() => setActiveSlug(slice.slug)}
-            onBlur={() => setActiveSlug(null)}
-            className="flex items-center justify-center gap-2 rounded border bg-[var(--surface)] p-4 text-sm text-[var(--text)] transition-transform duration-200 hover:scale-[1.03] active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
+            onMouseEnter={() => {
+              setActiveSlug(slice.slug);
+              setHoveredSlug(slice.slug);
+            }}
+            onMouseLeave={() => {
+              setActiveSlug(null);
+              setHoveredSlug(null);
+            }}
+            onFocus={() => {
+              setActiveSlug(slice.slug);
+              setHoveredSlug(slice.slug);
+            }}
+            onBlur={() => {
+              setActiveSlug(null);
+              setHoveredSlug(null);
+            }}
+            className="flex h-[42px] min-w-[168px] items-center justify-center gap-2 rounded border bg-[var(--surface)] px-4 text-sm font-normal text-[var(--text)] shadow-sm transition-transform duration-200 hover:scale-[1.03] active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
           >
             <slice.Icon className="h-4 w-4" />
             {t(`nav.${slice.slug}`)}
@@ -69,4 +87,3 @@ export function CakeNavigation() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- shrink navigation light boxes for a tighter layout
- add `hoveredSlug` state so slice labels appear only on hover
- render a single floating label near the hovered slice

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a72bebf8832a9a209ae40f374a24