### PR TITLE
feat: replace flavor drawer with modal

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -18,3 +18,10 @@ Examples:
 - `cak3seg-{slug}-{userId}` → cake slice segment (e.g., `cak3seg-planning-42`).
 - `n4vbox-{slug}-{userId}` → navigation light box (e.g., `n4vbox-planning-42`).
 - `cak3titleText` → page heading text.
+- `f7avourmdl-{mode}-{userId}` → flavor form modal container (`mode`: new|edit).
+- `f7avourn4me-frm-{userId}` → flavor form name input.
+- `f7avourde5cr-frm-{userId}` → flavor form description textarea.
+- `f7avour1mp-frm-{userId}` → flavor form importance slider.
+- `f7avourt4rg-frm-{userId}` → flavor form target percentage input.
+- `f7avoursav-frm-{userId}` → flavor form save button.
+- `f7avourcnl-frm-{userId}` → flavor form cancel button.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -22,3 +22,4 @@
 - 2025-08-21: Replaced arc title with centered H1 and reshaped cake into six equal circular slices with seam gaps.
 - 2025-08-22: Raised navigation boxes, synced slice hover with box animations, and simplified labels.
 - 2025-08-22: Added flavors MVP with sortable list, creation/edit drawer, and API routes.
+- 2025-08-23: Replaced flavor drawer with centered modal using server actions, autosizing description with counter, and updated ID scheme.

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -1,0 +1,66 @@
+'use server';
+
+import { auth } from '@/lib/auth';
+import { createFlavor as create, updateFlavor as update } from '@/lib/flavors-store';
+import type { FlavorInput } from '@/types/flavor';
+import { revalidatePath } from 'next/cache';
+
+function sanitize(body: any): FlavorInput {
+  if (!body.name || body.name.length < 2 || body.name.length > 40) {
+    throw new Error('Invalid name');
+  }
+  const description = typeof body.description === 'string' ? body.description.slice(0, 280) : '';
+  const color =
+    typeof body.color === 'string' && /^#?[0-9a-fA-F]{6}$/.test(body.color)
+      ? body.color.startsWith('#')
+        ? body.color
+        : '#' + body.color
+      : '#888888';
+  const icon = typeof body.icon === 'string' ? body.icon : '⭐';
+  const importance = clamp(Number(body.importance));
+  const targetMix = clamp(Number(body.targetMix));
+  const visibility: any = ['private', 'friends', 'followers', 'public'].includes(body.visibility)
+    ? body.visibility
+    : 'private';
+  const orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : 0;
+  return {
+    name: body.name,
+    description,
+    color,
+    icon,
+    importance,
+    targetMix,
+    visibility,
+    orderIndex,
+    slug: typeof body.slug === 'string' ? body.slug : undefined,
+  } as FlavorInput;
+}
+
+function clamp(n: number) {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+export async function createFlavor(input: any) {
+  const session = await auth();
+  const userId = (session?.user as any)?.id;
+  if (!userId) {
+    throw new Error('Please sign in.');
+  }
+  const flavor = create(userId, sanitize(input));
+  revalidatePath('/flavors');
+  return flavor;
+}
+
+export async function updateFlavor(id: string, input: any) {
+  const session = await auth();
+  const userId = (session?.user as any)?.id;
+  if (!userId) {
+    throw new Error('Please sign in.');
+  }
+  const flavor = update(userId, id, sanitize(input));
+  if (!flavor) {
+    throw new Error('Not found');
+  }
+  revalidatePath('/flavors');
+  return flavor;
+}

--- a/tests/flavors.spec.ts
+++ b/tests/flavors.spec.ts
@@ -17,7 +17,8 @@ test('flavor CRUD and ordering', async ({ page }) => {
   await page.goto('/flavors');
 
   // create first flavor
-  await page.click('text=+ Flavor');
+  await page.click('text=New Flavor');
+  await expect(page.locator('[role="dialog"]')).toBeVisible();
   await page.fill('input[id^="f7avourn4me"]', 'First');
   await page.fill('textarea[id^="f7avourde5cr"]', 'desc1');
   await page.fill('input[type="color"]', '#ff0000');
@@ -28,7 +29,7 @@ test('flavor CRUD and ordering', async ({ page }) => {
   await expect(page.locator('li:has-text("First")')).toBeVisible();
 
   // create second flavor with higher importance
-  await page.click('text=+ Flavor');
+  await page.click('text=New Flavor');
   await page.fill('input[id^="f7avourn4me"]', 'Second');
   await page.fill('textarea[id^="f7avourde5cr"]', 'desc2');
   await page.fill('input[type="color"]', '#00ff00');


### PR DESCRIPTION
## Summary
- replace flavors side drawer with centered modal and autosizing description field
- add server actions for creating and updating flavors to avoid 401s
- document flavor form IDs and update e2e tests

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d4dc7884832aa257521ce7bedaca