### PR TITLE
fix: require handle on signup to support multiple users

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -30,3 +30,4 @@
 - 2025-08-26: Added subflavors with CRUD UI, server actions, API routes, and navigation button from flavors list.
 - 2025-08-26: Added settings button with sign-out, dark mode toggle, follower count display, and profile visibility toggle.
 - 2025-08-27: Introduced social "People" pages with follow system, inbox for requests, and profile visibility enforcement.
+- 2025-08-27: Fixed sign-up flow to require unique handle, enabling multiple user accounts; updated Playwright tests and added people listing test.

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 
 export default function SignUpPage() {
   const [name, setName] = useState('');
+  const [handle, setHandle] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
@@ -18,7 +19,7 @@ export default function SignUpPage() {
             const res = await fetch('/api/signup', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ name, email, password }),
+              body: JSON.stringify({ name, email, password, handle }),
             });
             if (res.ok) {
               await signIn('credentials', {
@@ -36,6 +37,13 @@ export default function SignUpPage() {
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Name"
+            className="border p-2"
+          />
+          <input
+            type="text"
+            value={handle}
+            onChange={(e) => setHandle(e.target.value)}
+            placeholder="Handle"
             className="border p-2"
           />
           <input

--- a/tests/flavors.spec.ts
+++ b/tests/flavors.spec.ts
@@ -9,10 +9,12 @@ function rgb(hex: string) {
 }
 
 test('flavor CRUD and ordering', async ({ page }) => {
-  const email = `user${Date.now()}@example.com`;
+  const handle = `user${Date.now()}`;
+  const email = `${handle}@example.com`;
   const password = 'pass1234';
   await page.goto('/signup');
   await page.fill('input[placeholder="Name"]', 'Tester');
+  await page.fill('input[placeholder="Handle"]', handle);
   await page.fill('input[placeholder="Email"]', email);
   await page.fill('input[placeholder="Password"]', password);
   await page.click('text=Sign Up');
@@ -40,19 +42,31 @@ test('flavor CRUD and ordering', async ({ page }) => {
   await page.click('button[id^="f7avoursav-frm"]');
 
   const rows = page.locator('ul[id^="f7avourli5t"] > li');
-  await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText('Second');
-  await expect(rows.nth(1).locator('div[id^="f7avourn4me"]')).toHaveText('First');
+  await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText(
+    'Second',
+  );
+  await expect(rows.nth(1).locator('div[id^="f7avourn4me"]')).toHaveText(
+    'First',
+  );
 
   // avatar sizes compare
-  const firstSize = await rows.first().locator('div[id^="f7avourava"]').evaluate((el) => el.clientWidth);
-  const secondSize = await rows.nth(1).locator('div[id^="f7avourava"]').evaluate((el) => el.clientWidth);
+  const firstSize = await rows
+    .first()
+    .locator('div[id^="f7avourava"]')
+    .evaluate((el) => el.clientWidth);
+  const secondSize = await rows
+    .nth(1)
+    .locator('div[id^="f7avourava"]')
+    .evaluate((el) => el.clientWidth);
   expect(firstSize).toBeGreaterThan(secondSize);
 
   // edit importance of First to reorder
   await rows.nth(1).click();
   await page.fill('input[id^="f7avour1mp-frm"]', '90');
   await page.click('button[id^="f7avoursav-frm"]');
-  await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText('First');
+  await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText(
+    'First',
+  );
 
   // edit text/color/icon
   await rows.first().click();
@@ -61,10 +75,17 @@ test('flavor CRUD and ordering', async ({ page }) => {
   await page.click('button:has-text("❤️")');
   await page.click('button[id^="f7avoursav-frm"]');
   await page.reload();
-  await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText('First Updated');
-  const color = await rows.first().locator('div[id^="f7avourava"]').evaluate((el) => getComputedStyle(el).backgroundColor);
+  await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText(
+    'First Updated',
+  );
+  const color = await rows
+    .first()
+    .locator('div[id^="f7avourava"]')
+    .evaluate((el) => getComputedStyle(el).backgroundColor);
   expect(color).toBe(rgb('#0000ff'));
-  await expect(rows.first().locator('div[id^="f7avourava"] span')).toHaveText('❤️');
+  await expect(rows.first().locator('div[id^="f7avourava"] span')).toHaveText(
+    '❤️',
+  );
 
   // keyboard interaction: focus row, open with Enter then close with Esc
   await rows.first().focus();

--- a/tests/people.spec.ts
+++ b/tests/people.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+test('people page lists other users', async ({ page, browser }) => {
+  const ts = Date.now();
+  const handle1 = `user${ts}`;
+  const email1 = `${handle1}@example.com`;
+  const password = 'pass1234';
+
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'User One');
+  await page.fill('input[placeholder="Handle"]', handle1);
+  await page.fill('input[placeholder="Email"]', email1);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.waitForURL('**/flavors');
+
+  const handle2 = `user${ts + 1}`;
+  const email2 = `${handle2}@example.com`;
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  await page2.goto('/signup');
+  await page2.fill('input[placeholder="Name"]', 'User Two');
+  await page2.fill('input[placeholder="Handle"]', handle2);
+  await page2.fill('input[placeholder="Email"]', email2);
+  await page2.fill('input[placeholder="Password"]', password);
+  await page2.click('text=Sign Up');
+  await page2.waitForURL('**/flavors');
+  await ctx2.close();
+
+  await page.goto('/people');
+  await expect(page.getByText(`@${handle2}`)).toBeVisible();
+});

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -6,10 +6,12 @@ test('landing page shows CTA', async ({ page }) => {
 });
 
 test('can sign up and reach dashboard', async ({ page }) => {
-  const email = `user${Date.now()}@example.com`;
+  const handle = `user${Date.now()}`;
+  const email = `${handle}@example.com`;
   const password = 'pass1234';
   await page.goto('/signup');
   await page.fill('input[placeholder="Name"]', 'Tester');
+  await page.fill('input[placeholder="Handle"]', handle);
   await page.fill('input[placeholder="Email"]', email);
   await page.fill('input[placeholder="Password"]', password);
   await page.click('text=Sign Up');

--- a/tests/subflavors.spec.ts
+++ b/tests/subflavors.spec.ts
@@ -1,10 +1,12 @@
 import { test, expect } from '@playwright/test';
 
 test('subflavor CRUD', async ({ page }) => {
-  const email = `user${Date.now()}@example.com`;
+  const handle = `user${Date.now()}`;
+  const email = `${handle}@example.com`;
   const password = 'pass1234';
   await page.goto('/signup');
   await page.fill('input[placeholder="Name"]', 'Tester');
+  await page.fill('input[placeholder="Handle"]', handle);
   await page.fill('input[placeholder="Email"]', email);
   await page.fill('input[placeholder="Password"]', password);
   await page.click('text=Sign Up');


### PR DESCRIPTION
## Summary
- add handle field to signup form so multiple accounts can be created
- update existing tests for handle and add people page test for multiple users

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a20b283de8832a84b7816b273aac8a