### PR TITLE
feat: add arc title and hovered box pop interactions

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -6,6 +6,7 @@ Examples:
 - `u53r{userId}` → user record (e.g., `u53r42`).
 - `f7avour{flavorId}-{userId}` → flavor owned by a user (e.g., `f7avour12-42`).
 - `f7avourde5cr{flavorId}-{userId}` → description field for a flavor (e.g., `f7avourde5cr12-42`).
-- `cak3seg-{slug}-{userId}` → cake slice group (e.g., `cak3seg-planning-42`).
-- `cak3lbl-{slug}-{userId}` → cake slice label (e.g., `cak3lbl-planning-42`).
+- `cak3hit-{slug}-{userId}` → cake slice hit area (e.g., `cak3hit-planning-42`).
 - `n4vbox-{slug}-{userId}` → navigation light box (e.g., `n4vbox-planning-42`).
+- `cak3titlePath` → SVG path for arced title.
+- `cak3titleArc` → text element rendered on the title arc.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -18,3 +18,4 @@
 - 2025-08-18: Centered cake layout, added in-slice labels and direct slice navigation with stable IDs.
 - 2025-08-18: Repositioned cake higher with responsive offset and optical left nudge; navigation boxes remain centered.
 - 2025-08-19: Made navigation boxes compact and added hover-only slice labels driven by separate hoveredSlug state.
+- 2025-08-20: Lowered cake for arced title, removed slice labels, added hoveredSlug-driven box pop with reduced-motion support, and rendered responsive "A Piece Of Cake" title arc.

