### PR TITLE
fix: persist user id in NextAuth session

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -22,4 +22,5 @@
 - 2025-08-21: Replaced arc title with centered H1 and reshaped cake into six equal circular slices with seam gaps.
 - 2025-08-22: Raised navigation boxes, synced slice hover with box animations, and simplified labels.
 - 2025-08-22: Added flavors MVP with sortable list, creation/edit drawer, and API routes.
- - 2025-08-23: Replaced flavor drawer with centered modal, added server actions for create/update, autosizing description field, and updated tests.
+- 2025-08-23: Replaced flavor drawer with centered modal, added server actions for create/update, autosizing description field, and updated tests.
+- 2025-08-24: Persisted user id in NextAuth session to fix "Please sign in" error when saving flavors.

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -1,22 +1,39 @@
-'use server'
+'use server';
 
 import { auth } from '@/lib/auth';
-import { createFlavor as createFlavorStore, updateFlavor as updateFlavorStore } from '@/lib/flavors-store';
+import {
+  createFlavor as createFlavorStore,
+  updateFlavor as updateFlavorStore,
+} from '@/lib/flavors-store';
 import { revalidatePath } from 'next/cache';
 import type { Flavor, FlavorInput } from '@/types/flavor';
 
 function sanitize(body: any): FlavorInput {
-  if (!body.name || typeof body.name !== 'string' || body.name.length < 2 || body.name.length > 40) {
+  if (
+    !body.name ||
+    typeof body.name !== 'string' ||
+    body.name.length < 2 ||
+    body.name.length > 40
+  ) {
     throw new Error('Invalid name');
   }
-  const description = typeof body.description === 'string' ? body.description.slice(0, 280) : '';
-  const color = typeof body.color === 'string' && /^#?[0-9a-fA-F]{6}$/.test(body.color)
-    ? body.color.startsWith('#') ? body.color : '#' + body.color
-    : '#888888';
+  const description =
+    typeof body.description === 'string' ? body.description.slice(0, 280) : '';
+  const color =
+    typeof body.color === 'string' && /^#?[0-9a-fA-F]{6}$/.test(body.color)
+      ? body.color.startsWith('#')
+        ? body.color
+        : '#' + body.color
+      : '#888888';
   const icon = typeof body.icon === 'string' ? body.icon : '⭐';
   const importance = clamp(Number(body.importance));
   const targetMix = clamp(Number(body.targetMix));
-  const visibility: any = ['private', 'friends', 'followers', 'public'].includes(body.visibility)
+  const visibility: any = [
+    'private',
+    'friends',
+    'followers',
+    'public',
+  ].includes(body.visibility)
     ? body.visibility
     : 'private';
   const orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : 0;
@@ -39,7 +56,7 @@ function clamp(n: number) {
 
 export async function createFlavor(form: any): Promise<Flavor> {
   const session = await auth();
-  const userId = (session?.user as any)?.id;
+  const userId = session?.user?.id;
   if (!userId) {
     throw new Error('Please sign in.');
   }
@@ -50,7 +67,7 @@ export async function createFlavor(form: any): Promise<Flavor> {
 
 export async function updateFlavor(id: string, form: any): Promise<Flavor> {
   const session = await auth();
-  const userId = (session?.user as any)?.id;
+  const userId = session?.user?.id;
   if (!userId) {
     throw new Error('Please sign in.');
   }

--- a/app/api/flavors/route.ts
+++ b/app/api/flavors/route.ts
@@ -4,7 +4,7 @@ import { listFlavors, createFlavor } from '@/lib/flavors-store';
 
 export async function GET() {
   const session = await auth();
-  const userId = (session?.user as any)?.id;
+  const userId = session?.user?.id;
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
@@ -14,7 +14,7 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   const session = await auth();
-  const userId = (session?.user as any)?.id;
+  const userId = session?.user?.id;
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
@@ -31,14 +31,23 @@ function sanitize(body: any) {
   if (!body.name || body.name.length < 2 || body.name.length > 40) {
     throw new Error('Invalid name');
   }
-  const description = typeof body.description === 'string' ? body.description.slice(0, 280) : '';
-  const color = typeof body.color === 'string' && /^#?[0-9a-fA-F]{6}$/.test(body.color)
-    ? body.color.startsWith('#') ? body.color : '#' + body.color
-    : '#888888';
+  const description =
+    typeof body.description === 'string' ? body.description.slice(0, 280) : '';
+  const color =
+    typeof body.color === 'string' && /^#?[0-9a-fA-F]{6}$/.test(body.color)
+      ? body.color.startsWith('#')
+        ? body.color
+        : '#' + body.color
+      : '#888888';
   const icon = typeof body.icon === 'string' ? body.icon : 'Star';
   const importance = clamp(Number(body.importance));
   const targetMix = clamp(Number(body.targetMix));
-  const visibility: any = ['private', 'friends', 'followers', 'public'].includes(body.visibility)
+  const visibility: any = [
+    'private',
+    'friends',
+    'followers',
+    'public',
+  ].includes(body.visibility)
     ? body.visibility
     : 'private';
   const orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : 0;

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -17,6 +17,23 @@ export const authOptions: NextAuthOptions = {
       },
     }),
   ],
+  callbacks: {
+    // Persist the user's id in the JWT so it can be read from the session
+    async jwt({ token, user }) {
+      if (user) {
+        // On initial sign in, the user object is available and we store the id
+        token.id = (user as any).id;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        // Expose the user id on the session for server actions/routes
+        (session.user as any).id = token.id as string;
+      }
+      return session;
+    },
+  },
   session: { strategy: 'jwt' },
   secret: process.env.NEXTAUTH_SECRET,
   pages: {

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,19 @@
+import { DefaultSession } from 'next-auth';
+
+declare module 'next-auth' {
+  interface Session {
+    user: {
+      id: string;
+    } & DefaultSession['user'];
+  }
+
+  interface User {
+    id: string;
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    id?: string;
+  }
+}


### PR DESCRIPTION
## Summary
- include custom jwt/session callbacks so NextAuth exposes user id in session
- use typed `session.user.id` in flavor actions and API
- add NextAuth type declarations and update changelog

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d91a5a28832abd62b69bd9775a64