### PR TITLE
feat: add subflavors

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -27,3 +27,4 @@
 - 2025-08-24: Prevented modal from refocusing on the name field while typing flavor descriptions.
 - 2025-08-25: Added email/password authentication with sign-up and login pages and stored flavors in Postgres.
 - 2025-08-25: Added migration to add slug to flavors and guarded user ID parsing to prevent NaN queries.
+- 2025-08-26: Added subflavors with CRUD UI, server actions, API routes, and navigation button from flavors list.

--- a/app/(app)/flavors/[flavorId]/subflavors/actions.ts
+++ b/app/(app)/flavors/[flavorId]/subflavors/actions.ts
@@ -1,0 +1,92 @@
+'use server';
+
+import { auth } from '@/lib/auth';
+import {
+  createSubflavor as createSubflavorStore,
+  updateSubflavor as updateSubflavorStore,
+} from '@/lib/subflavors-store';
+import { revalidatePath } from 'next/cache';
+import type { Subflavor, SubflavorInput } from '@/types/subflavor';
+
+function sanitize(body: any): SubflavorInput {
+  if (
+    !body.name ||
+    typeof body.name !== 'string' ||
+    body.name.length < 2 ||
+    body.name.length > 40
+  ) {
+    throw new Error('Invalid name');
+  }
+  const description =
+    typeof body.description === 'string' ? body.description.slice(0, 280) : '';
+  const color =
+    typeof body.color === 'string' && /^#?[0-9a-fA-F]{6}$/.test(body.color)
+      ? body.color.startsWith('#')
+        ? body.color
+        : '#' + body.color
+      : '#888888';
+  const icon = typeof body.icon === 'string' ? body.icon : '⭐';
+  const importance = clamp(Number(body.importance));
+  const targetMix = clamp(Number(body.targetMix));
+  const visibility: any = [
+    'private',
+    'friends',
+    'followers',
+    'public',
+  ].includes(body.visibility)
+    ? body.visibility
+    : 'private';
+  const orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : 0;
+  return {
+    flavorId: body.flavorId,
+    name: body.name,
+    description,
+    color,
+    icon,
+    importance,
+    targetMix,
+    visibility,
+    orderIndex,
+    slug: typeof body.slug === 'string' ? body.slug : undefined,
+  } as SubflavorInput;
+}
+
+function clamp(n: number) {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+export async function createSubflavor(
+  flavorId: string,
+  form: any,
+): Promise<Subflavor> {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    throw new Error('Please sign in.');
+  }
+  const subflavor = await createSubflavorStore(
+    userId,
+    flavorId,
+    sanitize({ ...form, flavorId }),
+  );
+  revalidatePath(`/flavors/${flavorId}/subflavors`);
+  return subflavor;
+}
+
+export async function updateSubflavor(
+  flavorId: string,
+  id: string,
+  form: any,
+): Promise<Subflavor> {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    throw new Error('Please sign in.');
+  }
+  const updated = await updateSubflavorStore(userId, id, sanitize(form));
+  if (!updated) {
+    throw new Error('Not found');
+  }
+  revalidatePath(`/flavors/${flavorId}/subflavors`);
+  return updated;
+}

