### PR TITLE
fix: keep followed users discoverable

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -37,3 +37,4 @@
 - 2025-08-27: Reconciled session users with DB via email, preventing duplicate records and hiding self on People page.
 - 2025-08-28: Enabled class-based dark mode toggle, added account visibility API route, and sent inbox notifications for auto-accepted follows.
 - 2025-08-30: Added followers API, updated settings menu with live follower count, dark mode toggle fix, and link to new account settings page for visibility changes.
+- 2025-08-30: Fixed follow logic so followed users remain discoverable, renamed Followers section to Following, and added test coverage.

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -46,7 +46,7 @@ export default async function PeoplePage() {
   );
 
   const friends: typeof allUsers = [];
-  const followersList: typeof allUsers = [];
+  const following: typeof allUsers = [];
   const discover: ((typeof allUsers)[number] & { status?: string })[] = [];
 
   for (const u of allUsers) {
@@ -63,10 +63,10 @@ export default async function PeoplePage() {
     if (myStatus === 'accepted' && theirStatus === 'accepted') {
       friends.push(u);
     } else if (myStatus === 'accepted' && theirStatus !== 'accepted') {
-      followersList.push(u);
+      following.push(u);
     } else if (myStatus === 'pending') {
       discover.push({ ...u, status: 'pending' });
-    } else if (!myStatus && !theirStatus) {
+    } else if (!myStatus) {
       discover.push(u);
     }
   }
@@ -84,8 +84,8 @@ export default async function PeoplePage() {
         <UserList users={friends} relation="friend" />
       </div>
       <div>
-        <h2 className="text-xl font-semibold mb-2">Followers</h2>
-        <UserList users={followersList} relation="following" />
+        <h2 className="text-xl font-semibold mb-2">Following</h2>
+        <UserList users={following} relation="following" />
       </div>
       <div>
         <h2 className="text-xl font-semibold mb-2">Discover</h2>

--- a/tests/people.spec.ts
+++ b/tests/people.spec.ts
@@ -68,3 +68,44 @@ test('following an open account shows inbox notification', async ({ page, browse
     page.getByText(`@${handle2} accepted your follow request`),
   ).toBeVisible();
 });
+
+test('followed user remains visible to allow follow-back', async ({ page, browser }) => {
+  const ts = Date.now();
+  const handle1 = `user${ts}`;
+  const email1 = `${handle1}@example.com`;
+  const password = 'pass1234';
+
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'User One');
+  await page.fill('input[placeholder="Handle"]', handle1);
+  await page.fill('input[placeholder="Email"]', email1);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.waitForURL('**/flavors');
+
+  const handle2 = `user${ts + 1}`;
+  const email2 = `${handle2}@example.com`;
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  await page2.goto('/signup');
+  await page2.fill('input[placeholder="Name"]', 'User Two');
+  await page2.fill('input[placeholder="Handle"]', handle2);
+  await page2.fill('input[placeholder="Email"]', email2);
+  await page2.fill('input[placeholder="Password"]', password);
+  await page2.click('text=Sign Up');
+  await page2.waitForURL('**/flavors');
+
+  await page.goto('/people');
+  const row = page.locator(`li:has-text("@${handle2}")`);
+  await row.getByRole('button', { name: 'Follow' }).click();
+  await expect(row.getByRole('button', { name: 'Unfollow' })).toBeVisible();
+
+  await page2.goto('/people');
+  await expect(page2.getByText(`@${handle1}`)).toBeVisible();
+  await expect(
+    page2.locator(`li:has-text("@${handle1}")`).getByRole('button', {
+      name: 'Follow',
+    }),
+  ).toBeVisible();
+  await ctx2.close();
+});


### PR DESCRIPTION
## Summary
- rename People page section to "Following" and keep followed users in discover list for others to follow back
- add Playwright test ensuring newly followed user remains visible
- document follow logic fix in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a24401d690832a840eb3827509388f