### PR TITLE
fix: reconcile session user on follow

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -32,3 +32,6 @@
 - 2025-08-27: Introduced social "People" pages with follow system, inbox for requests, and profile visibility enforcement.
 - 2025-08-27: Fixed sign-up flow to require unique handle, enabling multiple user accounts; updated Playwright tests and added people listing test.
 - 2025-08-27: Added account visibility API and settings control; only open accounts are visible in People page.
+ - 2025-08-27: Validated follower existence in follow action to prevent foreign key errors.
+ - 2025-08-27: Auto-created missing user records during follow to avoid "User not found" errors.
+ - 2025-08-27: Reconciled session users with DB via email, preventing duplicate records and hiding self on People page.

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -3,6 +3,7 @@
 import { auth } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { follows, notifications, users } from '@/lib/db/schema';
+import { ensureUser } from '@/lib/users';
 import { and, eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 
@@ -11,8 +12,8 @@ export async function followRequest(
   _formData?: FormData,
 ): Promise<void> {
   const session = await auth();
-  const me = Number(session?.user?.id);
-  if (!me) throw new Error('Please sign in.');
+  const self = await ensureUser(session);
+  const me = self.id;
   if (me === targetId) throw new Error('Cannot follow yourself.');
 
   const [target] = await db
@@ -50,8 +51,8 @@ export async function cancelFollowRequest(
   _formData?: FormData,
 ): Promise<void> {
   const session = await auth();
-  const me = Number(session?.user?.id);
-  if (!me) throw new Error('Please sign in.');
+  const self = await ensureUser(session);
+  const me = self.id;
   await db
     .delete(follows)
     .where(
@@ -69,8 +70,8 @@ export async function acceptFollowRequest(
   _formData?: FormData,
 ): Promise<void> {
   const session = await auth();
-  const me = Number(session?.user?.id);
-  if (!me) throw new Error('Please sign in.');
+  const self = await ensureUser(session);
+  const me = self.id;
   const [req] = await db
     .select()
     .from(follows)
@@ -95,8 +96,8 @@ export async function unfollow(
   _formData?: FormData,
 ): Promise<void> {
   const session = await auth();
-  const me = Number(session?.user?.id);
-  if (!me) throw new Error('Please sign in.');
+  const self = await ensureUser(session);
+  const me = self.id;
   await db
     .delete(follows)
     .where(and(eq(follows.followerId, me), eq(follows.followingId, targetId)));
@@ -108,8 +109,8 @@ export async function declineFollowRequest(
   _formData?: FormData,
 ): Promise<void> {
   const session = await auth();
-  const me = Number(session?.user?.id);
-  if (!me) throw new Error('Please sign in.');
+  const self = await ensureUser(session);
+  const me = self.id;
   await db
     .delete(follows)
     .where(

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -2,14 +2,14 @@ import { db } from '@/lib/db';
 import { follows, users } from '@/lib/db/schema';
 import { auth } from '@/lib/auth';
 import { followRequest, unfollow, cancelFollowRequest } from './actions';
+import { ensureUser } from '@/lib/users';
 import Link from 'next/link';
 import { eq, ne } from 'drizzle-orm';
 import { Button } from '@/components/ui/button';
 
 export default async function PeoplePage() {
   const session = await auth();
-  const me = Number(session?.user?.id);
-  if (!me) {
+  if (!session?.user?.email) {
     return (
       <section>
         <h1 className="text-2xl font-bold">People</h1>
@@ -17,6 +17,8 @@ export default async function PeoplePage() {
       </section>
     );
   }
+  const self = await ensureUser(session);
+  const me = self.id;
 
   const allUsers = await db
     .select({


### PR DESCRIPTION
## Summary
- derive or create a user record from session email to keep database IDs in sync
- use the ensured user in social actions and People page to avoid duplicates and hide the current user
- note change in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a22da8c54c832a9ac1cc5280a32eab