### PR TITLE
feat: add social people pages

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -29,3 +29,4 @@
 - 2025-08-25: Added migration to add slug to flavors and guarded user ID parsing to prevent NaN queries.
 - 2025-08-26: Added subflavors with CRUD UI, server actions, API routes, and navigation button from flavors list.
 - 2025-08-26: Added settings button with sign-out, dark mode toggle, follower count display, and profile visibility toggle.
+- 2025-08-27: Introduced social "People" pages with follow system, inbox for requests, and profile visibility enforcement.

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -1,0 +1,123 @@
+'use server';
+
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { follows, notifications, users } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+
+export async function followRequest(
+  targetId: number,
+  _formData?: FormData,
+): Promise<void> {
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me) throw new Error('Please sign in.');
+  if (me === targetId) throw new Error('Cannot follow yourself.');
+
+  const [target] = await db
+    .select({ accountVisibility: users.accountVisibility })
+    .from(users)
+    .where(eq(users.id, targetId));
+  if (!target) throw new Error('User not found');
+  if (target.accountVisibility === 'private') {
+    throw new Error('User is private');
+  }
+
+  const status = target.accountVisibility === 'open' ? 'accepted' : 'pending';
+
+  await db
+    .insert(follows)
+    .values({ followerId: me, followingId: targetId, status })
+    .onConflictDoUpdate({
+      target: [follows.followerId, follows.followingId],
+      set: { status, updatedAt: new Date() },
+    });
+
+  if (status === 'pending') {
+    await db.insert(notifications).values({
+      toUserId: targetId,
+      fromUserId: me,
+      type: 'follow_request',
+    });
+  }
+
+  revalidatePath('/people');
+}
+
+export async function cancelFollowRequest(
+  targetId: number,
+  _formData?: FormData,
+): Promise<void> {
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me) throw new Error('Please sign in.');
+  await db
+    .delete(follows)
+    .where(
+      and(
+        eq(follows.followerId, me),
+        eq(follows.followingId, targetId),
+        eq(follows.status, 'pending'),
+      ),
+    );
+  revalidatePath('/people');
+}
+
+export async function acceptFollowRequest(
+  requesterId: number,
+  _formData?: FormData,
+): Promise<void> {
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me) throw new Error('Please sign in.');
+  const [req] = await db
+    .select()
+    .from(follows)
+    .where(
+      and(eq(follows.followerId, requesterId), eq(follows.followingId, me)),
+    );
+  if (!req || req.status !== 'pending') throw new Error('Request not found');
+  await db
+    .update(follows)
+    .set({ status: 'accepted', updatedAt: new Date() })
+    .where(eq(follows.id, req.id));
+  await db.insert(notifications).values({
+    toUserId: requesterId,
+    fromUserId: me,
+    type: 'follow_accepted',
+  });
+  revalidatePath('/people');
+}
+
+export async function unfollow(
+  targetId: number,
+  _formData?: FormData,
+): Promise<void> {
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me) throw new Error('Please sign in.');
+  await db
+    .delete(follows)
+    .where(and(eq(follows.followerId, me), eq(follows.followingId, targetId)));
+  revalidatePath('/people');
+}
+
+export async function declineFollowRequest(
+  requesterId: number,
+  _formData?: FormData,
+): Promise<void> {
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me) throw new Error('Please sign in.');
+  await db
+    .delete(follows)
+    .where(
+      and(
+        eq(follows.followerId, requesterId),
+        eq(follows.followingId, me),
+        eq(follows.status, 'pending'),
+      ),
+    );
+  revalidatePath('/people');
+}

