### PR TITLE
feat: arc title and box pop interactions

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -3,9 +3,11 @@
 Entity IDs follow `{TypeCode}{SubCode?}{entityId}-{userId}`. Prefixes identify entity type and optional sub-element.
 
 Examples:
+
 - `u53r{userId}` → user record (e.g., `u53r42`).
 - `f7avour{flavorId}-{userId}` → flavor owned by a user (e.g., `f7avour12-42`).
 - `f7avourde5cr{flavorId}-{userId}` → description field for a flavor (e.g., `f7avourde5cr12-42`).
-- `cak3seg-{slug}-{userId}` → cake slice group (e.g., `cak3seg-planning-42`).
-- `cak3lbl-{slug}-{userId}` → cake slice label (e.g., `cak3lbl-planning-42`).
+- `cak3hit-{slug}-{userId}` → cake slice hit area (e.g., `cak3hit-planning-42`).
+- `cak3titlePath` → SVG path for the arced title.
+- `cak3titleArc` → text element rendering the arced title.
 - `n4vbox-{slug}-{userId}` → navigation light box (e.g., `n4vbox-planning-42`).

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -18,3 +18,4 @@
 - 2025-08-18: Centered cake layout, added in-slice labels and direct slice navigation with stable IDs.
 - 2025-08-18: Repositioned cake higher with responsive offset and optical left nudge; navigation boxes remain centered.
 - 2025-08-19: Made navigation boxes compact and added hover-only slice labels driven by separate hoveredSlug state.
+- 2025-08-19: Added arced "A Piece Of Cake" title, moved cake lower, removed slice labels, and introduced box pop interactions with reduced-motion support.

--- a/components/cake/cake-3d.tsx
+++ b/components/cake/cake-3d.tsx
@@ -7,17 +7,11 @@ import { slices } from './slices';
 
 interface Cake3DProps {
   activeSlug: string | null;
-  hoveredSlug: string | null;
   setHoveredSlug: (slug: string | null) => void;
   userId: string | number;
 }
 
