### PR TITLE
feat: implement flavors CRUD interface

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -11,3 +11,11 @@ Examples:
 - `cak3seg-{slug}-{userId}` → cake slice segment (e.g., `cak3seg-planning-42`).
 - `n4vbox-{slug}-{userId}` → navigation light box (e.g., `n4vbox-planning-42`).
 - `cak3titleText` → page heading text.
+- `f7avourrow{flavorId}-{userId}` → flavor row container.
+- `f7avourava{flavorId}-{userId}` → flavor avatar.
+- `f7avourn4me{flavorId}-{userId}` → flavor title element.
+- `f7avourde5cr{flavorId}-{userId}` → flavor description element.
+- `f7avour1mp{flavorId}-{userId}` → importance slider input.
+- `f7avourt4rg{flavorId}-{userId}` → target percentage input.
+- `f7avoured1t{flavorId}-{userId}` → edit action.
+- `f7avourd3l{flavorId}-{userId}` → delete action.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -21,3 +21,4 @@
 - 2025-08-20: Lowered cake for arced title, removed slice labels, added hoveredSlug-driven box pop with reduced-motion support, and rendered responsive "A Piece Of Cake" title arc.
 - 2025-08-21: Replaced arc title with centered H1 and reshaped cake into six equal circular slices with seam gaps.
 - 2025-08-22: Raised navigation boxes, synced slice hover with box animations, and simplified labels.
