### PR TITLE
feat: add social people tab and follow model

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -29,3 +29,4 @@
 - 2025-08-25: Added migration to add slug to flavors and guarded user ID parsing to prevent NaN queries.
 - 2025-08-26: Added subflavors with CRUD UI, server actions, API routes, and navigation button from flavors list.
 - 2025-08-26: Added settings button with sign-out, dark mode toggle, follower count display, and profile visibility toggle.
+- 2025-08-27: Implemented social People tab with friends, followers, discover lists, follow requests inbox, and follow/notification models.

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -1,7 +1,26 @@
-export default function PeoplePage() {
+import { auth } from '@/lib/auth';
+import { getFriends, getFollowers, getDiscover, getInbox } from '@/lib/people';
+import PeopleTabs from './people-tabs';
+
+export default async function PeoplePage() {
+  const session = await auth();
+  const userId = Number((session as any)?.user?.id);
+  const [friends, followers, discover, inbox] = await Promise.all([
+    getFriends(userId),
+    getFollowers(userId),
+    getDiscover(userId),
+    getInbox(userId),
+  ]);
   return (
-    <section>
-      <h1 className="text-2xl font-bold">People</h1>
+    <section className="p-4">
+      <h1 className="text-2xl font-bold mb-4">People</h1>
+      <PeopleTabs
+        friends={friends}
+        followers={followers}
+        discover={discover}
+        requests={inbox.requests}
+        activity={inbox.activity}
+      />
     </section>
   );
 }

--- a/app/(app)/people/people-tabs.tsx
+++ b/app/(app)/people/people-tabs.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import type { SimpleUser } from '@/lib/people';
+import {
+  followRequest,
+  unfollow,
+  acceptFollowRequest,
+  declineFollowRequest,
+} from '@/lib/people';
+
+interface Props {
+  friends: SimpleUser[];
+  followers: SimpleUser[];
+  discover: SimpleUser[];
+  requests: { id: number; handle: string; displayName: string | null; createdAt: string }[];
+  activity: { id: number; handle: string; displayName: string | null; createdAt: string; readAt: string | null }[];
+}
+
+const tabs = ['friends', 'followers', 'discover', 'inbox'] as const;
+
+export default function PeopleTabs({ friends, followers, discover, requests, activity }: Props) {
+  const [tab, setTab] = useState<(typeof tabs)[number]>('friends');
+  const [search, setSearch] = useState('');
+  const [inboxTab, setInboxTab] = useState<'requests' | 'activity'>('requests');
+
+  let list: SimpleUser[] = [];
+  if (tab === 'friends') list = friends;
+  if (tab === 'followers') list = followers;
+  if (tab === 'discover') list = discover;
+
+  const filtered = list.filter((u) => {
+    const term = search.toLowerCase();
+    return (
+      (u.displayName ?? '').toLowerCase().includes(term) ||
+      u.handle.toLowerCase().includes(term)
+    );
+  });
+
+  return (
+    <div>
+      <div className="flex gap-4 border-b mb-4">
+        {tabs.map((t) => (
+          <button
+            key={t}
+            className={`pb-2 ${tab === t ? 'border-b-2 border-black' : 'text-gray-500'}`}
+            onClick={() => setTab(t)}
+          >
+            {t.charAt(0).toUpperCase() + t.slice(1)}
+          </button>
+        ))}
+      </div>
+      {tab !== 'inbox' && (
+        <div>
+          <input
+            type="text"
+            placeholder="Search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="mb-4 border p-2 w-full max-w-sm"
+          />
+          <ul className="space-y-2">
+            {filtered.map((u) => (
+              <li key={u.id} className="flex items-center justify-between border p-2 rounded">
+                <div>
+                  <div className="font-bold">{u.displayName ?? u.handle}</div>
+                  <div className="text-sm text-gray-600">@{u.handle}</div>
+                </div>
+                <div>
+                  {tab === 'discover' && (
+                    <form action={followRequest.bind(null, u.id)}>
+                      <Button type="submit">
+                        {u.accountVisibility === 'closed' ? 'Request to follow' : 'Follow'}
+                      </Button>
+                    </form>
+                  )}
+                  {tab !== 'discover' && (
+                    <form action={unfollow.bind(null, u.id)}>
+                      <Button type="submit" variant="outline">
+                        Unfollow
+                      </Button>
+                    </form>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {tab === 'inbox' && (
+        <div>
+          <div className="flex gap-4 border-b mb-4">
+            <button
+              className={`pb-2 ${inboxTab === 'requests' ? 'border-b-2 border-black' : 'text-gray-500'}`}
+              onClick={() => setInboxTab('requests')}
+            >
+              Requests ({requests.length})
+            </button>
+            <button
+              className={`pb-2 ${inboxTab === 'activity' ? 'border-b-2 border-black' : 'text-gray-500'}`}
+              onClick={() => setInboxTab('activity')}
+            >
+              Activity ({activity.length})
+            </button>
+          </div>
+          {inboxTab === 'requests' && (
+            <ul className="space-y-2">
+              {requests.map((r) => (
+                <li key={r.id} className="flex items-center justify-between border p-2 rounded">
+                  <div>
+                    <div className="font-bold">{r.displayName ?? r.handle}</div>
+                    <div className="text-sm text-gray-600">@{r.handle}</div>
+                  </div>
+                  <div className="flex gap-2">
+                    <form action={acceptFollowRequest.bind(null, r.id)}>
+                      <Button type="submit">Accept</Button>
+                    </form>
+                    <form action={declineFollowRequest.bind(null, r.id)}>
+                      <Button type="submit" variant="outline">
+                        Decline
+                      </Button>
+                    </form>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+          {inboxTab === 'activity' && (
+            <ul className="space-y-2">
+              {activity.map((a) => (
+                <li key={a.id} className="border p-2 rounded">
+                  <span className="font-bold">@{a.handle}</span> accepted your follow request
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/drizzle/0003_people.sql
+++ b/drizzle/0003_people.sql
@@ -1,0 +1,25 @@
+ALTER TABLE users
+  ADD COLUMN handle text NOT NULL UNIQUE,
+  ADD COLUMN display_name text,
+  ADD COLUMN avatar_url text,
+  ADD COLUMN account_visibility varchar(10) NOT NULL DEFAULT 'open',
+  ADD COLUMN updated_at timestamp DEFAULT now();
+
+CREATE TABLE IF NOT EXISTS "follows" (
+  "id" serial PRIMARY KEY,
+  "follower_id" integer NOT NULL REFERENCES users(id),
+  "following_id" integer NOT NULL REFERENCES users(id),
+  "status" varchar(10) NOT NULL,
+  "created_at" timestamp DEFAULT now(),
+  "updated_at" timestamp DEFAULT now(),
+  UNIQUE("follower_id", "following_id")
+);
+
+CREATE TABLE IF NOT EXISTS "notifications" (
+  "id" serial PRIMARY KEY,
+  "to_user_id" integer NOT NULL REFERENCES users(id),
+  "from_user_id" integer NOT NULL REFERENCES users(id),
+  "type" varchar(20) NOT NULL,
+  "created_at" timestamp DEFAULT now(),
+  "read_at" timestamp
+);

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -5,14 +5,22 @@ import {
   varchar,
   timestamp,
   integer,
+  uniqueIndex,
 } from 'drizzle-orm/pg-core';
 
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
   email: text('email').notNull().unique(),
+  handle: text('handle').notNull().unique(),
+  displayName: text('display_name'),
+  avatarUrl: text('avatar_url'),
+  accountVisibility: varchar('account_visibility', { length: 10 })
+    .notNull()
+    .default('open'),
   name: text('name'),
   passwordHash: text('password_hash').notNull(),
   createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
 });
 
 export const flavors = pgTable('flavors', {
@@ -46,4 +54,29 @@ export const subflavors = pgTable('subflavors', {
   orderIndex: integer('order_index'),
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),
+});
+
+export const follows = pgTable(
+  'follows',
+  {
+    id: serial('id').primaryKey(),
+    followerId: integer('follower_id').references(() => users.id).notNull(),
+    followingId: integer('following_id').references(() => users.id).notNull(),
+    status: varchar('status', { length: 10 }).notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+    updatedAt: timestamp('updated_at').defaultNow(),
+  },
+  (table) => ({
+    uniq: uniqueIndex('follows_unique')
+      .on(table.followerId, table.followingId),
+  })
+);
+
+export const notifications = pgTable('notifications', {
+  id: serial('id').primaryKey(),
+  toUserId: integer('to_user_id').references(() => users.id).notNull(),
+  fromUserId: integer('from_user_id').references(() => users.id).notNull(),
+  type: varchar('type', { length: 20 }).notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
+  readAt: timestamp('read_at'),
 });

--- a/lib/people.ts
+++ b/lib/people.ts
@@ -1,0 +1,157 @@
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { follows, notifications, users } from '@/lib/db/schema';
+import { eq, and, sql, isNull } from 'drizzle-orm';
+
+export interface SimpleUser {
+  id: number;
+  handle: string;
+  displayName: string | null;
+  accountVisibility: string;
+}
+
+export async function getFriends(userId: number): Promise<SimpleUser[]> {
+  const res = await db.execute(
+    sql`SELECT u.id, u.handle, u.display_name as "displayName", u.account_visibility as "accountVisibility"
+        FROM users u
+        JOIN follows f1 ON f1.following_id = u.id AND f1.follower_id = ${userId} AND f1.status = 'accepted'
+        JOIN follows f2 ON f2.following_id = ${userId} AND f2.follower_id = u.id AND f2.status = 'accepted'
+        WHERE u.account_visibility <> 'private'
+        ORDER BY u.display_name NULLS LAST, u.handle`
+  );
+  return res.rows as any;
+}
+
+export async function getFollowers(userId: number): Promise<SimpleUser[]> {
+  const res = await db.execute(
+    sql`SELECT u.id, u.handle, u.display_name as "displayName", u.account_visibility as "accountVisibility"
+        FROM users u
+        JOIN follows f1 ON f1.following_id = u.id AND f1.follower_id = ${userId} AND f1.status = 'accepted'
+        LEFT JOIN follows f2 ON f2.following_id = ${userId} AND f2.follower_id = u.id AND f2.status = 'accepted'
+        WHERE f2.id IS NULL AND u.account_visibility <> 'private'
+        ORDER BY u.display_name NULLS LAST, u.handle`
+  );
+  return res.rows as any;
+}
+
+export async function getDiscover(userId: number): Promise<SimpleUser[]> {
+  const res = await db.execute(
+    sql`SELECT u.id, u.handle, u.display_name as "displayName", u.account_visibility as "accountVisibility"
+        FROM users u
+        LEFT JOIN follows f1 ON f1.follower_id = ${userId} AND f1.following_id = u.id
+        LEFT JOIN follows f2 ON f2.follower_id = u.id AND f2.following_id = ${userId} AND f2.status = 'accepted'
+        WHERE u.id <> ${userId}
+          AND u.account_visibility IN ('open','closed')
+          AND f1.id IS NULL
+          AND f2.id IS NULL
+        ORDER BY u.display_name NULLS LAST, u.handle`
+  );
+  return res.rows as any;
+}
+
+export async function getInbox(userId: number) {
+  const requests = await db.execute(
+    sql`SELECT u.id, u.handle, u.display_name as "displayName", f.created_at as "createdAt"
+        FROM users u
+        JOIN follows f ON f.follower_id = u.id AND f.following_id = ${userId} AND f.status = 'pending'
+        ORDER BY f.created_at DESC`
+  );
+  const activity = await db.execute(
+    sql`SELECT n.id, u.handle, u.display_name as "displayName", n.created_at as "createdAt", n.read_at as "readAt"
+        FROM notifications n
+        JOIN users u ON u.id = n.from_user_id
+        WHERE n.to_user_id = ${userId} AND n.type = 'follow_accepted'
+        ORDER BY n.created_at DESC`
+  );
+  return { requests: requests.rows as any, activity: activity.rows as any };
+}
+
+export async function markAllActivityRead() {
+  'use server';
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me) return;
+  await db
+    .update(notifications)
+    .set({ readAt: new Date() })
+    .where(and(eq(notifications.toUserId, me), eq(notifications.type, 'follow_accepted'), isNull(notifications.readAt)));
+}
+
+export async function followRequest(targetId: number) {
+  'use server';
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me || me === targetId) return;
+  const [target] = await db
+    .select({ id: users.id, accountVisibility: users.accountVisibility })
+    .from(users)
+    .where(eq(users.id, targetId));
+  if (!target) return;
+  if (target.accountVisibility === 'private') return;
+  if (target.accountVisibility === 'open') {
+    await db
+      .insert(follows)
+      .values({ followerId: me, followingId: targetId, status: 'accepted' })
+      .onConflictDoUpdate({
+        target: [follows.followerId, follows.followingId],
+        set: { status: 'accepted', updatedAt: sql`now()` },
+      });
+  } else {
+    await db
+      .insert(follows)
+      .values({ followerId: me, followingId: targetId, status: 'pending' })
+      .onConflictDoUpdate({
+        target: [follows.followerId, follows.followingId],
+        set: { status: 'pending', updatedAt: sql`now()` },
+      });
+    await db.insert(notifications).values({ toUserId: targetId, fromUserId: me, type: 'follow_request' });
+  }
+}
+
+export async function cancelFollowRequest(targetId: number) {
+  'use server';
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me) return;
+  await db
+    .delete(follows)
+    .where(and(eq(follows.followerId, me), eq(follows.followingId, targetId), eq(follows.status, 'pending')));
+  await db
+    .delete(notifications)
+    .where(and(eq(notifications.toUserId, targetId), eq(notifications.fromUserId, me), eq(notifications.type, 'follow_request')));
+}
+
+export async function unfollow(targetId: number) {
+  'use server';
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me) return;
+  await db
+    .delete(follows)
+    .where(and(eq(follows.followerId, me), eq(follows.followingId, targetId)));
+}
+
+export async function acceptFollowRequest(requesterId: number) {
+  'use server';
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me) return;
+  const updated = await db
+    .update(follows)
+    .set({ status: 'accepted', updatedAt: new Date() })
+    .where(and(eq(follows.followerId, requesterId), eq(follows.followingId, me), eq(follows.status, 'pending')))
+    .returning();
+  if (updated.length) {
+    await db.insert(notifications).values({ toUserId: requesterId, fromUserId: me, type: 'follow_accepted' });
+  }
+}
+
+export async function declineFollowRequest(requesterId: number) {
+  'use server';
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (!me) return;
+  await db
+    .delete(follows)
+    .where(and(eq(follows.followerId, requesterId), eq(follows.followingId, me), eq(follows.status, 'pending')));
+}

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -24,14 +24,28 @@ export function verifyPassword(password: string, hash: string): boolean {
 
 export async function createUser(input: NewUser) {
   const passwordHash = hashPassword(input.password);
+  const handle = input.email.split('@')[0];
+  const displayName = input.name ?? handle;
   const [user] = await db
     .insert(users)
-    .values({ email: input.email, name: input.name, passwordHash })
+    .values({
+      email: input.email,
+      name: input.name,
+      passwordHash,
+      handle,
+      displayName,
+      accountVisibility: 'open',
+    })
     .returning();
   return user;
 }
 
 export async function getUserByEmail(email: string) {
   const [user] = await db.select().from(users).where(eq(users.email, email));
+  return user ?? null;
+}
+
+export async function getUserById(id: number) {
+  const [user] = await db.select().from(users).where(eq(users.id, id));
   return user ?? null;
 }


### PR DESCRIPTION
## Summary
- add People page with Friends, Followers, Discover lists and inbox for follow requests
- introduce follow and notification tables plus user visibility fields
- provide server actions for follow requests, acceptance, and unfollowing

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a203d76d38832ab1b87f5ed9ba3f80