### PR TITLE
feat: implement flavors MVP

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -7,6 +7,13 @@ Examples:
 - `u53r{userId}` → user record (e.g., `u53r42`).
 - `f7avour{flavorId}-{userId}` → flavor owned by a user (e.g., `f7avour12-42`).
 - `f7avourde5cr{flavorId}-{userId}` → description field for a flavor (e.g., `f7avourde5cr12-42`).
+- `f7avourrow{flavorId}-{userId}` → flavor row container.
+- `f7avourava{flavorId}-{userId}` → flavor avatar circle.
+- `f7avourn4me{flavorId}-{userId}` → flavor title text.
+- `f7avour1mp{flavorId}-{userId}` → importance slider input.
+- `f7avourt4rg{flavorId}-{userId}` → target percentage input.
+- `f7avoured1t{flavorId}-{userId}` → edit action button.
+- `f7avourd3l{flavorId}-{userId}` → delete action button.
 - `cak3hit-{slug}-{userId}` → cake slice hit area (e.g., `cak3hit-planning-42`).
 - `cak3seg-{slug}-{userId}` → cake slice segment (e.g., `cak3seg-planning-42`).
 - `n4vbox-{slug}-{userId}` → navigation light box (e.g., `n4vbox-planning-42`).

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -21,3 +21,4 @@
 - 2025-08-20: Lowered cake for arced title, removed slice labels, added hoveredSlug-driven box pop with reduced-motion support, and rendered responsive "A Piece Of Cake" title arc.
 - 2025-08-21: Replaced arc title with centered H1 and reshaped cake into six equal circular slices with seam gaps.
 - 2025-08-22: Raised navigation boxes, synced slice hover with box animations, and simplified labels.
