### PR TITLE
feat: replace flavor drawer with modal and server actions

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -18,3 +18,12 @@ Examples:
 - `cak3seg-{slug}-{userId}` → cake slice segment (e.g., `cak3seg-planning-42`).
 - `n4vbox-{slug}-{userId}` → navigation light box (e.g., `n4vbox-planning-42`).
 - `cak3titleText` → page heading text.
+
+Modal form IDs:
+- `f7avourmdl-{mode}-{userId}` → flavor modal root (`mode`: new|edit).
+- `f7avourn4me-frm-{userId}` → flavor form name input.
+- `f7avourde5cr-frm-{userId}` → flavor form description textarea.
+- `f7avour1mp-frm-{userId}` → flavor form importance slider.
+- `f7avourt4rg-frm-{userId}` → flavor form target percentage input.
+- `f7avoursav-frm-{userId}` → flavor form save button.
+- `f7avourcnl-frm-{userId}` → flavor form cancel button.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -22,3 +22,4 @@
 - 2025-08-21: Replaced arc title with centered H1 and reshaped cake into six equal circular slices with seam gaps.
 - 2025-08-22: Raised navigation boxes, synced slice hover with box animations, and simplified labels.
 - 2025-08-22: Added flavors MVP with sortable list, creation/edit drawer, and API routes.
