### PR TITLE
fix: keep focus in flavor description input

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -24,3 +24,4 @@
 - 2025-08-22: Added flavors MVP with sortable list, creation/edit drawer, and API routes.
 - 2025-08-23: Replaced flavor drawer with centered modal, added server actions for create/update, autosizing description field, and updated tests.
 - 2025-08-24: Persisted user id in NextAuth session to fix "Please sign in" error when saving flavors.
+- 2025-08-24: Prevented modal from refocusing on the name field while typing flavor descriptions.

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -52,6 +52,16 @@ export default function FlavorsClient({
   const [error, setError] = useState('');
   const triggerRef = useRef<HTMLElement | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);
+  const formRef = useRef(form);
+  const initialFormRef = useRef(initialForm);
+
+  useEffect(() => {
+    formRef.current = form;
+  }, [form]);
+
+  useEffect(() => {
+    initialFormRef.current = initialForm;
+  }, [initialForm]);
 
   const mode = editing ? 'edit' : 'new';
 
@@ -97,20 +107,17 @@ export default function FlavorsClient({
     setFlavors((prev) => prev.filter((p) => p.id !== f.id));
   }
 
-  const isDirty = useCallback(
-    () => JSON.stringify(form) !== JSON.stringify(initialForm),
-    [form, initialForm]
-  );
-
   const attemptClose = useCallback(() => {
-    if (isDirty() && !confirm('Discard changes?')) {
+    const dirty =
+      JSON.stringify(formRef.current) !== JSON.stringify(initialFormRef.current);
+    if (dirty && !confirm('Discard changes?')) {
       return;
     }
     setModalOpen(false);
     setEditing(null);
     setError('');
     triggerRef.current?.focus();
-  }, [isDirty]);
+  }, []);
 
   async function save() {
     setSubmitting(true);


### PR DESCRIPTION
## Summary
- ensure flavor modal doesn't refocus name field after each keystroke
- note behavior in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a1de384f64832ab46eb9e508fa0069