### PR TITLE
fix: validate current user before follow

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -32,3 +32,4 @@
 - 2025-08-27: Introduced social "People" pages with follow system, inbox for requests, and profile visibility enforcement.
 - 2025-08-27: Fixed sign-up flow to require unique handle, enabling multiple user accounts; updated Playwright tests and added people listing test.
 - 2025-08-27: Added account visibility API and settings control; only open accounts are visible in People page.
+- 2025-08-28: Resolved follow action foreign key errors by validating current user via email lookup before inserting follow rows.


### PR DESCRIPTION
## Summary
- ensure follow actions resolve current user via database lookup
- document follow fix in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a22da8c54c832a9ac1cc5280a32eab