--- a/components/cake/cake-3d.tsx
+++ b/components/cake/cake-3d.tsx
@@ -39,16 +39,6 @@ export function Cake3D({
   const cakeScale = 1.3;
   const radius = baseSize / 2;
   const leftNudge = radius * 0.1;
-  const labelFont = Math.min(22, Math.max(14, radius * 0.18));
-  const topOffset = baseSize * 0.06;
-
-  const idx = hoveredSlug
-    ? slices.findIndex((s) => s.slug === hoveredSlug)
-    : -1;
-  const mid = idx >= 0 ? idx * 60 + 30 : 0;
-  const rad = (mid * Math.PI) / 180;
-  const x = hoveredSlug ? Math.cos(rad) * radius * 0.96 : 0;
-  const y = hoveredSlug ? Math.sin(rad) * radius * 0.96 : 0;
 
   return (
     <div
@@ -74,7 +64,7 @@ export function Cake3D({
           return (
             <button
               key={slice.slug}
-              id={`cak3seg-${slice.slug}-${userId}`}
+              id={`cak3hit-${slice.slug}-${userId}`}
               aria-label={t(`nav.${slice.slug}`)}
               role="link"
               tabIndex={0}
@@ -87,6 +77,8 @@ export function Cake3D({
               }}
               onPointerEnter={() => setHoveredSlug(slice.slug)}
               onPointerLeave={() => setHoveredSlug(null)}
+              onFocus={() => setHoveredSlug(slice.slug)}
+              onBlur={() => setHoveredSlug(null)}
               className="absolute inset-0 flex cursor-pointer items-center justify-center bg-transparent"
               style={{
                 transform: `translate3d(${dx}px,0,${dz}px) scale(${s})`,
@@ -104,21 +96,6 @@ export function Cake3D({
           );
         })}
       </div>
-      <span
-        id={`cak3lbl-${hoveredSlug ?? 'none'}-${userId}`}
-        className="pointer-events-none absolute whitespace-nowrap font-normal text-[var(--text)] [text-shadow:0_0_1px_rgba(0,0,0,0.4)]"
-        style={{
-          fontSize: `${labelFont}px`,
-          left: `calc(50% + ${x - leftNudge}px)`,
-          top: `calc(50% + ${y - topOffset}px)`,
-          transform: `translate(-50%, -50%) scale(${hoveredSlug ? 1 : 0.96})`,
-          opacity: hoveredSlug ? 1 : 0,
-          transition: 'opacity 120ms ease, transform 120ms ease',
-          transitionDelay: hoveredSlug ? '80ms' : '0ms',
-        }}
-      >
-        {hoveredSlug ? t(`nav.${hoveredSlug}`) : ''}
-      </span>
     </div>
   );
 }

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -1,24 +1,97 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { t } from '@/lib/i18n';
 import { slices } from './slices';
 import { Cake3D } from './cake-3d';
 
+function polarToCartesian(cx: number, cy: number, r: number, angle: number) {
+  const rad = ((angle - 90) * Math.PI) / 180;
+  return {
+    x: cx + r * Math.cos(rad),
+    y: cy + r * Math.sin(rad),
+  };
+}
+
+function describeArc(
+  cx: number,
+  cy: number,
+  r: number,
+  startAngle: number,
+  endAngle: number,
+) {
+  const start = polarToCartesian(cx, cy, r, endAngle);
+  const end = polarToCartesian(cx, cy, r, startAngle);
+  const largeArc = Math.abs(endAngle - startAngle) <= 180 ? '0' : '1';
+  return `M ${start.x} ${start.y} A ${r} ${r} 0 ${largeArc} 0 ${end.x} ${end.y}`;
+}
+
+function TitleArc({ reduced }: { reduced: boolean }) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [dim, setDim] = useState({ w: 0, r: 0 });
+  const [mounted, setMounted] = useState(reduced);
+
+  useEffect(() => {
+    const update = () => {
+      const w = svgRef.current?.parentElement?.offsetWidth ?? 0;
+      const r = Math.min(w * 0.34, 360);
+      setDim({ w, r });
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  useEffect(() => {
+    if (reduced) {
+      setMounted(true);
+      return;
+    }
+    const id = requestAnimationFrame(() => setMounted(true));
+    return () => cancelAnimationFrame(id);
+  }, [reduced]);
+
+  const { w, r } = dim;
+  const cx = w / 2;
+  const cy = r;
+  const d = describeArc(cx, cy, r, 200, -20);
+
+  return (
+    <svg
+      ref={svgRef}
+      viewBox={`0 0 ${w} ${cy}`}
+      className={`h-full w-full ${
+        reduced ? '' : 'transition-opacity duration-200'
+      } ${mounted ? 'opacity-100' : 'opacity-0'}`}
+    >
+      <path id="cak3titlePath" d={d} fill="none" />
+      <text
+        id="cak3titleArc"
+        className="fill-[var(--text)] tracking-[0.02em]"
+      >
+        <textPath href="#cak3titlePath" startOffset="50%" textAnchor="middle">
+          A Piece Of Cake
+        </textPath>
+      </text>
+    </svg>
+  );
+}
+
 export function CakeNavigation() {
   const router = useRouter();
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
   const [hoveredSlug, setHoveredSlug] = useState<string | null>(null);
-  const [offsetVh, setOffsetVh] = useState(-18);
+  const [offsetVh, setOffsetVh] = useState(-8);
+  const [reduced, setReduced] = useState(false);
   const userId = '42';
 
   useEffect(() => {
     const computeOffset = () => {
       const vh = window.innerHeight;
-      let val = -18;
-      if (vh < 720) val = -16;
-      else if (vh > 900) val = -20;
+      let val = -8;
+      if (vh < 720) val = -6;
+      else if (vh >= 900) val = -10;
       setOffsetVh(val);
     };
     computeOffset();
@@ -26,11 +99,25 @@ export function CakeNavigation() {
     return () => window.removeEventListener('resize', computeOffset);
   }, []);
 
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handler = () => setReduced(media.matches);
+    setReduced(media.matches);
+    media.addEventListener('change', handler);
+    return () => media.removeEventListener('change', handler);
+  }, []);
+
   return (
     <div
       className="grid w-full justify-items-center"
       style={{ minHeight: 'calc(100vh - 64px)' }}
     >
+      <div
+        className="grid w-full place-items-center"
+        style={{ height: 'clamp(72px,12vh,144px)' }}
+      >
+        <TitleArc reduced={reduced} />
+      </div>
       <div
         className="grid w-full place-items-center"
         style={{
@@ -45,44 +132,66 @@ export function CakeNavigation() {
           userId={userId}
         />
       </div>
-      <nav
-        className="grid grid-cols-2 justify-center justify-items-center gap-3 sm:grid-cols-3 xl:grid-cols-6"
-        style={{
-          marginTop: 'clamp(32px,6vh,96px)',
-          marginInline: 'auto',
-        }}
-      >
-        {slices.map((slice) => (
-          <button
-            key={slice.slug}
-            id={`n4vbox-${slice.slug}-${userId}`}
-            aria-label={t(`nav.${slice.slug}`)}
-            onClick={() => router.push(slice.href)}
-            onMouseEnter={() => {
-              setActiveSlug(slice.slug);
-              setHoveredSlug(slice.slug);
-            }}
-            onMouseLeave={() => {
-              setActiveSlug(null);
-              setHoveredSlug(null);
-            }}
-            onFocus={() => {
-              setActiveSlug(slice.slug);
-              setHoveredSlug(slice.slug);
-            }}
-            onBlur={() => {
-              setActiveSlug(null);
-              setHoveredSlug(null);
-            }}
-            className="flex h-[42px] min-w-[168px] items-center justify-center gap-2 rounded border bg-[var(--surface)] px-4 text-sm font-normal text-[var(--text)] shadow-sm transition-transform duration-200 hover:scale-[1.03] active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
-          >
-            <slice.Icon className="h-4 w-4" />
-            {t(`nav.${slice.slug}`)}
-          </button>
-        ))}
-      </nav>
+      <div className="grid w-full place-items-center">
+        <nav
+          className="grid grid-cols-2 place-items-center gap-3 sm:grid-cols-3 xl:grid-cols-6"
+          style={{
+            marginTop: 'clamp(32px,6vh,96px)',
+          }}
+        >
+          {slices.map((slice) => {
+            const popped = hoveredSlug === slice.slug;
+            const scale = popped ? (reduced ? 1.02 : 1.08) : 1;
+            const transition = popped
+              ? 'transform 140ms ease-out, background-color 140ms ease-out, box-shadow 140ms ease-out, border-color 140ms ease-out'
+              : 'transform 160ms ease-in, background-color 160ms ease-in, box-shadow 160ms ease-in, border-color 160ms ease-in';
+            return (
+              <button
+                key={slice.slug}
+                id={`n4vbox-${slice.slug}-${userId}`}
+                data-popped={popped ? true : undefined}
+                aria-label={t(`nav.${slice.slug}`)}
+                onClick={() => router.push(slice.href)}
+                onMouseEnter={() => {
+                  setActiveSlug(slice.slug);
+                  setHoveredSlug(slice.slug);
+                }}
+                onMouseLeave={() => {
+                  setActiveSlug(null);
+                  setHoveredSlug(null);
+                }}
+                onFocus={() => {
+                  setActiveSlug(slice.slug);
+                  setHoveredSlug(slice.slug);
+                }}
+                onBlur={() => {
+                  setActiveSlug(null);
+                  setHoveredSlug(null);
+                }}
+                className={`flex h-[42px] min-w-[168px] items-center justify-center gap-2 rounded border px-4 text-sm font-normal text-[var(--text)] shadow-sm active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 ${
+                  popped ? 'shadow-md' : ''
+                }`}
+                style={{
+                  transform: `scale(${scale})`,
+                  transition,
+                  willChange: 'transform',
+                  backgroundColor: popped
+                    ? 'color-mix(in srgb, var(--surface), white 4%)'
+                    : 'var(--surface)',
+                  borderColor: popped
+                    ? 'hsl(var(--accent) / 0.24)'
+                    : undefined,
+                }}
+              >
+                <slice.Icon className="h-4 w-4" />
+                {t(`nav.${slice.slug}`)}
+              </button>
+            );
+          })}
+        </nav>
+      </div>
       <p className="sr-only" aria-live="polite">
-        {activeSlug ? `${t(`nav.${activeSlug}`)} slice highlighted` : ''}
+        {hoveredSlug ? t(`nav.${hoveredSlug}`) : ''}
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- add responsive SVG title arc above cake and reorganize layout with lowered cake
- trigger box pop visual emphasis from hovered or focused slices/boxes, no slice labels
- document new IDs for slice hit areas and title elements

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 60000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ad1a52c8832a8492a16ec3835d4b