### PR TITLE
fix: validate follower existence before follow insert

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -32,3 +32,4 @@
 - 2025-08-27: Introduced social "People" pages with follow system, inbox for requests, and profile visibility enforcement.
 - 2025-08-27: Fixed sign-up flow to require unique handle, enabling multiple user accounts; updated Playwright tests and added people listing test.
 - 2025-08-27: Added account visibility API and settings control; only open accounts are visible in People page.
+ - 2025-08-27: Validated follower existence in follow action to prevent foreign key errors.

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -15,6 +15,13 @@ export async function followRequest(
   if (!me) throw new Error('Please sign in.');
   if (me === targetId) throw new Error('Cannot follow yourself.');
 
+  // Ensure the current user exists to avoid foreign key issues
+  const [self] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.id, me));
+  if (!self) throw new Error('User not found');
+
   const [target] = await db
     .select({ accountVisibility: users.accountVisibility })
     .from(users)


### PR DESCRIPTION
## Summary
- check that the current user exists before inserting follow record to avoid foreign key errors
- note change in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a22da8c54c832a9ac1cc5280a32eab