### PR TITLE
Show account visibility in settings and restrict listings to open accounts

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -31,3 +31,4 @@
 - 2025-08-26: Added settings button with sign-out, dark mode toggle, follower count display, and profile visibility toggle.
 - 2025-08-27: Introduced social "People" pages with follow system, inbox for requests, and profile visibility enforcement.
 - 2025-08-27: Fixed sign-up flow to require unique handle, enabling multiple user accounts; updated Playwright tests and added people listing test.
+- 2025-08-27: Added account visibility API and settings control; only open accounts are visible in People page.

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -39,16 +39,25 @@ export default async function PeoplePage() {
     .where(eq(follows.followingId, me));
 
   const myMap = new Map(myFollows.map((f) => [f.followingId, f.status]));
-  const inboundMap = new Map(inboundFollows.map((f) => [f.followerId, f.status]));
+  const inboundMap = new Map(
+    inboundFollows.map((f) => [f.followerId, f.status]),
+  );
 
   const friends: typeof allUsers = [];
   const followersList: typeof allUsers = [];
-  const discover: (typeof allUsers[number] & { status?: string })[] = [];
+  const discover: ((typeof allUsers)[number] & { status?: string })[] = [];
 
   for (const u of allUsers) {
     if (u.accountVisibility === 'private') continue;
     const myStatus = myMap.get(u.id);
     const theirStatus = inboundMap.get(u.id);
+    if (
+      u.accountVisibility !== 'open' &&
+      myStatus !== 'accepted' &&
+      theirStatus !== 'accepted'
+    ) {
+      continue;
+    }
     if (myStatus === 'accepted' && theirStatus === 'accepted') {
       friends.push(u);
     } else if (myStatus === 'accepted' && theirStatus !== 'accepted') {

--- a/app/api/account/visibility/route.ts
+++ b/app/api/account/visibility/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+export async function GET() {
+  const session = await auth();
+  const id = session?.user?.id ? Number(session.user.id) : null;
+  if (!id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const [user] = await db
+    .select({ accountVisibility: users.accountVisibility })
+    .from(users)
+    .where(eq(users.id, id));
+  if (!user) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json({ accountVisibility: user.accountVisibility });
+}
+
+export async function POST(req: Request) {
+  const session = await auth();
+  const id = session?.user?.id ? Number(session.user.id) : null;
+  if (!id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { accountVisibility } = await req.json();
+  if (!['open', 'closed', 'private'].includes(accountVisibility)) {
+    return NextResponse.json({ error: 'Invalid' }, { status: 400 });
+  }
+  await db.update(users).set({ accountVisibility }).where(eq(users.id, id));
+  return NextResponse.json({ accountVisibility });
+}


### PR DESCRIPTION
## Summary
- add account visibility API endpoint
- show and update account type in settings popover
- hide users who are not open from discover people list

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*
- `pnpm build` *(fails: Type error: Type '{ params: { flavorId: string; }; }' does not satisfy the constraint 'PageProps'.)*

------
https://chatgpt.com/codex/tasks/task_e_68a20de201e8832abc84c76d5c6a04d4