-export function Cake3D({
-  activeSlug,
-  hoveredSlug,
-  setHoveredSlug,
-  userId,
-}: Cake3DProps) {
+export function Cake3D({ activeSlug, setHoveredSlug, userId }: Cake3DProps) {
   const router = useRouter();
   const [reduced, setReduced] = useState(false);
 
@@ -39,17 +33,6 @@ export function Cake3D({
   const cakeScale = 1.3;
   const radius = baseSize / 2;
   const leftNudge = radius * 0.1;
-  const labelFont = Math.min(22, Math.max(14, radius * 0.18));
-  const topOffset = baseSize * 0.06;
-
-  const idx = hoveredSlug
-    ? slices.findIndex((s) => s.slug === hoveredSlug)
-    : -1;
-  const mid = idx >= 0 ? idx * 60 + 30 : 0;
-  const rad = (mid * Math.PI) / 180;
-  const x = hoveredSlug ? Math.cos(rad) * radius * 0.96 : 0;
-  const y = hoveredSlug ? Math.sin(rad) * radius * 0.96 : 0;
-
   return (
     <div
       className="relative [perspective:800px]"
@@ -74,7 +57,7 @@ export function Cake3D({
           return (
             <button
               key={slice.slug}
-              id={`cak3seg-${slice.slug}-${userId}`}
+              id={`cak3hit-${slice.slug}-${userId}`}
               aria-label={t(`nav.${slice.slug}`)}
               role="link"
               tabIndex={0}
@@ -87,6 +70,8 @@ export function Cake3D({
               }}
               onPointerEnter={() => setHoveredSlug(slice.slug)}
               onPointerLeave={() => setHoveredSlug(null)}
+              onFocus={() => setHoveredSlug(slice.slug)}
+              onBlur={() => setHoveredSlug(null)}
               className="absolute inset-0 flex cursor-pointer items-center justify-center bg-transparent"
               style={{
                 transform: `translate3d(${dx}px,0,${dz}px) scale(${s})`,
@@ -104,21 +89,6 @@ export function Cake3D({
           );
         })}
       </div>
-      <span
-        id={`cak3lbl-${hoveredSlug ?? 'none'}-${userId}`}
-        className="pointer-events-none absolute whitespace-nowrap font-normal text-[var(--text)] [text-shadow:0_0_1px_rgba(0,0,0,0.4)]"
-        style={{
-          fontSize: `${labelFont}px`,
-          left: `calc(50% + ${x - leftNudge}px)`,
-          top: `calc(50% + ${y - topOffset}px)`,
-          transform: `translate(-50%, -50%) scale(${hoveredSlug ? 1 : 0.96})`,
-          opacity: hoveredSlug ? 1 : 0,
-          transition: 'opacity 120ms ease, transform 120ms ease',
-          transitionDelay: hoveredSlug ? '80ms' : '0ms',
-        }}
-      >
-        {hoveredSlug ? t(`nav.${hoveredSlug}`) : ''}
-      </span>
     </div>
   );
 }

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -5,20 +5,22 @@ import { useRouter } from 'next/navigation';
 import { t } from '@/lib/i18n';
 import { slices } from './slices';
 import { Cake3D } from './cake-3d';
+import { TitleArc } from './title-arc';
 
 export function CakeNavigation() {
   const router = useRouter();
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
   const [hoveredSlug, setHoveredSlug] = useState<string | null>(null);
-  const [offsetVh, setOffsetVh] = useState(-18);
+  const [offsetVh, setOffsetVh] = useState(-8);
+  const [reduced, setReduced] = useState(false);
   const userId = '42';
 
   useEffect(() => {
     const computeOffset = () => {
       const vh = window.innerHeight;
-      let val = -18;
-      if (vh < 720) val = -16;
-      else if (vh > 900) val = -20;
+      let val = -8;
+      if (vh < 720) val = -6;
+      else if (vh >= 900) val = -10;
       setOffsetVh(val);
     };
     computeOffset();
@@ -26,11 +28,28 @@ export function CakeNavigation() {
     return () => window.removeEventListener('resize', computeOffset);
   }, []);
 
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handler = () => setReduced(media.matches);
+    handler();
+    media.addEventListener('change', handler);
+    return () => media.removeEventListener('change', handler);
+  }, []);
+
   return (
     <div
       className="grid w-full justify-items-center"
       style={{ minHeight: 'calc(100vh - 64px)' }}
     >
+      {/* Title Row */}
+      <div
+        className="grid w-full place-items-center"
+        style={{ height: 'clamp(72px,12vh,144px)' }}
+      >
+        <TitleArc reduced={reduced} />
+      </div>
+
+      {/* Cake Row */}
       <div
         className="grid w-full place-items-center"
         style={{
@@ -40,49 +59,75 @@ export function CakeNavigation() {
       >
         <Cake3D
           activeSlug={activeSlug}
-          hoveredSlug={hoveredSlug}
           setHoveredSlug={setHoveredSlug}
           userId={userId}
         />
       </div>
-      <nav
-        className="grid grid-cols-2 justify-center justify-items-center gap-3 sm:grid-cols-3 xl:grid-cols-6"
-        style={{
-          marginTop: 'clamp(32px,6vh,96px)',
-          marginInline: 'auto',
-        }}
+
+      {/* Boxes Row */}
+      <div
+        className="grid w-full place-items-center"
+        style={{ marginTop: 'clamp(32px,6vh,96px)' }}
       >
-        {slices.map((slice) => (
-          <button
-            key={slice.slug}
-            id={`n4vbox-${slice.slug}-${userId}`}
-            aria-label={t(`nav.${slice.slug}`)}
-            onClick={() => router.push(slice.href)}
-            onMouseEnter={() => {
-              setActiveSlug(slice.slug);
-              setHoveredSlug(slice.slug);
-            }}
-            onMouseLeave={() => {
-              setActiveSlug(null);
-              setHoveredSlug(null);
-            }}
-            onFocus={() => {
-              setActiveSlug(slice.slug);
-              setHoveredSlug(slice.slug);
-            }}
-            onBlur={() => {
-              setActiveSlug(null);
-              setHoveredSlug(null);
-            }}
-            className="flex h-[42px] min-w-[168px] items-center justify-center gap-2 rounded border bg-[var(--surface)] px-4 text-sm font-normal text-[var(--text)] shadow-sm transition-transform duration-200 hover:scale-[1.03] active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
-          >
-            <slice.Icon className="h-4 w-4" />
-            {t(`nav.${slice.slug}`)}
-          </button>
-        ))}
-      </nav>
+        <nav
+          className="grid grid-cols-2 justify-center justify-items-center gap-3 sm:grid-cols-3 xl:grid-cols-6"
+          style={{ marginInline: 'auto' }}
+        >
+          {slices.map((slice) => {
+            const popped = hoveredSlug === slice.slug;
+            const scale = popped ? (reduced ? 1.02 : 1.08) : 1;
+            const transition = popped
+              ? 'transform 140ms ease-out'
+              : 'transform 160ms ease-in';
+            return (
+              <button
+                key={slice.slug}
+                id={`n4vbox-${slice.slug}-${userId}`}
+                data-popped={popped ? 'true' : undefined}
+                aria-label={t(`nav.${slice.slug}`)}
+                onClick={() => router.push(slice.href)}
+                onMouseEnter={() => {
+                  setActiveSlug(slice.slug);
+                  setHoveredSlug(slice.slug);
+                }}
+                onMouseLeave={() => {
+                  setActiveSlug(null);
+                  setHoveredSlug(null);
+                }}
+                onFocus={() => {
+                  setActiveSlug(slice.slug);
+                  setHoveredSlug(slice.slug);
+                }}
+                onBlur={() => {
+                  setActiveSlug(null);
+                  setHoveredSlug(null);
+                }}
+                className="flex h-[42px] min-w-[168px] items-center justify-center gap-2 rounded border bg-[var(--surface)] px-4 text-sm font-normal text-[var(--text)] shadow-sm active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
+                style={{
+                  transform: `scale(${scale})`,
+                  transition,
+                  willChange: 'transform',
+                  boxShadow: popped ? '0 4px 6px rgb(0 0 0 / 0.15)' : undefined,
+                  borderColor: popped
+                    ? 'color-mix(in srgb, var(--accent) 24%, transparent)'
+                    : undefined,
+                  backgroundColor: popped
+                    ? 'color-mix(in srgb, var(--surface) 96%, white)'
+                    : undefined,
+                  opacity: reduced ? (popped ? 1 : 0.92) : 1,
+                }}
+              >
+                <slice.Icon className="h-4 w-4" />
+                {t(`nav.${slice.slug}`)}
+              </button>
+            );
+          })}
+        </nav>
+      </div>
+
+      {/* Screen reader announcement */}
       <p className="sr-only" aria-live="polite">
-        {activeSlug ? `${t(`nav.${activeSlug}`)} slice highlighted` : ''}
+        {hoveredSlug ? t(`nav.${hoveredSlug}`) : ''}
       </p>
     </div>
   );

--- a/components/cake/title-arc.tsx
+++ b/components/cake/title-arc.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface TitleArcProps {
+  reduced: boolean;
+}
+
+export function TitleArc({ reduced }: TitleArcProps) {
+  const [width, setWidth] = useState(0);
+  const [visible, setVisible] = useState(reduced);
+
+  useEffect(() => {
+    const resize = () => setWidth(window.innerWidth);
+    resize();
+    window.addEventListener('resize', resize);
+    return () => window.removeEventListener('resize', resize);
+  }, []);
+
+  useEffect(() => {
+    if (!reduced) {
+      const id = requestAnimationFrame(() => setVisible(true));
+      return () => cancelAnimationFrame(id);
+    }
+    setVisible(true);
+  }, [reduced]);
+
+  if (!width) return null;
+
+  const radius = Math.min(width * 0.34, 360);
+  const sweep = 220;
+  const startAngle = ((90 + sweep / 2) * Math.PI) / 180; // degrees to rad
+  const endAngle = ((90 - sweep / 2) * Math.PI) / 180;
+  const cx = width / 2;
+  const cy = radius;
+  const startX = cx + radius * Math.cos(startAngle);
+  const startY = cy + radius * Math.sin(startAngle);
+  const endX = cx + radius * Math.cos(endAngle);
+  const endY = cy + radius * Math.sin(endAngle);
+  const d = `M ${startX} ${startY} A ${radius} ${radius} 0 1 1 ${endX} ${endY}`;
+
+  return (
+    <svg
+      width={width}
+      height={radius}
+      viewBox={`0 0 ${width} ${radius}`}
+      style={{
+        opacity: visible ? 1 : 0,
+        transition: reduced ? undefined : 'opacity 220ms ease-out',
+      }}
+      aria-hidden="true"
+    >
+      <path id="cak3titlePath" d={d} fill="none" />
+      <text
+        id="cak3titleArc"
+        fill="var(--text)"
+        className="tracking-[0.04em]"
+        style={{ fontSize: 'clamp(24px,4vh,42px)' }}
+      >
+        <textPath href="#cak3titlePath" startOffset="50%" textAnchor="middle">
+          A Piece Of Cake
+        </textPath>
+      </text>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add SVG arc title above the cake
- pop navigation boxes on slice hover with data-popped attribute
- lower cake layout and remove slice labels

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ad1a52c8832a8492a16ec3835d4b