--- a/app/(app)/flavors/[flavorId]/subflavors/client.tsx
+++ b/app/(app)/flavors/[flavorId]/subflavors/client.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { useRouter } from 'next/navigation';
-import type { Flavor, Visibility } from '@/types/flavor';
-import { createFlavor, updateFlavor } from './actions';
+import type { Subflavor, Visibility } from '@/types/subflavor';
+import { createSubflavor, updateSubflavor } from './actions';
 
 const ICONS = ['⭐', '❤️', '🌞', '🌙', '📚'];
 const VISIBILITIES: Visibility[] = [
@@ -21,7 +20,7 @@ const COLOR_SWATCHES = [
   '#f472b6',
 ];
 
-function sortFlavors(list: Flavor[]) {
+function sortSubflavors(list: Subflavor[]) {
   return [...list].sort((a, b) => {
     if (b.importance !== a.importance) return b.importance - a.importance;
     if (a.orderIndex !== b.orderIndex) return a.orderIndex - b.orderIndex;
@@ -40,17 +39,20 @@ type FormState = {
   orderIndex: number;
 };
 
-export default function FlavorsClient({
+export default function SubflavorsClient({
   userId,
-  initialFlavors,
+  flavorId,
+  initialSubflavors,
 }: {
   userId: string;
-  initialFlavors: Flavor[];
+  flavorId: string;
+  initialSubflavors: Subflavor[];
 }) {
-  const router = useRouter();
-  const [flavors, setFlavors] = useState<Flavor[]>(sortFlavors(initialFlavors));
+  const [subflavors, setSubflavors] = useState<Subflavor[]>(
+    sortSubflavors(initialSubflavors),
+  );
   const [modalOpen, setModalOpen] = useState(false);
-  const [editing, setEditing] = useState<Flavor | null>(null);
+  const [editing, setEditing] = useState<Subflavor | null>(null);
   const [form, setForm] = useState<FormState>({
     name: '',
     description: '',
@@ -90,14 +92,14 @@ export default function FlavorsClient({
       importance: 50,
       targetMix: 50,
       visibility: 'private' as Visibility,
-      orderIndex: flavors.length,
+      orderIndex: subflavors.length,
     };
     setForm(blank);
     setInitialForm(blank);
     setModalOpen(true);
   }
 
-  function openEdit(f: Flavor, e: HTMLElement) {
+  function openEdit(f: Subflavor, e: HTMLElement) {
     triggerRef.current = e;
     const current = {
       name: f.name,
@@ -115,10 +117,10 @@ export default function FlavorsClient({
     setModalOpen(true);
   }
 
-  async function remove(f: Flavor) {
+  async function remove(f: Subflavor) {
     if (!confirm(`Delete '${f.name}'? This can't be undone.`)) return;
-    await fetch(`/api/flavors/${f.id}`, { method: 'DELETE' });
-    setFlavors((prev) => prev.filter((p) => p.id !== f.id));
+    await fetch(`/api/subflavors/${f.id}`, { method: 'DELETE' });
+    setSubflavors((prev) => prev.filter((p) => p.id !== f.id));
   }
 
   const attemptClose = useCallback(() => {
@@ -139,14 +141,14 @@ export default function FlavorsClient({
     setError('');
     try {
       const data = editing
-        ? await updateFlavor(editing.id, form)
-        : await createFlavor(form);
+        ? await updateSubflavor(flavorId, editing.id, form)
+        : await createSubflavor(flavorId, form);
       if (editing) {
-        setFlavors((prev) =>
-          sortFlavors(prev.map((p) => (p.id === data.id ? data : p))),
+        setSubflavors((prev) =>
+          sortSubflavors(prev.map((p) => (p.id === data.id ? data : p))),
         );
       } else {
-        setFlavors((prev) => sortFlavors([...prev, data]));
+        setSubflavors((prev) => sortSubflavors([...prev, data]));
       }
       setModalOpen(false);
       setEditing(null);
@@ -206,16 +208,16 @@ export default function FlavorsClient({
         <button
           onClick={(e) => openCreate(e.currentTarget)}
           className="rounded bg-orange-500 px-3 py-2 text-white"
-          id={`f7avoured1tnew-${userId}`}
+          id={`s7ubflavoured1tnew-${userId}`}
         >
-          New Flavor
+          New Subflavor
         </button>
       </div>
-      <ul className="flex flex-col gap-4" id={`f7avourli5t-${userId}`}>
-        {flavors.map((f) => (
+      <ul className="flex flex-col gap-4" id={`s7ubflavourli5t-${userId}`}>
+        {subflavors.map((f) => (
           <li
             key={f.id}
-            id={`f7avourrow${f.id}-${userId}`}
+            id={`s7ubflavourrow${f.id}-${userId}`}
             role="button"
             tabIndex={0}
             onClick={(e) => openEdit(f, e.currentTarget)}
@@ -226,50 +228,38 @@ export default function FlavorsClient({
             }}
             className="flex items-center gap-4 p-2 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
           >
-            <div className="flex flex-col items-center">
-              <div
-                id={`f7avourava${f.id}-${userId}`}
-                aria-label={`${f.name} flavor, importance ${f.importance}, target ${f.targetMix} percent, ${f.visibility}`}
-                title={`Importance: ${f.importance} • Target: ${f.targetMix}%`}
-                style={
-                  {
-                    '--importance': f.importance,
-                    '--diam': `clamp(44px, calc(28px + 0.8px * var(--importance)), 120px)`,
-                    backgroundColor: f.color,
-                    width: 'var(--diam)',
-                    height: 'var(--diam)',
-                  } as React.CSSProperties
-                }
-                className="flex items-center justify-center rounded-full shadow-inner"
+            <div
+              id={`s7ubflavourava${f.id}-${userId}`}
+              aria-label={`${f.name} subflavor, importance ${f.importance}, target ${f.targetMix} percent, ${f.visibility}`}
+              title={`Importance: ${f.importance} • Target: ${f.targetMix}%`}
+              style={
+                {
+                  '--importance': f.importance,
+                  '--diam': `clamp(44px, calc(28px + 0.8px * var(--importance)), 120px)`,
+                  backgroundColor: f.color,
+                  width: 'var(--diam)',
+                  height: 'var(--diam)',
+                } as React.CSSProperties
+              }
+              className="flex items-center justify-center rounded-full shadow-inner"
+            >
+              <span
+                className="text-white"
+                style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
               >
-                <span
-                  className="text-white"
-                  style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
-                >
-                  {f.icon}
-                </span>
-              </div>
-              <button
-                id={`f7avsubfbtn${f.id}-${userId}`}
-                className="mt-2 text-xs text-blue-600 underline"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  router.push(`/flavors/${f.id}/subflavors`);
-                }}
-              >
-                View Subflavors
-              </button>
+                {f.icon}
+              </span>
             </div>
             <div className="flex min-w-0 flex-1 flex-col gap-1">
               <div
-                id={`f7avourn4me${f.id}-${userId}`}
+                id={`s7ubflavourn4me${f.id}-${userId}`}
                 className="font-semibold"
                 style={{ color: '#000' }}
               >
                 {f.name}
               </div>
               <div
-                id={`f7avourde5cr${f.id}-${userId}`}
+                id={`s7ubflavourde5cr${f.id}-${userId}`}
                 className="text-sm text-gray-500"
               >
                 {f.description}
@@ -284,14 +274,14 @@ export default function FlavorsClient({
               onClick={(e) => e.stopPropagation()}
             >
               <button
-                id={`f7avoured1t${f.id}-${userId}`}
+                id={`s7ubflavoured1t${f.id}-${userId}`}
                 className="text-sm text-blue-600 underline"
                 onClick={(e) => openEdit(f, e.currentTarget)}
               >
                 Edit ▸
               </button>
               <button
-                id={`f7avourd3l${f.id}-${userId}`}
+                id={`s7ubflavourd3l${f.id}-${userId}`}
                 className="text-sm text-red-600 underline"
                 onClick={() => remove(f)}
               >
@@ -303,11 +293,11 @@ export default function FlavorsClient({
       </ul>
       {modalOpen && (
         <div
-          id={`f7avourmdl-${mode}-${userId}`}
+          id={`s7ubflavourmdl-${mode}-${userId}`}
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-md"
           aria-modal="true"
           role="dialog"
-          aria-labelledby="flavor-modal-title"
+          aria-labelledby="subflavor-modal-title"
           onClick={attemptClose}
         >
           <div
@@ -316,8 +306,8 @@ export default function FlavorsClient({
             onClick={(e) => e.stopPropagation()}
           >
             <div className="mb-4 flex items-center justify-between">
-              <h2 id="flavor-modal-title" className="text-lg font-semibold">
-                {editing ? 'Edit Flavor' : 'New Flavor'}
+              <h2 id="subflavor-modal-title" className="text-lg font-semibold">
+                {editing ? 'Edit Subflavor' : 'New Subflavor'}
               </h2>
               <div
                 style={
@@ -349,12 +339,12 @@ export default function FlavorsClient({
               <div>
                 <label
                   className="block text-sm font-medium"
-                  htmlFor={`f7avourn4me-frm-${userId}`}
+                  htmlFor={`s7ubflavourn4me-frm-${userId}`}
                 >
                   Name
                 </label>
                 <input
-                  id={`f7avourn4me-frm-${userId}`}
+                  id={`s7ubflavourn4me-frm-${userId}`}
                   className="w-full rounded border p-1"
                   value={form.name}
                   onChange={(e) => setForm({ ...form, name: e.target.value })}
@@ -366,13 +356,13 @@ export default function FlavorsClient({
               <div className="md:col-span-2">
                 <label
                   className="block text-sm font-medium"
-                  htmlFor={`f7avourde5cr-frm-${userId}`}
+                  htmlFor={`s7ubflavourde5cr-frm-${userId}`}
                 >
                   Description
                 </label>
                 <div className="relative">
                   <textarea
-                    id={`f7avourde5cr-frm-${userId}`}
+                    id={`s7ubflavourde5cr-frm-${userId}`}
                     className="w-full resize-none overflow-hidden rounded border p-1"
                     value={form.description}
                     onChange={handleDescription}
@@ -429,12 +419,12 @@ export default function FlavorsClient({
               <div>
                 <label
                   className="block text-sm font-medium"
-                  htmlFor={`f7avour1mp-frm-${userId}`}
+                  htmlFor={`s7ubflavour1mp-frm-${userId}`}
                 >
                   Importance
                 </label>
                 <input
-                  id={`f7avour1mp-frm-${userId}`}
+                  id={`s7ubflavour1mp-frm-${userId}`}
                   type="range"
                   min={0}
                   max={100}
@@ -448,12 +438,12 @@ export default function FlavorsClient({
               <div>
                 <label
                   className="block text-sm font-medium"
-                  htmlFor={`f7avourt4rg-frm-${userId}`}
+                  htmlFor={`s7ubflavourt4rg-frm-${userId}`}
                 >
                   Target %
                 </label>
                 <input
-                  id={`f7avourt4rg-frm-${userId}`}
+                  id={`s7ubflavourt4rg-frm-${userId}`}
                   type="number"
                   min={0}
                   max={100}
@@ -489,14 +479,14 @@ export default function FlavorsClient({
               <div className="md:col-span-2 flex justify-end gap-2 pt-4">
                 <button
                   type="button"
-                  id={`f7avourcnl-frm-${userId}`}
+                  id={`s7ubflavourcnl-frm-${userId}`}
                   className="rounded border px-3 py-1"
                   onClick={attemptClose}
                 >
                   Cancel
                 </button>
                 <button
-                  id={`f7avoursav-frm-${userId}`}
+                  id={`s7ubflavoursav-frm-${userId}`}
                   type="submit"
                   disabled={submitting}
                   className="rounded bg-orange-500 px-3 py-1 text-white disabled:opacity-50"

--- a/app/(app)/flavors/[flavorId]/subflavors/page.tsx
+++ b/app/(app)/flavors/[flavorId]/subflavors/page.tsx
@@ -1,0 +1,22 @@
+import { auth } from '@/lib/auth';
+import { listSubflavors } from '@/lib/subflavors-store';
+import SubflavorsClient from './client';
+
+export default async function SubflavorsPage({
+  params,
+}: {
+  params: { flavorId: string };
+}) {
+  const session = await auth();
+  const userId = (session?.user as any)?.id || '';
+  const subflavors = userId
+    ? await listSubflavors(userId, params.flavorId)
+    : [];
+  return (
+    <SubflavorsClient
+      userId={userId}
+      flavorId={params.flavorId}
+      initialSubflavors={subflavors}
+    />
+  );
+}

--- a/app/api/subflavors/[id]/route.ts
+++ b/app/api/subflavors/[id]/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import {
+  getSubflavor,
+  updateSubflavor,
+  deleteSubflavor,
+} from '@/lib/subflavors-store';
+
+export async function GET(req: Request, context: any) {
+  const { params } = context as { params: { id: string } };
+  const session = await auth();
+  const userId = (session?.user as any)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const subflavor = await getSubflavor(userId, params.id);
+  if (!subflavor)
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(subflavor);
+}
+
+export async function PUT(req: Request, context: any) {
+  const { params } = context as { params: { id: string } };
+  const session = await auth();
+  const userId = (session?.user as any)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const body = await req.json();
+  const updated = await updateSubflavor(userId, params.id, sanitize(body));
+  if (!updated)
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(updated);
+}
+
+export async function DELETE(req: Request, context: any) {
+  const { params } = context as { params: { id: string } };
+  const session = await auth();
+  const userId = (session?.user as any)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const ok = await deleteSubflavor(userId, params.id);
+  if (!ok) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json({ success: true });
+}
+
+function sanitize(body: any) {
+  const out: any = {};
+  if (body.name) {
+    if (body.name.length < 2 || body.name.length > 40)
+      throw new Error('Invalid name');
+    out.name = body.name;
+  }
+  if (body.description) out.description = body.description.slice(0, 280);
+  if (body.color && /^#?[0-9a-fA-F]{6}$/.test(body.color)) {
+    out.color = body.color.startsWith('#') ? body.color : '#' + body.color;
+  }
+  if (body.icon) out.icon = body.icon;
+  if (body.importance !== undefined)
+    out.importance = clamp(Number(body.importance));
+  if (body.targetMix !== undefined)
+    out.targetMix = clamp(Number(body.targetMix));
+  if (
+    body.visibility &&
+    ['private', 'friends', 'followers', 'public'].includes(body.visibility)
+  ) {
+    out.visibility = body.visibility;
+  }
+  if (body.orderIndex !== undefined) out.orderIndex = Number(body.orderIndex);
+  return out;
+}
+
+function clamp(n: number) {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}

--- a/app/api/subflavors/route.ts
+++ b/app/api/subflavors/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { listSubflavors, createSubflavor } from '@/lib/subflavors-store';
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const flavorId = req.nextUrl.searchParams.get('flavorId');
+  if (!flavorId) {
+    return NextResponse.json({ error: 'Missing flavorId' }, { status: 400 });
+  }
+  const subflavors = await listSubflavors(userId, flavorId);
+  return NextResponse.json(subflavors);
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const body = await req.json();
+  if (!body.flavorId) {
+    return NextResponse.json({ error: 'Missing flavorId' }, { status: 400 });
+  }
+  try {
+    const subflavor = await createSubflavor(
+      userId,
+      body.flavorId,
+      sanitize(body),
+    );
+    return NextResponse.json(subflavor, { status: 201 });
+  } catch (e: any) {
+    return NextResponse.json({ error: e.message }, { status: 400 });
+  }
+}
+
+function sanitize(body: any) {
+  if (!body.name || body.name.length < 2 || body.name.length > 40) {
+    throw new Error('Invalid name');
+  }
+  const description =
+    typeof body.description === 'string' ? body.description.slice(0, 280) : '';
+  const color =
+    typeof body.color === 'string' && /^#?[0-9a-fA-F]{6}$/.test(body.color)
+      ? body.color.startsWith('#')
+        ? body.color
+        : '#' + body.color
+      : '#888888';
+  const icon = typeof body.icon === 'string' ? body.icon : '⭐';
+  const importance = clamp(Number(body.importance));
+  const targetMix = clamp(Number(body.targetMix));
+  const visibility: any = [
+    'private',
+    'friends',
+    'followers',
+    'public',
+  ].includes(body.visibility)
+    ? body.visibility
+    : 'private';
+  const orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : 0;
+  return {
+    flavorId: body.flavorId,
+    name: body.name,
+    description,
+    color,
+    icon,
+    importance,
+    targetMix,
+    visibility,
+    orderIndex,
+    slug: typeof body.slug === 'string' ? body.slug : undefined,
+  };
+}
+
+function clamp(n: number) {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}

--- a/drizzle/0002_create_subflavors.sql
+++ b/drizzle/0002_create_subflavors.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "subflavors" (
+  "id" text PRIMARY KEY NOT NULL,
+  "user_id" integer REFERENCES users(id),
+  "flavor_id" text REFERENCES flavors(id),
+  "slug" text NOT NULL,
+  "name" varchar(40),
+  "description" text,
+  "color" varchar(10),
+  "icon" varchar(10),
+  "importance" integer,
+  "target_mix" integer,
+  "visibility" varchar(20),
+  "order_index" integer,
+  "created_at" timestamp DEFAULT NOW(),
+  "updated_at" timestamp DEFAULT NOW()
+);

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -30,3 +30,20 @@ export const flavors = pgTable('flavors', {
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),
 });
+
+export const subflavors = pgTable('subflavors', {
+  id: text('id').primaryKey(),
+  userId: integer('user_id').references(() => users.id),
+  flavorId: text('flavor_id').references(() => flavors.id),
+  slug: text('slug').notNull(),
+  name: varchar('name', { length: 40 }),
+  description: text('description'),
+  color: varchar('color', { length: 10 }),
+  icon: varchar('icon', { length: 10 }),
+  importance: integer('importance'),
+  targetMix: integer('target_mix'),
+  visibility: varchar('visibility', { length: 20 }),
+  orderIndex: integer('order_index'),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
+});

--- a/lib/subflavors-store.ts
+++ b/lib/subflavors-store.ts
@@ -1,0 +1,133 @@
+import { db } from './db';
+import { subflavors } from './db/schema';
+import { eq, and } from 'drizzle-orm';
+import type { Subflavor, SubflavorInput, Visibility } from '@/types/subflavor';
+
+function sortSubflavors(list: Subflavor[]) {
+  return list.sort((a, b) => {
+    if (b.importance !== a.importance) return b.importance - a.importance;
+    if (a.orderIndex !== b.orderIndex) return a.orderIndex - b.orderIndex;
+    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+  });
+}
+
+function toSubflavor(row: typeof subflavors.$inferSelect): Subflavor {
+  return {
+    id: row.id,
+    userId: row.userId?.toString() ?? '',
+    flavorId: row.flavorId ?? '',
+    slug: row.slug,
+    name: row.name ?? '',
+    description: row.description ?? '',
+    color: row.color ?? '#888888',
+    icon: row.icon ?? '⭐',
+    importance: row.importance ?? 0,
+    targetMix: row.targetMix ?? 0,
+    visibility: (row.visibility as Visibility) ?? 'private',
+    orderIndex: row.orderIndex ?? 0,
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+    updatedAt: row.updatedAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+export async function listSubflavors(
+  userId: string,
+  flavorId: string,
+): Promise<Subflavor[]> {
+  const id = Number(userId);
+  if (Number.isNaN(id)) return [];
+  const rows = await db
+    .select()
+    .from(subflavors)
+    .where(and(eq(subflavors.userId, id), eq(subflavors.flavorId, flavorId)));
+  return sortSubflavors(rows.map(toSubflavor));
+}
+
+export async function getSubflavor(
+  userId: string,
+  id: string,
+): Promise<Subflavor | null> {
+  const [row] = await db
+    .select()
+    .from(subflavors)
+    .where(and(eq(subflavors.userId, Number(userId)), eq(subflavors.id, id)));
+  return row ? toSubflavor(row) : null;
+}
+
+export async function createSubflavor(
+  userId: string,
+  flavorId: string,
+  input: SubflavorInput,
+): Promise<Subflavor> {
+  const id = crypto.randomUUID();
+  const now = new Date();
+  const [row] = await db
+    .insert(subflavors)
+    .values({
+      id,
+      userId: Number(userId),
+      flavorId,
+      slug:
+        input.slug ||
+        input.name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .slice(0, 40),
+      name: input.name.slice(0, 40),
+      description: input.description.slice(0, 280),
+      color: input.color,
+      icon: input.icon,
+      importance: clamp(input.importance),
+      targetMix: clamp(input.targetMix),
+      visibility: input.visibility,
+      orderIndex: input.orderIndex ?? 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+  return toSubflavor(row);
+}
+
+export async function updateSubflavor(
+  userId: string,
+  id: string,
+  input: Partial<SubflavorInput>,
+): Promise<Subflavor | null> {
+  const now = new Date();
+  const [row] = await db
+    .update(subflavors)
+    .set({
+      slug: input.slug,
+      name: input.name ? input.name.slice(0, 40) : undefined,
+      description: input.description
+        ? input.description.slice(0, 280)
+        : undefined,
+      color: input.color,
+      icon: input.icon,
+      importance:
+        input.importance !== undefined ? clamp(input.importance) : undefined,
+      targetMix:
+        input.targetMix !== undefined ? clamp(input.targetMix) : undefined,
+      visibility: input.visibility,
+      orderIndex: input.orderIndex,
+      updatedAt: now,
+    })
+    .where(and(eq(subflavors.userId, Number(userId)), eq(subflavors.id, id)))
+    .returning();
+  return row ? toSubflavor(row) : null;
+}
+
+export async function deleteSubflavor(
+  userId: string,
+  id: string,
+): Promise<boolean> {
+  const rows = await db
+    .delete(subflavors)
+    .where(and(eq(subflavors.userId, Number(userId)), eq(subflavors.id, id)))
+    .returning();
+  return rows.length > 0;
+}
+
+function clamp(n: number) {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}

--- a/tests/subflavors.spec.ts
+++ b/tests/subflavors.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+test('subflavor CRUD', async ({ page }) => {
+  const email = `user${Date.now()}@example.com`;
+  const password = 'pass1234';
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Tester');
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.goto('/flavors');
+
+  // create a flavor to attach subflavors
+  await page.click('text=New Flavor');
+  await page.fill('input[id^="f7avourn4me-frm"]', 'Main');
+  await page.fill('textarea[id^="f7avourde5cr-frm"]', 'maindesc');
+  await page.fill('input[name="color"]', '#ff0000');
+  await page.click('button:has-text("⭐")');
+  await page.fill('input[id^="f7avour1mp-frm"]', '60');
+  await page.fill('input[id^="f7avourt4rg-frm"]', '20');
+  await page.click('button[id^="f7avoursav-frm"]');
+
+  // go to subflavors
+  await page.click('button[id^="f7avsubfbtn"]');
+
+  // create subflavor
+  await page.click('text=New Subflavor');
+  await page.fill('input[id^="s7ubflavourn4me-frm"]', 'Sub1');
+  await page.fill('textarea[id^="s7ubflavourde5cr-frm"]', 'sdesc');
+  await page.fill('input[name="color"]', '#00ff00');
+  await page.click('button:has-text("📚")');
+  await page.fill('input[id^="s7ubflavour1mp-frm"]', '70');
+  await page.fill('input[id^="s7ubflavourt4rg-frm"]', '30');
+  await page.click('button[id^="s7ubflavoursav-frm"]');
+  await expect(page.locator('li:has-text("Sub1")')).toBeVisible();
+
+  const rows = page.locator('ul[id^="s7ubflavourli5t"] > li');
+  await rows.first().click();
+  await page.fill('input[id^="s7ubflavour1mp-frm"]', '80');
+  await page.click('button[id^="s7ubflavoursav-frm"]');
+  await expect(rows.first().locator('div[id^="s7ubflavourn4me"]')).toHaveText(
+    'Sub1',
+  );
+
+  // delete subflavor
+  page.on('dialog', (d) => d.accept());
+  await rows.first().locator('button:has-text("Delete")').click();
+  await expect(page.locator('li:has-text("Sub1")')).toHaveCount(0);
+});

--- a/types/subflavor.ts
+++ b/types/subflavor.ts
@@ -1,0 +1,23 @@
+export type Visibility = 'private' | 'friends' | 'followers' | 'public';
+
+export interface Subflavor {
+  id: string;
+  userId: string;
+  flavorId: string;
+  slug: string;
+  name: string;
+  description: string;
+  color: string;
+  icon: string;
+  importance: number;
+  targetMix: number;
+  visibility: Visibility;
+  orderIndex: number;
+  createdAt: string; // ISO string
+  updatedAt: string;
+}
+
+export type SubflavorInput = Omit<
+  Subflavor,
+  'id' | 'userId' | 'createdAt' | 'updatedAt'
+>;


### PR DESCRIPTION
## Summary
- add subflavor model, API routes, and UI to manage subflavors per flavor
- navigate to subflavors from flavor list via new "View Subflavors" button
- cover subflavor flows with Playwright tests

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ec085d68832a8d73ed90d2c331e6