### PR TITLE
Fix dark mode toggle and follow notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,10 @@ out
 .env.local
 .DS_Store
 playwright-report
+*.tsbuildinfo
+test-results
+.nyc_output
+.coverage
+.pnpm-store
+.turbo
 .babelrc

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -34,4 +34,5 @@
 - 2025-08-27: Added account visibility API and settings control; only open accounts are visible in People page.
  - 2025-08-27: Validated follower existence in follow action to prevent foreign key errors.
  - 2025-08-27: Auto-created missing user records during follow to avoid "User not found" errors.
- - 2025-08-27: Reconciled session users with DB via email, preventing duplicate records and hiding self on People page.
+- 2025-08-27: Reconciled session users with DB via email, preventing duplicate records and hiding self on People page.
+- 2025-08-28: Enabled class-based dark mode toggle, added account visibility API route, and sent inbox notifications for auto-accepted follows.

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -41,6 +41,12 @@ export async function followRequest(
       fromUserId: me,
       type: 'follow_request',
     });
+  } else {
+    await db.insert(notifications).values({
+      toUserId: me,
+      fromUserId: targetId,
+      type: 'follow_accepted',
+    });
   }
 
   revalidatePath('/people');

--- a/app/api/account/visibility/route.ts
+++ b/app/api/account/visibility/route.ts
@@ -3,33 +3,35 @@ import { auth } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
+import { ensureUser } from '@/lib/users';
 
 export async function GET() {
   const session = await auth();
-  const id = session?.user?.id ? Number(session.user.id) : null;
-  if (!id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
+  const self = await ensureUser(session);
+  const userId = self.id;
   const [user] = await db
     .select({ accountVisibility: users.accountVisibility })
     .from(users)
-    .where(eq(users.id, id));
-  if (!user) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 });
-  }
-  return NextResponse.json({ accountVisibility: user.accountVisibility });
+    .where(eq(users.id, userId));
+  return NextResponse.json({
+    accountVisibility: user?.accountVisibility ?? 'open',
+  });
 }
 
 export async function POST(req: Request) {
   const session = await auth();
-  const id = session?.user?.id ? Number(session.user.id) : null;
-  if (!id) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const self = await ensureUser(session);
+  const userId = self.id;
+  const body = await req.json();
+  const visibility = ['open', 'closed', 'private'].includes(body.accountVisibility)
+    ? (body.accountVisibility as 'open' | 'closed' | 'private')
+    : null;
+  if (!visibility) {
+    return NextResponse.json({ error: 'Invalid visibility' }, { status: 400 });
   }
-  const { accountVisibility } = await req.json();
-  if (!['open', 'closed', 'private'].includes(accountVisibility)) {
-    return NextResponse.json({ error: 'Invalid' }, { status: 400 });
-  }
-  await db.update(users).set({ accountVisibility }).where(eq(users.id, id));
-  return NextResponse.json({ accountVisibility });
+  await db
+    .update(users)
+    .set({ accountVisibility: visibility, updatedAt: new Date() })
+    .where(eq(users.id, userId));
+  return NextResponse.json({ accountVisibility: visibility });
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,6 +2,7 @@ import type { Config } from 'tailwindcss';
 import { fontFamily } from 'tailwindcss/defaultTheme';
 
 const config: Config = {
+  darkMode: 'class',
   content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
   theme: {
     extend: {

--- a/tests/people.spec.ts
+++ b/tests/people.spec.ts
@@ -30,3 +30,41 @@ test('people page lists other users', async ({ page, browser }) => {
   await page.goto('/people');
   await expect(page.getByText(`@${handle2}`)).toBeVisible();
 });
+
+test('following an open account shows inbox notification', async ({ page, browser }) => {
+  const ts = Date.now();
+  const handle1 = `user${ts}`;
+  const email1 = `${handle1}@example.com`;
+  const password = 'pass1234';
+
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'User One');
+  await page.fill('input[placeholder="Handle"]', handle1);
+  await page.fill('input[placeholder="Email"]', email1);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.waitForURL('**/flavors');
+
+  const handle2 = `user${ts + 1}`;
+  const email2 = `${handle2}@example.com`;
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  await page2.goto('/signup');
+  await page2.fill('input[placeholder="Name"]', 'User Two');
+  await page2.fill('input[placeholder="Handle"]', handle2);
+  await page2.fill('input[placeholder="Email"]', email2);
+  await page2.fill('input[placeholder="Password"]', password);
+  await page2.click('text=Sign Up');
+  await page2.waitForURL('**/flavors');
+  await ctx2.close();
+
+  await page.goto('/people');
+  const row = page.locator(`li:has-text("@${handle2}")`);
+  await row.getByRole('button', { name: 'Follow' }).click();
+  await expect(row.getByRole('button', { name: 'Unfollow' })).toBeVisible();
+
+  await page.goto('/people/inbox');
+  await expect(
+    page.getByText(`@${handle2} accepted your follow request`),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- enable Tailwind class-based dark mode for settings toggle
- add account visibility API to persist user account type
- send inbox notification when following open accounts and test it

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*
- `pnpm build` *(fails: Type error in app/(app)/flavors/[flavorId]/subflavors/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a23c956694832a9d2e4faa13cd7443