+- 2025-08-22: Implemented Flavors MVP with CRUD API, importance-sized avatars, drawer form, and Playwright tests.

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+
+interface Flavor {
+  id: number;
+  userId: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  color: string;
+  icon: string;
+  importance: number;
+  targetMix: number;
+  visibility: string;
+  orderIndex: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const ICONS: Record<string, string> = {
+  star: '⭐',
+  heart: '❤️',
+  smile: '😊',
+  target: '🎯',
+};
+
+function sortFlavors(list: Flavor[]) {
+  return [...list].sort(
+    (a, b) =>
+      b.importance - a.importance ||
+      a.orderIndex - b.orderIndex ||
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+  );
+}
+
+export default function FlavorsClient({
+  initialFlavors,
+  userId,
+}: {
+  initialFlavors: Flavor[];
+  userId: string;
+}) {
+  const [flavors, setFlavors] = useState<Flavor[]>(sortFlavors(initialFlavors));
+  const [editing, setEditing] = useState<Flavor | null>(null);
+  const [form, setForm] = useState<any>({});
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      setForm(editing);
+      dialogRef.current?.showModal();
+    } else {
+      dialogRef.current?.close();
+    }
+  }, [editing]);
+
+  function openNew() {
+    setEditing({
+      id: 0,
+      userId,
+      slug: '',
+      name: '',
+      description: '',
+      color: '#000000',
+      icon: 'star',
+      importance: 50,
+      targetMix: 50,
+      visibility: 'public',
+      orderIndex: 0,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) {
+    const { name, value } = e.target;
+    setForm((f: any) => ({ ...f, [name]: value }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const payload = {
+      name: form.name,
+      description: form.description,
+      color: form.color,
+      icon: form.icon,
+      importance: Number(form.importance),
+      targetMix: Number(form.targetMix),
+      visibility: form.visibility,
+    };
+    const method = editing && editing.id ? 'PATCH' : 'POST';
+    const url = editing && editing.id ? `/api/flavors/${editing.id}` : '/api/flavors';
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (res.ok) {
+      const data: Flavor = await res.json();
+      setFlavors((prev) =>
+        sortFlavors(
+          prev.filter((f) => f.id !== data.id).concat(data)
+        )
+      );
+      setEditing(null);
+    }
+  }
+
+  async function handleDelete(flavor: Flavor) {
+    if (!confirm(`Delete '${flavor.name}'? This can't be undone.`)) return;
+    await fetch(`/api/flavors/${flavor.id}`, { method: 'DELETE' });
+    setFlavors((prev) => prev.filter((f) => f.id !== flavor.id));
+  }
+
+  return (
+    <section>
+      <h1 className="text-2xl font-bold mb-4">Flavors</h1>
+      <button className="mb-4 border px-2 py-1" onClick={openNew}>
+        + Flavor
+      </button>
+      <ul className="space-y-4">
+        {flavors.map((flavor) => (
+          <li
+            key={flavor.id}
+            id={`f7avourrow${flavor.id}-${userId}`}
+            className="flex items-center gap-4 p-2 hover:bg-gray-100 focus-within:ring-2"
+            tabIndex={0}
+            role="button"
+            onClick={() => setEditing(flavor)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') setEditing(flavor);
+              if (e.key === 'Delete') handleDelete(flavor);
+            }}
+          >
+            <div
+              id={`f7avourava${flavor.id}-${userId}`}
+              aria-label={`${flavor.name} flavor, importance ${flavor.importance}, target ${flavor.targetMix} percent, ${flavor.visibility}`}
+              title={`Importance: ${flavor.importance} • Target: ${flavor.targetMix}%`}
+              style={
+                {
+                  '--importance': flavor.importance,
+                  '--diam': `clamp(44px, calc(28px + 0.8px * var(--importance)), 120px)`,
+                  backgroundColor: flavor.color,
+                  width: 'var(--diam)',
+                  height: 'var(--diam)',
+                } as React.CSSProperties
+              }
+              className="flex items-center justify-center rounded-full shadow-inner text-white flex-shrink-0"
+            >
+              <span style={{ fontSize: 'min(48%, 44px)' }}>{ICONS[flavor.icon] || '⭐'}</span>
+            </div>
+            <div className="flex-1 overflow-hidden">
+              <div
+                id={`f7avourn4me${flavor.id}-${userId}`}
+                className="font-semibold truncate"
+              >
+                {flavor.name}
+              </div>
+              <div
+                id={`f7avourde5cr${flavor.id}-${userId}`}
+                className="text-sm text-gray-600 truncate"
+              >
+                {flavor.description}
+              </div>
+              <div className="text-xs text-gray-500 mt-1">
+                Target {flavor.targetMix}% • {flavor.visibility}
+              </div>
+            </div>
+            <div className="flex gap-2 ml-2">
+              <button
+                id={`f7avoured1t${flavor.id}-${userId}`}
+                className="underline"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setEditing(flavor);
+                }}
+              >
+                Edit ▸
+              </button>
+              <button
+                id={`f7avourd3l${flavor.id}-${userId}`}
+                className="underline"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleDelete(flavor);
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <dialog ref={dialogRef} onClose={() => setEditing(null)} className="p-4 rounded">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4" method="dialog">
+          <div className="self-center">
+            <div
+              style={
+                {
+                  '--importance': form.importance || 0,
+                  '--diam': `clamp(44px, calc(28px + 0.8px * var(--importance)), 120px)`,
+                  backgroundColor: form.color,
+                  width: 'var(--diam)',
+                  height: 'var(--diam)',
+                } as React.CSSProperties
+              }
+              className="flex items-center justify-center rounded-full shadow-inner text-white"
+            >
+              <span style={{ fontSize: 'min(48%, 44px)' }}>{ICONS[form.icon] || '⭐'}</span>
+            </div>
+          </div>
+          <label className="flex flex-col">
+            <span>Name</span>
+            <input
+              name="name"
+              value={form.name || ''}
+              onChange={handleChange}
+              required
+              minLength={2}
+              maxLength={40}
+            />
+          </label>
+          <label className="flex flex-col">
+            <span>Description</span>
+            <textarea
+              name="description"
+              value={form.description || ''}
+              onChange={handleChange}
+              maxLength={280}
+            />
+          </label>
+          <label className="flex flex-col">
+            <span>Color</span>
+            <input type="color" name="color" value={form.color || '#000000'} onChange={handleChange} />
+          </label>
+          <label className="flex flex-col">
+            <span>Icon</span>
+            <select name="icon" value={form.icon || 'star'} onChange={handleChange}>
+              {Object.keys(ICONS).map((k) => (
+                <option key={k} value={k}>
+                  {ICONS[k]} {k}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col">
+            <span>Importance</span>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              name="importance"
+              id={`f7avour1mp${editing?.id}-${userId}`}
+              value={form.importance || 0}
+              onChange={handleChange}
+            />
+          </label>
+          <label className="flex flex-col">
+            <span>Target %</span>
+            <input
+              type="number"
+              min={0}
+              max={100}
+              name="targetMix"
+              id={`f7avourt4rg${editing?.id}-${userId}`}
+              value={form.targetMix || 0}
+              onChange={handleChange}
+            />
+          </label>
+          <label className="flex flex-col">
+            <span>Visibility</span>
+            <select name="visibility" value={form.visibility || 'public'} onChange={handleChange}>
+              <option value="private">private</option>
+              <option value="friends">friends</option>
+              <option value="followers">followers</option>
+              <option value="public">public</option>
+            </select>
+          </label>
+          <div className="flex justify-end gap-2 mt-2">
+            <button type="button" onClick={() => setEditing(null)}>
+              Cancel
+            </button>
+            <button type="submit">Save</button>
+          </div>
+        </form>
+      </dialog>
+    </section>
+  );
+}

--- a/app/(app)/flavors/page.tsx
+++ b/app/(app)/flavors/page.tsx
@@ -1,7 +1,19 @@
-export default function FlavorsPage() {
-  return (
-    <section>
-      <h1 className="text-2xl font-bold">Flavors</h1>
-    </section>
-  );
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { flavors } from '@/lib/db/schema';
+import { desc, asc, eq } from 'drizzle-orm';
+import FlavorsClient from './client';
+
+export default async function FlavorsPage() {
+  const session = await auth();
+  const userId = (session?.user as any)?.id as string | undefined;
+  if (!userId) {
+    return null;
+  }
+  const data = (await db
+    .select()
+    .from(flavors)
+    .where(eq(flavors.userId, userId))
+    .orderBy(desc(flavors.importance), asc(flavors.orderIndex), asc(flavors.createdAt))) as any;
+  return <FlavorsClient initialFlavors={data} userId={userId} />;
 }

--- a/app/api/flavors/[id]/route.ts
+++ b/app/api/flavors/[id]/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { flavors } from '@/lib/db/schema';
+import { auth } from '@/lib/auth';
+import { eq, and } from 'drizzle-orm';
+
+function sanitize(str: unknown, max: number) {
+  return (typeof str === 'string' ? str : '').trim().slice(0, max);
+}
+
+function clamp(num: unknown) {
+  const n = typeof num === 'number' ? num : Number(num);
+  if (Number.isNaN(n)) return 0;
+  return Math.min(100, Math.max(0, Math.round(n)));
+}
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await auth();
+  if (!session || !(session.user as any)?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = (session.user as any).id as string;
+  const id = Number(params.id);
+  const body = await req.json();
+  const updates: any = {};
+  if (body.name !== undefined) {
+    const name = sanitize(body.name, 40);
+    if (name.length < 2) {
+      return NextResponse.json({ error: 'Name too short' }, { status: 400 });
+    }
+    updates.name = name;
+  }
+  if (body.description !== undefined) {
+    updates.description = sanitize(body.description, 280);
+  }
+  if (body.color !== undefined) {
+    updates.color = /^#([0-9a-fA-F]{6})$/.test(body.color)
+      ? body.color
+      : '#000000';
+  }
+  if (body.icon !== undefined) {
+    updates.icon = sanitize(body.icon, 64) || 'star';
+  }
+  if (body.importance !== undefined) {
+    updates.importance = clamp(body.importance);
+  }
+  if (body.targetMix !== undefined) {
+    updates.targetMix = clamp(body.targetMix);
+  }
+  if (body.visibility !== undefined) {
+    updates.visibility = ['private', 'friends', 'followers', 'public'].includes(
+      body.visibility
+    )
+      ? body.visibility
+      : 'public';
+  }
+  if (body.orderIndex !== undefined) {
+    updates.orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : 0;
+  }
+  updates.updatedAt = new Date();
+  const [flavor] = await db
+    .update(flavors)
+    .set(updates)
+    .where(and(eq(flavors.id, id), eq(flavors.userId, userId)))
+    .returning();
+  if (!flavor) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json(flavor);
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await auth();
+  if (!session || !(session.user as any)?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = (session.user as any).id as string;
+  const id = Number(params.id);
+  const [flavor] = await db
+    .delete(flavors)
+    .where(and(eq(flavors.id, id), eq(flavors.userId, userId)))
+    .returning();
+  if (!flavor) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/app/api/flavors/route.ts
+++ b/app/api/flavors/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { flavors } from '@/lib/db/schema';
+import { auth } from '@/lib/auth';
+import { desc, asc, eq } from 'drizzle-orm';
+
+function sanitize(str: unknown, max: number) {
+  return (typeof str === 'string' ? str : '').trim().slice(0, max);
+}
+
+function clamp(num: unknown) {
+  const n = typeof num === 'number' ? num : Number(num);
+  if (Number.isNaN(n)) return 0;
+  return Math.min(100, Math.max(0, Math.round(n)));
+}
+
+function slugify(name: string) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 64);
+}
+
+export async function GET() {
+  const session = await auth();
+  if (!session || !(session.user as any)?.id) {
+    return NextResponse.json([], { status: 200 });
+  }
+  const userId = (session.user as any).id as string;
+  const data = await db
+    .select()
+    .from(flavors)
+    .where(eq(flavors.userId, userId))
+    .orderBy(desc(flavors.importance), asc(flavors.orderIndex), asc(flavors.createdAt));
+  return NextResponse.json(data);
+}
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session || !(session.user as any)?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const userId = (session.user as any).id as string;
+  const body = await req.json();
+  const name = sanitize(body.name, 40);
+  if (name.length < 2) {
+    return NextResponse.json({ error: 'Name too short' }, { status: 400 });
+  }
+  const description = sanitize(body.description, 280);
+  const color = /^#([0-9a-fA-F]{6})$/.test(body.color) ? body.color : '#000000';
+  const icon = sanitize(body.icon, 64) || 'star';
+  const importance = clamp(body.importance);
+  const targetMix = clamp(body.targetMix);
+  const visibility = ['private', 'friends', 'followers', 'public'].includes(body.visibility)
+    ? body.visibility
+    : 'public';
+  const orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : 0;
+  const slug = slugify(name);
+  const [flavor] = await db
+    .insert(flavors)
+    .values({
+      userId,
+      slug,
+      name,
+      description,
+      color,
+      icon,
+      importance,
+      targetMix,
+      visibility,
+      orderIndex,
+    })
+    .returning();
+  return NextResponse.json(flavor, { status: 201 });
+}

--- a/drizzle/0000_init.sql
+++ b/drizzle/0000_init.sql
@@ -4,10 +4,20 @@ CREATE TABLE IF NOT EXISTS users (
   created_at timestamp DEFAULT now()
 );
 
+CREATE TYPE visibility AS ENUM ('private','friends','followers','public');
+
 CREATE TABLE IF NOT EXISTS flavors (
   id serial PRIMARY KEY,
-  user_id integer REFERENCES users(id),
-  name varchar(256),
-  description text,
-  created_at timestamp DEFAULT now()
+  user_id text NOT NULL,
+  slug varchar(64) NOT NULL,
+  name varchar(40) NOT NULL,
+  description varchar(280),
+  color varchar(7) NOT NULL,
+  icon varchar(64) NOT NULL,
+  importance integer NOT NULL,
+  target_mix integer NOT NULL,
+  visibility visibility NOT NULL DEFAULT 'public',
+  order_index integer NOT NULL DEFAULT 0,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now()
 );

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,4 +1,12 @@
-import { pgTable, serial, text, varchar, timestamp } from 'drizzle-orm/pg-core';
+import {
+  pgEnum,
+  pgTable,
+  serial,
+  text,
+  varchar,
+  integer,
+  timestamp,
+} from 'drizzle-orm/pg-core';
 
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
@@ -6,10 +14,25 @@ export const users = pgTable('users', {
   createdAt: timestamp('created_at').defaultNow(),
 });
 
+export const visibilityEnum = pgEnum('visibility', [
+  'private',
+  'friends',
+  'followers',
+  'public',
+]);
+
 export const flavors = pgTable('flavors', {
   id: serial('id').primaryKey(),
-  userId: serial('user_id').references(() => users.id),
-  name: varchar('name', { length: 256 }),
-  description: text('description'),
+  userId: text('user_id').notNull(),
+  slug: varchar('slug', { length: 64 }).notNull(),
+  name: varchar('name', { length: 40 }).notNull(),
+  description: varchar('description', { length: 280 }),
+  color: varchar('color', { length: 7 }).notNull(),
+  icon: varchar('icon', { length: 64 }).notNull(),
+  importance: integer('importance').notNull(),
+  targetMix: integer('target_mix').notNull(),
+  visibility: visibilityEnum('visibility').default('public').notNull(),
+  orderIndex: integer('order_index').default(0).notNull(),
   createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './tests',
   webServer: {
-    command: 'pnpm dev',
-    url: 'http://localhost:3000',
+    command: 'npx next dev -p 3002',
+    url: 'http://localhost:3002',
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/tests/flavors.spec.ts
+++ b/tests/flavors.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, Page } from '@playwright/test';
+
+const password = process.env.GUEST_PASSWORD ?? '';
+
+async function signIn(page: Page) {
+  await page.goto('/signin');
+  await page.fill('input[type="password"]', password);
+  await page.click('text=Enter');
+  await page.click('text=Flavors');
+}
+
+test('flavor CRUD and interactions', async ({ page }) => {
+  await signIn(page);
+
+  // Create flavor Alpha
+  await page.click('text=+ Flavor');
+  await page.fill('input[name="name"]', 'Alpha');
+  await page.fill('textarea[name="description"]', 'first');
+  await page.fill('input[name="color"]', '#ff0000');
+  await page.selectOption('select[name="icon"]', 'heart');
+  await page.locator('input[id^="f7avour1mp0-"]').fill('80');
+  await page.locator('input[id^="f7avourt4rg0-"]').fill('40');
+  await page.click('button:has-text("Save")');
+
+  const firstRow = page.locator('ul li').first();
+  await expect(firstRow).toContainText('Alpha');
+  const avatar = firstRow.locator('div[id^="f7avourava"]');
+  const width = await avatar.evaluate((el) => getComputedStyle(el).width);
+  expect(width.startsWith('92')).toBeTruthy();
+  const bg = await avatar.evaluate((el) => getComputedStyle(el).backgroundColor);
+  expect(bg).toBe('rgb(255, 0, 0)');
+  await expect(avatar.locator('span')).toHaveText('❤️');
+
+  // Create flavor Beta with lower importance
+  await page.click('text=+ Flavor');
+  await page.fill('input[name="name"]', 'Beta');
+  await page.fill('textarea[name="description"]', 'second');
+  await page.fill('input[name="color"]', '#00ff00');
+  await page.selectOption('select[name="icon"]', 'star');
+  await page.locator('input[id^="f7avour1mp0-"]').fill('20');
+  await page.locator('input[id^="f7avourt4rg0-"]').fill('10');
+  await page.click('button:has-text("Save")');
+
+  const rows = page.locator('ul li');
+  await expect(rows.nth(0)).toContainText('Alpha');
+  await expect(rows.nth(1)).toContainText('Beta');
+
+  // Edit Beta
+  const betaRow = rows.filter({ hasText: 'Beta' });
+  await betaRow.click();
+  await page.locator('input[id^="f7avour1mp"]').fill('90');
+  await page.fill('textarea[name="description"]', 'second updated');
+  await page.fill('input[name="color"]', '#0000ff');
+  await page.selectOption('select[name="icon"]', 'smile');
+  await page.click('button:has-text("Save")');
+
+  await expect(rows.nth(0)).toContainText('Beta');
+  const betaAvatar = rows.nth(0).locator('div[id^="f7avourava"]');
+  const betaWidth = await betaAvatar.evaluate((el) => getComputedStyle(el).width);
+  expect(betaWidth.startsWith('100')).toBeTruthy();
+  await expect(betaAvatar.locator('span')).toHaveText('😊');
+
+  // Reload and check persistence
+  await page.reload();
+  await expect(page.locator('ul li').first()).toContainText('Beta');
+
+  // Keyboard open/close
+  const betaRowAgain = page.locator('ul li').first();
+  await betaRowAgain.focus();
+  await page.keyboard.press('Enter');
+  await expect(page.locator('dialog')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.locator('dialog')).toBeHidden();
+
+  // Delete Beta
+  page.once('dialog', (d) => d.accept());
+  await betaRowAgain.locator('button:has-text("Delete")').click();
+  await expect(page.locator('ul li').first()).not.toContainText('Beta');
+});


### PR DESCRIPTION
## Summary
- add full Flavor schema with visibility and importance fields
- list flavors with importance-sized avatars and CRUD drawer
- provide REST API for flavors and accompanying tests

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d00012bc832aa3e0ca7fce38bc54