### PR TITLE
feat: add account settings and dark mode toggle

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -36,3 +36,4 @@
  - 2025-08-27: Auto-created missing user records during follow to avoid "User not found" errors.
 - 2025-08-27: Reconciled session users with DB via email, preventing duplicate records and hiding self on People page.
 - 2025-08-28: Enabled class-based dark mode toggle, added account visibility API route, and sent inbox notifications for auto-accepted follows.
+ - 2025-08-29: Fixed dark mode toggle, added real-time follower count API with polling, and created account settings page.

--- a/app/(app)/settings/account/page.tsx
+++ b/app/(app)/settings/account/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+export default function AccountSettingsPage() {
+  const [visibility, setVisibility] = useState<'open' | 'closed' | 'private'>('open');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/account/visibility')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.accountVisibility) {
+          setVisibility(data.accountVisibility);
+        }
+      });
+  }, []);
+
+  async function save() {
+    setSaving(true);
+    await fetch('/api/account/visibility', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accountVisibility: visibility }),
+    });
+    setSaving(false);
+  }
+
+  return (
+    <div className="max-w-md space-y-4">
+      <h1 className="text-xl font-semibold">Account Settings</h1>
+      <label className="flex items-center gap-2">
+        <span>Visibility</span>
+        <select
+          className="rounded border px-1 py-0.5"
+          value={visibility}
+          onChange={(e) =>
+            setVisibility(e.target.value as 'open' | 'closed' | 'private')
+          }
+        >
+          <option value="open">open</option>
+          <option value="closed">closed</option>
+          <option value="private">private</option>
+        </select>
+      </label>
+      <Button onClick={save} disabled={saving}>
+        {saving ? 'Saving...' : 'Save'}
+      </Button>
+    </div>
+  );
+}

--- a/app/api/account/followers/route.ts
+++ b/app/api/account/followers/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { follows } from '@/lib/db/schema';
+import { ensureUser } from '@/lib/users';
+import { and, eq, sql } from 'drizzle-orm';
+
+export async function GET() {
+  const session = await auth();
+  const self = await ensureUser(session);
+  const userId = self.id;
+  const [row] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(follows)
+    .where(and(eq(follows.followingId, userId), eq(follows.status, 'accepted')));
+  return NextResponse.json({ followers: row?.count ?? 0 });
+}


### PR DESCRIPTION
## Summary
- fix settings dark mode toggle and add follower polling
- expose follower count API
- add account settings page with visibility save

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a24095c054832a9ba1d9e20cc039bd