+ - 2025-08-23: Replaced flavor drawer with centered modal, added server actions for create/update, autosizing description field, and updated tests.

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -1,0 +1,63 @@
+'use server'
+
+import { auth } from '@/lib/auth';
+import { createFlavor as createFlavorStore, updateFlavor as updateFlavorStore } from '@/lib/flavors-store';
+import { revalidatePath } from 'next/cache';
+import type { Flavor, FlavorInput } from '@/types/flavor';
+
+function sanitize(body: any): FlavorInput {
+  if (!body.name || typeof body.name !== 'string' || body.name.length < 2 || body.name.length > 40) {
+    throw new Error('Invalid name');
+  }
+  const description = typeof body.description === 'string' ? body.description.slice(0, 280) : '';
+  const color = typeof body.color === 'string' && /^#?[0-9a-fA-F]{6}$/.test(body.color)
+    ? body.color.startsWith('#') ? body.color : '#' + body.color
+    : '#888888';
+  const icon = typeof body.icon === 'string' ? body.icon : '⭐';
+  const importance = clamp(Number(body.importance));
+  const targetMix = clamp(Number(body.targetMix));
+  const visibility: any = ['private', 'friends', 'followers', 'public'].includes(body.visibility)
+    ? body.visibility
+    : 'private';
+  const orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : 0;
+  return {
+    name: body.name,
+    description,
+    color,
+    icon,
+    importance,
+    targetMix,
+    visibility,
+    orderIndex,
+    slug: typeof body.slug === 'string' ? body.slug : undefined,
+  } as FlavorInput;
+}
+
+function clamp(n: number) {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+export async function createFlavor(form: any): Promise<Flavor> {
+  const session = await auth();
+  const userId = (session?.user as any)?.id;
+  if (!userId) {
+    throw new Error('Please sign in.');
+  }
+  const flavor = createFlavorStore(userId, sanitize(form));
+  revalidatePath('/flavors');
+  return flavor;
+}
+
+export async function updateFlavor(id: string, form: any): Promise<Flavor> {
+  const session = await auth();
+  const userId = (session?.user as any)?.id;
+  if (!userId) {
+    throw new Error('Please sign in.');
+  }
+  const updated = updateFlavorStore(userId, id, sanitize(form));
+  if (!updated) {
+    throw new Error('Not found');
+  }
+  revalidatePath('/flavors');
+  return updated;
+}

--- a/tests/flavors.spec.ts
+++ b/tests/flavors.spec.ts
@@ -17,25 +17,25 @@ test('flavor CRUD and ordering', async ({ page }) => {
   await page.goto('/flavors');
 
   // create first flavor
-  await page.click('text=+ Flavor');
-  await page.fill('input[id^="f7avourn4me"]', 'First');
-  await page.fill('textarea[id^="f7avourde5cr"]', 'desc1');
-  await page.fill('input[type="color"]', '#ff0000');
-  await page.selectOption('select', { value: '⭐' });
-  await page.fill('input[id^="f7avour1mp"]', '60');
-  await page.fill('input[id^="f7avourt4rg"]', '20');
-  await page.click('button:has-text("Save")');
+  await page.click('text=New Flavor');
+  await page.fill('input[id^="f7avourn4me-frm"]', 'First');
+  await page.fill('textarea[id^="f7avourde5cr-frm"]', 'desc1');
+  await page.fill('input[name="color"]', '#ff0000');
+  await page.click('button:has-text("⭐")');
+  await page.fill('input[id^="f7avour1mp-frm"]', '60');
+  await page.fill('input[id^="f7avourt4rg-frm"]', '20');
+  await page.click('button[id^="f7avoursav-frm"]');
   await expect(page.locator('li:has-text("First")')).toBeVisible();
 
   // create second flavor with higher importance
-  await page.click('text=+ Flavor');
-  await page.fill('input[id^="f7avourn4me"]', 'Second');
-  await page.fill('textarea[id^="f7avourde5cr"]', 'desc2');
-  await page.fill('input[type="color"]', '#00ff00');
-  await page.selectOption('select', { value: '📚' });
-  await page.fill('input[id^="f7avour1mp"]', '80');
-  await page.fill('input[id^="f7avourt4rg"]', '30');
-  await page.click('button:has-text("Save")');
+  await page.click('text=New Flavor');
+  await page.fill('input[id^="f7avourn4me-frm"]', 'Second');
+  await page.fill('textarea[id^="f7avourde5cr-frm"]', 'desc2');
+  await page.fill('input[name="color"]', '#00ff00');
+  await page.click('button:has-text("📚")');
+  await page.fill('input[id^="f7avour1mp-frm"]', '80');
+  await page.fill('input[id^="f7avourt4rg-frm"]', '30');
+  await page.click('button[id^="f7avoursav-frm"]');
 
   const rows = page.locator('ul[id^="f7avourli5t"] > li');
   await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText('Second');
@@ -48,16 +48,16 @@ test('flavor CRUD and ordering', async ({ page }) => {
 
   // edit importance of First to reorder
   await rows.nth(1).click();
-  await page.fill('input[id^="f7avour1mp"]', '90');
-  await page.click('button:has-text("Save")');
+  await page.fill('input[id^="f7avour1mp-frm"]', '90');
+  await page.click('button[id^="f7avoursav-frm"]');
   await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText('First');
 
   // edit text/color/icon
   await rows.first().click();
-  await page.fill('input[id^="f7avourn4me"]', 'First Updated');
-  await page.fill('input[type="color"]', '#0000ff');
-  await page.selectOption('select', { value: '❤️' });
-  await page.click('button:has-text("Save")');
+  await page.fill('input[id^="f7avourn4me-frm"]', 'First Updated');
+  await page.fill('input[name="color"]', '#0000ff');
+  await page.click('button:has-text("❤️")');
+  await page.click('button[id^="f7avoursav-frm"]');
   await page.reload();
   await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText('First Updated');
   const color = await rows.first().locator('div[id^="f7avourava"]').evaluate((el) => getComputedStyle(el).backgroundColor);
@@ -67,9 +67,9 @@ test('flavor CRUD and ordering', async ({ page }) => {
   // keyboard interaction: focus row, open with Enter then close with Esc
   await rows.first().focus();
   await page.keyboard.press('Enter');
-  await expect(page.locator('button:has-text("Save")')).toBeVisible();
+  await expect(page.locator('button[id^="f7avoursav-frm"]')).toBeVisible();
   await page.keyboard.press('Escape');
-  await expect(page.locator('button:has-text("Save")')).not.toBeVisible();
+  await expect(page.locator('button[id^="f7avoursav-frm"]')).not.toBeVisible();
 
   // delete flavor
   page.on('dialog', (d) => d.accept());


### PR DESCRIPTION
## Summary
- replace flavor sidebar with centered modal featuring autosizing description and color/icon pickers
- persist flavors using server actions instead of client fetches
- document new flavor modal IDs and update tests

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d4dc7884832aa257521ce7bedaca