--- a/app/(app)/people/inbox/page.tsx
+++ b/app/(app)/people/inbox/page.tsx
@@ -1,0 +1,91 @@
+import { db } from '@/lib/db';
+import { follows, notifications, users } from '@/lib/db/schema';
+import { auth } from '@/lib/auth';
+import { acceptFollowRequest, declineFollowRequest } from '../actions';
+import { eq, and } from 'drizzle-orm';
+import { Button } from '@/components/ui/button';
+
+export default async function InboxPage() {
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me) {
+    return (
+      <section>
+        <h1 className="text-2xl font-bold">Inbox</h1>
+        <p>Please sign in.</p>
+      </section>
+    );
+  }
+
+  const requests = await db
+    .select({
+      id: follows.followerId,
+      handle: users.handle,
+      displayName: users.displayName,
+    })
+    .from(follows)
+    .innerJoin(users, eq(users.id, follows.followerId))
+    .where(and(eq(follows.followingId, me), eq(follows.status, 'pending')));
+
+  const activity = await db
+    .select({
+      id: notifications.id,
+      handle: users.handle,
+      displayName: users.displayName,
+    })
+    .from(notifications)
+    .innerJoin(users, eq(users.id, notifications.fromUserId))
+    .where(
+      and(eq(notifications.toUserId, me), eq(notifications.type, 'follow_accepted')),
+    );
+
+  return (
+    <section className="space-y-8">
+      <h1 className="text-2xl font-bold">Inbox</h1>
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Requests</h2>
+        {requests.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No requests.</p>
+        ) : (
+          <ul className="divide-y">
+            {requests.map((r) => (
+              <li key={r.id} className="flex items-center justify-between py-2">
+                <div>
+                  <div className="font-semibold">{r.displayName ?? r.handle}</div>
+                  <div className="text-sm text-muted-foreground">@{r.handle}</div>
+                </div>
+                <div className="flex gap-2">
+                  <form action={acceptFollowRequest.bind(null, r.id)}>
+                    <Button size="sm">Accept</Button>
+                  </form>
+                  <form action={declineFollowRequest.bind(null, r.id)}>
+                    <Button variant="outline" size="sm">
+                      Decline
+                    </Button>
+                  </form>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Activity</h2>
+        {activity.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No activity.</p>
+        ) : (
+          <ul className="divide-y">
+            {activity.map((a) => (
+              <li key={a.id} className="py-2">
+                <div className="text-sm">
+                  <span className="font-semibold">@{a.handle}</span> accepted your follow
+                  request
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -1,7 +1,158 @@
-export default function PeoplePage() {
+import { db } from '@/lib/db';
+import { follows, users } from '@/lib/db/schema';
+import { auth } from '@/lib/auth';
+import { followRequest, unfollow, cancelFollowRequest } from './actions';
+import Link from 'next/link';
+import { eq, ne } from 'drizzle-orm';
+import { Button } from '@/components/ui/button';
+
+export default async function PeoplePage() {
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me) {
+    return (
+      <section>
+        <h1 className="text-2xl font-bold">People</h1>
+        <p>Please sign in.</p>
+      </section>
+    );
+  }
+
+  const allUsers = await db
+    .select({
+      id: users.id,
+      handle: users.handle,
+      displayName: users.displayName,
+      accountVisibility: users.accountVisibility,
+    })
+    .from(users)
+    .where(ne(users.id, me));
+
+  const myFollows = await db
+    .select({ followingId: follows.followingId, status: follows.status })
+    .from(follows)
+    .where(eq(follows.followerId, me));
+
+  const inboundFollows = await db
+    .select({ followerId: follows.followerId, status: follows.status })
+    .from(follows)
+    .where(eq(follows.followingId, me));
+
+  const myMap = new Map(myFollows.map((f) => [f.followingId, f.status]));
+  const inboundMap = new Map(inboundFollows.map((f) => [f.followerId, f.status]));
+
+  const friends: typeof allUsers = [];
+  const followersList: typeof allUsers = [];
+  const discover: (typeof allUsers[number] & { status?: string })[] = [];
+
+  for (const u of allUsers) {
+    if (u.accountVisibility === 'private') continue;
+    const myStatus = myMap.get(u.id);
+    const theirStatus = inboundMap.get(u.id);
+    if (myStatus === 'accepted' && theirStatus === 'accepted') {
+      friends.push(u);
+    } else if (myStatus === 'accepted' && theirStatus !== 'accepted') {
+      followersList.push(u);
+    } else if (myStatus === 'pending') {
+      discover.push({ ...u, status: 'pending' });
+    } else if (!myStatus && !theirStatus) {
+      discover.push(u);
+    }
+  }
+
   return (
-    <section>
-      <h1 className="text-2xl font-bold">People</h1>
+    <section className="space-y-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">People</h1>
+        <Link href="/people/inbox" className="text-sm underline">
+          Inbox
+        </Link>
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Friends</h2>
+        <UserList users={friends} relation="friend" />
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Followers</h2>
+        <UserList users={followersList} relation="following" />
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Discover</h2>
+        <UserList users={discover} relation="discover" />
+      </div>
     </section>
   );
+}
+
+interface UserInfo {
+  id: number;
+  handle: string;
+  displayName: string | null;
+  accountVisibility: string;
+}
+
+function UserList({
+  users,
+  relation,
+}: {
+  users: (UserInfo & { status?: string })[];
+  relation: 'friend' | 'following' | 'discover';
+}) {
+  if (users.length === 0) {
+    return <p className="text-sm text-muted-foreground">No users.</p>;
+  }
+  return (
+    <ul className="divide-y">
+      {users.map((u) => (
+        <li key={u.id} className="flex items-center justify-between py-2">
+          <div>
+            <Link href={`/u/${u.handle}`} className="font-semibold">
+              {u.displayName ?? u.handle}
+            </Link>
+            <div className="text-sm text-muted-foreground">@{u.handle}</div>
+          </div>
+          <UserAction user={u} relation={relation} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function UserAction({
+  user,
+  relation,
+}: {
+  user: UserInfo & { status?: string };
+  relation: 'friend' | 'following' | 'discover';
+}) {
+  switch (relation) {
+    case 'friend':
+    case 'following':
+      return (
+        <form action={unfollow.bind(null, user.id)}>
+          <Button variant="outline" size="sm">
+            Unfollow
+          </Button>
+        </form>
+      );
+    case 'discover':
+      if (user.status === 'pending') {
+        return (
+          <form action={cancelFollowRequest.bind(null, user.id)}>
+            <Button variant="outline" size="sm">
+              Cancel request
+            </Button>
+          </form>
+        );
+      }
+      return (
+        <form action={followRequest.bind(null, user.id)}>
+          <Button size="sm">
+            {user.accountVisibility === 'open' ? 'Follow' : 'Request to follow'}
+          </Button>
+        </form>
+      );
+    default:
+      return null;
+  }
 }

--- a/app/(app)/u/[handle]/page.tsx
+++ b/app/(app)/u/[handle]/page.tsx
@@ -1,0 +1,92 @@
+import { db } from '@/lib/db';
+import { users, follows } from '@/lib/db/schema';
+import { auth } from '@/lib/auth';
+import { followRequest, cancelFollowRequest, unfollow } from '../../people/actions';
+import { eq, and } from 'drizzle-orm';
+import { notFound } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+export default async function ProfilePage({
+  params,
+}: {
+  params: { handle: string };
+}) {
+  const session = await auth();
+  const viewerId = Number(session?.user?.id);
+  const handle = params.handle;
+
+  const [user] = await db
+    .select({
+      id: users.id,
+      handle: users.handle,
+      displayName: users.displayName,
+      accountVisibility: users.accountVisibility,
+    })
+    .from(users)
+    .where(eq(users.handle, handle));
+
+  if (!user) notFound();
+
+  if (user.accountVisibility === 'private' && viewerId !== user.id) {
+    notFound();
+  }
+
+  let relation: 'self' | 'accepted' | 'pending' | 'none' = 'none';
+  if (viewerId) {
+    if (viewerId === user.id) {
+      relation = 'self';
+    } else {
+      const [follow] = await db
+        .select()
+        .from(follows)
+        .where(
+          and(eq(follows.followerId, viewerId), eq(follows.followingId, user.id)),
+        );
+      if (follow) relation = follow.status as 'accepted' | 'pending';
+    }
+  }
+
+  if (
+    user.accountVisibility === 'closed' &&
+    viewerId !== user.id &&
+    relation !== 'accepted'
+  ) {
+    return (
+      <section className="space-y-4">
+        <h1 className="text-2xl font-bold">{user.displayName ?? user.handle}</h1>
+        <p>@{user.handle}</p>
+        {relation === 'pending' ? (
+          <form action={cancelFollowRequest.bind(null, user.id)}>
+            <Button variant="outline">Requested</Button>
+          </form>
+        ) : (
+          <form action={followRequest.bind(null, user.id)}>
+            <Button>Request to follow</Button>
+          </form>
+        )}
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-4">
+      <h1 className="text-2xl font-bold">{user.displayName ?? user.handle}</h1>
+      <p>@{user.handle}</p>
+      {relation === 'self' ? null : relation === 'accepted' ? (
+        <form action={unfollow.bind(null, user.id)}>
+          <Button variant="outline">Unfollow</Button>
+        </form>
+      ) : relation === 'pending' ? (
+        <form action={cancelFollowRequest.bind(null, user.id)}>
+          <Button variant="outline">Cancel request</Button>
+        </form>
+      ) : (
+        <form action={followRequest.bind(null, user.id)}>
+          <Button>
+            {user.accountVisibility === 'open' ? 'Follow' : 'Request to follow'}
+          </Button>
+        </form>
+      )}
+    </section>
+  );
+}

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,15 +1,19 @@
 import { NextResponse } from 'next/server';
-import { createUser, getUserByEmail } from '@/lib/users';
+import { createUser, getUserByEmail, getUserByHandle } from '@/lib/users';
 
 export async function POST(req: Request) {
-  const { email, password, name } = await req.json();
-  if (!email || !password) {
+  const { email, password, handle, name } = await req.json();
+  if (!email || !password || !handle) {
     return NextResponse.json({ error: 'Invalid' }, { status: 400 });
   }
   const existing = await getUserByEmail(email);
   if (existing) {
     return NextResponse.json({ error: 'Email already exists' }, { status: 400 });
   }
-  const user = await createUser({ email, password, name });
+  const existingHandle = await getUserByHandle(handle);
+  if (existingHandle) {
+    return NextResponse.json({ error: 'Handle already exists' }, { status: 400 });
+  }
+  const user = await createUser({ email, password, handle, displayName: name });
   return NextResponse.json({ id: user.id }, { status: 201 });
 }

--- a/drizzle/0003_people.sql
+++ b/drizzle/0003_people.sql
@@ -1,0 +1,34 @@
+-- Account visibility enum
+CREATE TYPE "account_visibility" AS ENUM ('open','closed','private');
+
+ALTER TABLE "users" ADD COLUMN "handle" varchar(50) NOT NULL;
+ALTER TABLE "users" ADD COLUMN "display_name" text;
+ALTER TABLE "users" ADD COLUMN "avatar_url" text;
+ALTER TABLE "users" ADD COLUMN "account_visibility" "account_visibility" NOT NULL DEFAULT 'open';
+ALTER TABLE "users" ADD COLUMN "updated_at" timestamp DEFAULT now();
+ALTER TABLE "users" ADD CONSTRAINT "users_handle_unique" UNIQUE("handle");
+
+-- Follow status enum
+CREATE TYPE "follow_status" AS ENUM ('pending','accepted');
+
+CREATE TABLE "follows" (
+  "id" serial PRIMARY KEY,
+  "follower_id" integer NOT NULL REFERENCES "users"("id"),
+  "following_id" integer NOT NULL REFERENCES "users"("id"),
+  "status" "follow_status" NOT NULL DEFAULT 'pending',
+  "created_at" timestamp DEFAULT now(),
+  "updated_at" timestamp DEFAULT now(),
+  CONSTRAINT "follows_follower_following_unique" UNIQUE("follower_id","following_id")
+);
+
+-- Notification type enum
+CREATE TYPE "notification_type" AS ENUM ('follow_request','follow_accepted');
+
+CREATE TABLE "notifications" (
+  "id" serial PRIMARY KEY,
+  "to_user_id" integer NOT NULL REFERENCES "users"("id"),
+  "from_user_id" integer NOT NULL REFERENCES "users"("id"),
+  "type" "notification_type" NOT NULL,
+  "created_at" timestamp DEFAULT now(),
+  "read_at" timestamp
+);

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -6,6 +6,10 @@ import { randomBytes, scryptSync, timingSafeEqual } from 'crypto';
 export interface NewUser {
   email: string;
   password: string;
+  handle: string;
+  displayName?: string;
+  avatarUrl?: string;
+  accountVisibility?: 'open' | 'closed' | 'private';
   name?: string;
 }
 
@@ -26,12 +30,25 @@ export async function createUser(input: NewUser) {
   const passwordHash = hashPassword(input.password);
   const [user] = await db
     .insert(users)
-    .values({ email: input.email, name: input.name, passwordHash })
+    .values({
+      email: input.email,
+      handle: input.handle,
+      displayName: input.displayName ?? input.name,
+      avatarUrl: input.avatarUrl,
+      accountVisibility: input.accountVisibility ?? 'open',
+      name: input.name,
+      passwordHash,
+    })
     .returning();
   return user;
 }
 
 export async function getUserByEmail(email: string) {
   const [user] = await db.select().from(users).where(eq(users.email, email));
+  return user ?? null;
+}
+
+export async function getUserByHandle(handle: string) {
+  const [user] = await db.select().from(users).where(eq(users.handle, handle));
   return user ?? null;
 }


### PR DESCRIPTION
## Summary
- expand database with user handles, follows, and notifications
- add People pages with friends, followers, discover, and inbox
- enforce profile visibility and follow actions

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` (fails: Timed out waiting 120000ms from config.webServer)

------
https://chatgpt.com/codex/tasks/task_e_68a203d76d38832ab1b87f5ed9ba3f80