+- 2025-08-22: Added flavors MVP with sortable list, creation/edit drawer, and API routes.

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -1,0 +1,316 @@
+'use client';
+import { useState } from 'react';
+import type { Flavor, Visibility } from '@/types/flavor';
+
+const ICONS = ['⭐', '❤️', '🌞', '🌙', '📚'];
+const VISIBILITIES: Visibility[] = ['private', 'friends', 'followers', 'public'];
+
+function sortFlavors(list: Flavor[]) {
+  return [...list].sort((a, b) => {
+    if (b.importance !== a.importance) return b.importance - a.importance;
+    if (a.orderIndex !== b.orderIndex) return a.orderIndex - b.orderIndex;
+    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+  });
+}
+
+export default function FlavorsClient({
+  userId,
+  initialFlavors,
+}: {
+  userId: string;
+  initialFlavors: Flavor[];
+}) {
+  const [flavors, setFlavors] = useState<Flavor[]>(sortFlavors(initialFlavors));
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editing, setEditing] = useState<Flavor | null>(null);
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    color: '#888888',
+    icon: ICONS[0],
+    importance: 50,
+    targetMix: 50,
+    visibility: 'private' as Visibility,
+    orderIndex: 0,
+  });
+
+  function openCreate() {
+    setEditing(null);
+    setForm({
+      name: '',
+      description: '',
+      color: '#888888',
+      icon: ICONS[0],
+      importance: 50,
+      targetMix: 50,
+      visibility: 'private',
+      orderIndex: flavors.length,
+    });
+    setDrawerOpen(true);
+  }
+
+  function openEdit(f: Flavor) {
+    setEditing(f);
+    setForm({
+      name: f.name,
+      description: f.description,
+      color: f.color,
+      icon: f.icon,
+      importance: f.importance,
+      targetMix: f.targetMix,
+      visibility: f.visibility,
+      orderIndex: f.orderIndex,
+    });
+    setDrawerOpen(true);
+  }
+
+  async function save() {
+    const method = editing ? 'PUT' : 'POST';
+    const url = editing ? `/api/flavors/${editing.id}` : '/api/flavors';
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(form),
+    });
+    if (res.ok) {
+      const data: Flavor = await res.json();
+      if (editing) {
+        setFlavors((prev) => sortFlavors(prev.map((p) => (p.id === data.id ? data : p))));
+      } else {
+        setFlavors((prev) => sortFlavors([...prev, data]));
+      }
+      setDrawerOpen(false);
+    }
+  }
+
+  async function remove(f: Flavor) {
+    if (!confirm(`Delete '${f.name}'? This can't be undone.`)) return;
+    const res = await fetch(`/api/flavors/${f.id}`, { method: 'DELETE' });
+    if (res.ok) {
+      setFlavors((prev) => prev.filter((p) => p.id !== f.id));
+    }
+  }
+
+  return (
+    <section>
+      <div className="mb-4 flex justify-end">
+        <button
+          onClick={openCreate}
+          className="rounded bg-orange-500 px-3 py-2 text-white"
+          id={`f7avoured1tnew-${userId}`}
+        >
+          + Flavor
+        </button>
+      </div>
+      <ul className="flex flex-col gap-4" id={`f7avourli5t-${userId}`}>
+        {flavors.map((f) => (
+          <li
+            key={f.id}
+            id={`f7avourrow${f.id}-${userId}`}
+            role="button"
+            tabIndex={0}
+            onClick={() => openEdit(f)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') openEdit(f);
+              if (e.key === 'Delete') remove(f);
+            }}
+            className="flex items-center gap-4 p-2 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
+          >
+            <div
+              id={`f7avourava${f.id}-${userId}`}
+              aria-label={`${f.name} flavor, importance ${f.importance}, target ${f.targetMix} percent, ${f.visibility}`}
+              title={`Importance: ${f.importance} • Target: ${f.targetMix}%`}
+              style={{
+                '--importance': f.importance,
+                '--diam': `clamp(44px, calc(28px + 0.8px * var(--importance)), 120px)`,
+                backgroundColor: f.color,
+                width: 'var(--diam)',
+                height: 'var(--diam)',
+              } as React.CSSProperties}
+              className="flex items-center justify-center rounded-full shadow-inner"
+            >
+              <span
+                className="text-white"
+                style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
+              >
+                {f.icon}
+              </span>
+            </div>
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <div
+                id={`f7avourn4me${f.id}-${userId}`}
+                className="font-semibold"
+                style={{ color: '#000' }}
+              >
+                {f.name}
+              </div>
+              <div
+                id={`f7avourde5cr${f.id}-${userId}`}
+                className="text-sm text-gray-500"
+              >
+                {f.description}
+              </div>
+              <div className="mt-1 flex gap-2 text-xs text-gray-400">
+                <span>Target {f.targetMix}%</span>
+                <span>{f.visibility}</span>
+              </div>
+            </div>
+            <div className="ml-auto flex gap-2" onClick={(e) => e.stopPropagation()}>
+              <button
+                id={`f7avoured1t${f.id}-${userId}`}
+                className="text-sm text-blue-600 underline"
+                onClick={() => openEdit(f)}
+              >
+                Edit ▸
+              </button>
+              <button
+                id={`f7avourd3l${f.id}-${userId}`}
+                className="text-sm text-red-600 underline"
+                onClick={() => remove(f)}
+              >
+                Delete
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {drawerOpen && (
+        <div
+          className="fixed inset-0 z-50 flex justify-end bg-black/20"
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') setDrawerOpen(false);
+          }}
+        >
+          <div className="h-full w-80 bg-white p-4 shadow-lg" role="dialog">
+            <h2 className="mb-4 text-lg font-semibold">
+              {editing ? 'Edit Flavor' : 'New Flavor'}
+            </h2>
+            <div className="mb-4 flex justify-center">
+              <div
+              style={{
+                '--importance': form.importance,
+                '--diam': `clamp(44px, calc(28px + 0.8px * var(--importance)), 120px)`,
+                backgroundColor: form.color,
+                width: 'var(--diam)',
+                height: 'var(--diam)',
+              } as React.CSSProperties}
+                className="flex items-center justify-center rounded-full shadow-inner"
+              >
+                <span className="text-white" style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}>
+                  {form.icon}
+                </span>
+              </div>
+            </div>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                save();
+              }}
+              className="space-y-3"
+            >
+              <div>
+                <label className="block text-sm font-medium" htmlFor={`name-input`}>
+                  Name
+                </label>
+                <input
+                  id={`f7avourn4me${editing ? editing.id : 'new'}-${userId}`}
+                  className="w-full rounded border p-1"
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  required
+                  minLength={2}
+                  maxLength={40}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium" htmlFor={`desc-input`}>
+                  Description
+                </label>
+                <textarea
+                  id={`f7avourde5cr${editing ? editing.id : 'new'}-${userId}`}
+                  className="w-full rounded border p-1"
+                  value={form.description}
+                  onChange={(e) => setForm({ ...form, description: e.target.value })}
+                  maxLength={280}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium">Color</label>
+                <input
+                  type="color"
+                  value={form.color}
+                  onChange={(e) => setForm({ ...form, color: e.target.value })}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium">Icon</label>
+                <select
+                  value={form.icon}
+                  onChange={(e) => setForm({ ...form, icon: e.target.value })}
+                >
+                  {ICONS.map((ic) => (
+                    <option key={ic} value={ic}>
+                      {ic}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium" htmlFor={`importance`}>Importance</label>
+                <input
+                  id={`f7avour1mp${editing ? editing.id : 'new'}-${userId}`}
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={form.importance}
+                  onChange={(e) => setForm({ ...form, importance: Number(e.target.value) })}
+                />
+                <span className="ml-2 text-sm">{form.importance}</span>
+              </div>
+              <div>
+                <label className="block text-sm font-medium" htmlFor={`target`}>Target %</label>
+                <input
+                  id={`f7avourt4rg${editing ? editing.id : 'new'}-${userId}`}
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={form.targetMix}
+                  onChange={(e) => setForm({ ...form, targetMix: Number(e.target.value) })}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium">Visibility</label>
+                <select
+                  value={form.visibility}
+                  onChange={(e) => setForm({ ...form, visibility: e.target.value as Visibility })}
+                >
+                  {VISIBILITIES.map((v) => (
+                    <option key={v} value={v}>
+                      {v}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex justify-end gap-2 pt-4">
+                <button
+                  type="button"
+                  className="rounded border px-3 py-1"
+                  onClick={() => setDrawerOpen(false)}
+                >
+                  Cancel
+                </button>
+                <button
+                  id={`f7avour5ave${editing ? editing.id : 'new'}-${userId}`}
+                  type="submit"
+                  className="rounded bg-orange-500 px-3 py-1 text-white"
+                >
+                  Save
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/(app)/flavors/page.tsx
+++ b/app/(app)/flavors/page.tsx
@@ -1,7 +1,10 @@
-export default function FlavorsPage() {
-  return (
-    <section>
-      <h1 className="text-2xl font-bold">Flavors</h1>
-    </section>
-  );
+import { auth } from '@/lib/auth';
+import { listFlavors } from '@/lib/flavors-store';
+import FlavorsClient from './client';
+
+export default async function FlavorsPage() {
+  const session = await auth();
+  const userId = (session?.user as any)?.id || '';
+  const flavors = userId ? listFlavors(userId) : [];
+  return <FlavorsClient userId={userId} initialFlavors={flavors} />;
 }

--- a/app/api/flavors/[id]/route.ts
+++ b/app/api/flavors/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { listFlavors, updateFlavor, deleteFlavor } from '@/lib/flavors-store';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = await auth();
+  const userId = (session?.user as any)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const flavors = listFlavors(userId);
+  const flavor = flavors.find((f) => f.id === params.id);
+  if (!flavor) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(flavor);
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = await auth();
+  const userId = (session?.user as any)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const body = await req.json();
+  const updated = updateFlavor(userId, params.id, sanitize(body));
+  if (!updated) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = await auth();
+  const userId = (session?.user as any)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const ok = deleteFlavor(userId, params.id);
+  if (!ok) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json({ success: true });
+}
+
+function sanitize(body: any) {
+  const out: any = {};
+  if (body.name) {
+    if (body.name.length < 2 || body.name.length > 40) throw new Error('Invalid name');
+    out.name = body.name;
+  }
+  if (body.description) out.description = body.description.slice(0, 280);
+  if (body.color && /^#?[0-9a-fA-F]{6}$/.test(body.color)) {
+    out.color = body.color.startsWith('#') ? body.color : '#' + body.color;
+  }
+  if (body.icon) out.icon = body.icon;
+  if (body.importance !== undefined) out.importance = clamp(Number(body.importance));
+  if (body.targetMix !== undefined) out.targetMix = clamp(Number(body.targetMix));
+  if (body.visibility && ['private', 'friends', 'followers', 'public'].includes(body.visibility)) {
+    out.visibility = body.visibility;
+  }
+  if (body.orderIndex !== undefined) out.orderIndex = Number(body.orderIndex);
+  return out;
+}
+
+function clamp(n: number) {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}

--- a/app/api/flavors/route.ts
+++ b/app/api/flavors/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { listFlavors, createFlavor } from '@/lib/flavors-store';
+
+export async function GET() {
+  const session = await auth();
+  const userId = (session?.user as any)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const flavors = listFlavors(userId);
+  return NextResponse.json(flavors);
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  const userId = (session?.user as any)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const body = await req.json();
+  try {
+    const flavor = createFlavor(userId, sanitize(body));
+    return NextResponse.json(flavor, { status: 201 });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 400 });
+  }
+}
+
+function sanitize(body: any) {
+  if (!body.name || body.name.length < 2 || body.name.length > 40) {
+    throw new Error('Invalid name');
+  }
+  const description = typeof body.description === 'string' ? body.description.slice(0, 280) : '';
+  const color = typeof body.color === 'string' && /^#?[0-9a-fA-F]{6}$/.test(body.color)
+    ? body.color.startsWith('#') ? body.color : '#' + body.color
+    : '#888888';
+  const icon = typeof body.icon === 'string' ? body.icon : 'Star';
+  const importance = clamp(Number(body.importance));
+  const targetMix = clamp(Number(body.targetMix));
+  const visibility: any = ['private', 'friends', 'followers', 'public'].includes(body.visibility)
+    ? body.visibility
+    : 'private';
+  const orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : 0;
+  return {
+    name: body.name,
+    description,
+    color,
+    icon,
+    importance,
+    targetMix,
+    visibility,
+    orderIndex,
+    slug: typeof body.slug === 'string' ? body.slug : undefined,
+  };
+}
+
+function clamp(n: number) {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}

--- a/lib/flavors-store.ts
+++ b/lib/flavors-store.ts
@@ -1,0 +1,78 @@
+import { Flavor, FlavorInput } from '@/types/flavor';
+
+const store = new Map<string, Flavor[]>();
+
+function sortFlavors(list: Flavor[]) {
+  return list.sort((a, b) => {
+    if (b.importance !== a.importance) return b.importance - a.importance;
+    if (a.orderIndex !== b.orderIndex) return a.orderIndex - b.orderIndex;
+    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+  });
+}
+
+export function listFlavors(userId: string): Flavor[] {
+  const list = store.get(userId) ?? [];
+  return sortFlavors([...list]);
+}
+
+export function createFlavor(userId: string, input: FlavorInput): Flavor {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const flavor: Flavor = {
+    ...input,
+    id,
+    userId,
+    slug: input.slug || input.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 40),
+    name: input.name.slice(0, 40),
+    description: input.description.slice(0, 280),
+    color: input.color,
+    icon: input.icon,
+    importance: clamp(input.importance),
+    targetMix: clamp(input.targetMix),
+    visibility: input.visibility,
+    orderIndex: input.orderIndex ?? 0,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const list = store.get(userId) ?? [];
+  list.push(flavor);
+  store.set(userId, list);
+  return flavor;
+}
+
+export function updateFlavor(userId: string, id: string, input: Partial<FlavorInput>): Flavor | null {
+  const list = store.get(userId);
+  if (!list) return null;
+  const idx = list.findIndex((f) => f.id === id);
+  if (idx === -1) return null;
+  const now = new Date().toISOString();
+  const existing = list[idx];
+  const updated: Flavor = {
+    ...existing,
+    ...input,
+    name: input.name ? input.name.slice(0, 40) : existing.name,
+    description: input.description ? input.description.slice(0, 280) : existing.description,
+    importance: input.importance !== undefined ? clamp(input.importance) : existing.importance,
+    targetMix: input.targetMix !== undefined ? clamp(input.targetMix) : existing.targetMix,
+    color: input.color ?? existing.color,
+    icon: input.icon ?? existing.icon,
+    visibility: input.visibility ?? existing.visibility,
+    orderIndex: input.orderIndex ?? existing.orderIndex,
+    updatedAt: now,
+  };
+  list[idx] = updated;
+  return updated;
+}
+
+export function deleteFlavor(userId: string, id: string): boolean {
+  const list = store.get(userId);
+  if (!list) return false;
+  const idx = list.findIndex((f) => f.id === id);
+  if (idx === -1) return false;
+  list.splice(idx, 1);
+  return true;
+}
+
+function clamp(n: number) {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,8 @@ export default defineConfig({
   testDir: './tests',
   webServer: {
     command: 'pnpm dev',
-    url: 'http://localhost:3000',
+    url: 'http://localhost:3001',
     reuseExistingServer: !process.env.CI,
+    timeout: 120000,
   },
 });

--- a/tests/flavors.spec.ts
+++ b/tests/flavors.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+
+const password = process.env.GUEST_PASSWORD ?? '';
+
+function rgb(hex: string) {
+  const bigint = parseInt(hex.slice(1), 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+test('flavor CRUD and ordering', async ({ page }) => {
+  await page.goto('/signin');
+  await page.fill('input[type="password"]', password);
+  await page.click('text=Enter');
+  await page.goto('/flavors');
+
+  // create first flavor
+  await page.click('text=+ Flavor');
+  await page.fill('input[id^="f7avourn4me"]', 'First');
+  await page.fill('textarea[id^="f7avourde5cr"]', 'desc1');
+  await page.fill('input[type="color"]', '#ff0000');
+  await page.selectOption('select', { value: '⭐' });
+  await page.fill('input[id^="f7avour1mp"]', '60');
+  await page.fill('input[id^="f7avourt4rg"]', '20');
+  await page.click('button:has-text("Save")');
+  await expect(page.locator('li:has-text("First")')).toBeVisible();
+
+  // create second flavor with higher importance
+  await page.click('text=+ Flavor');
+  await page.fill('input[id^="f7avourn4me"]', 'Second');
+  await page.fill('textarea[id^="f7avourde5cr"]', 'desc2');
+  await page.fill('input[type="color"]', '#00ff00');
+  await page.selectOption('select', { value: '📚' });
+  await page.fill('input[id^="f7avour1mp"]', '80');
+  await page.fill('input[id^="f7avourt4rg"]', '30');
+  await page.click('button:has-text("Save")');
+
+  const rows = page.locator('ul[id^="f7avourli5t"] > li');
+  await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText('Second');
+  await expect(rows.nth(1).locator('div[id^="f7avourn4me"]')).toHaveText('First');
+
+  // avatar sizes compare
+  const firstSize = await rows.first().locator('div[id^="f7avourava"]').evaluate((el) => el.clientWidth);
+  const secondSize = await rows.nth(1).locator('div[id^="f7avourava"]').evaluate((el) => el.clientWidth);
+  expect(firstSize).toBeGreaterThan(secondSize);
+
+  // edit importance of First to reorder
+  await rows.nth(1).click();
+  await page.fill('input[id^="f7avour1mp"]', '90');
+  await page.click('button:has-text("Save")');
+  await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText('First');
+
+  // edit text/color/icon
+  await rows.first().click();
+  await page.fill('input[id^="f7avourn4me"]', 'First Updated');
+  await page.fill('input[type="color"]', '#0000ff');
+  await page.selectOption('select', { value: '❤️' });
+  await page.click('button:has-text("Save")');
+  await page.reload();
+  await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText('First Updated');
+  const color = await rows.first().locator('div[id^="f7avourava"]').evaluate((el) => getComputedStyle(el).backgroundColor);
+  expect(color).toBe(rgb('#0000ff'));
+  await expect(rows.first().locator('div[id^="f7avourava"] span')).toHaveText('❤️');
+
+  // keyboard interaction: focus row, open with Enter then close with Esc
+  await rows.first().focus();
+  await page.keyboard.press('Enter');
+  await expect(page.locator('button:has-text("Save")')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('button:has-text("Save")')).not.toBeVisible();
+
+  // delete flavor
+  page.on('dialog', (d) => d.accept());
+  await rows.first().locator('button:has-text("Delete")').click();
+  await expect(page.locator('li:has-text("First Updated")')).toHaveCount(0);
+});

--- a/types/flavor.ts
+++ b/types/flavor.ts
@@ -1,0 +1,19 @@
+export type Visibility = 'private' | 'friends' | 'followers' | 'public';
+
+export interface Flavor {
+  id: string;
+  userId: string;
+  slug: string;
+  name: string;
+  description: string;
+  color: string;
+  icon: string;
+  importance: number;
+  targetMix: number;
+  visibility: Visibility;
+  orderIndex: number;
+  createdAt: string; // ISO string for simplicity
+  updatedAt: string;
+}
+
+export type FlavorInput = Omit<Flavor, 'id' | 'userId' | 'createdAt' | 'updatedAt'>;


### PR DESCRIPTION
## Summary
- add in-memory flavor store and REST API endpoints
- build sortable flavor list with avatar sizing, CRUD drawer, and a11y IDs
- add Playwright test covering flavor creation, edit, reorder, delete

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*


------
https://chatgpt.com/codex/tasks/task_e_68a1d00012bc832aa3e0ca7fce38bc54