### PR TITLE
fix: create missing user records on follow

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -32,3 +32,5 @@
 - 2025-08-27: Introduced social "People" pages with follow system, inbox for requests, and profile visibility enforcement.
 - 2025-08-27: Fixed sign-up flow to require unique handle, enabling multiple user accounts; updated Playwright tests and added people listing test.
 - 2025-08-27: Added account visibility API and settings control; only open accounts are visible in People page.
+ - 2025-08-27: Validated follower existence in follow action to prevent foreign key errors.
+ - 2025-08-27: Auto-created missing user records during follow to avoid "User not found" errors.


### PR DESCRIPTION
## Summary
- auto-create a user record from session info if the current user is missing when sending a follow request
- note change in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a22da8c54c832a9ac1cc5280a32eab