### PR TITLE
fix: keep followed users discoverable and notify targets

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -32,8 +32,9 @@
 - 2025-08-27: Introduced social "People" pages with follow system, inbox for requests, and profile visibility enforcement.
 - 2025-08-27: Fixed sign-up flow to require unique handle, enabling multiple user accounts; updated Playwright tests and added people listing test.
 - 2025-08-27: Added account visibility API and settings control; only open accounts are visible in People page.
- - 2025-08-27: Validated follower existence in follow action to prevent foreign key errors.
- - 2025-08-27: Auto-created missing user records during follow to avoid "User not found" errors.
+- 2025-08-27: Validated follower existence in follow action to prevent foreign key errors.
+- 2025-08-27: Auto-created missing user records during follow to avoid "User not found" errors.
 - 2025-08-27: Reconciled session users with DB via email, preventing duplicate records and hiding self on People page.
 - 2025-08-28: Enabled class-based dark mode toggle, added account visibility API route, and sent inbox notifications for auto-accepted follows.
 - 2025-08-30: Added followers API, updated settings menu with live follower count, dark mode toggle fix, and link to new account settings page for visibility changes.
+- 2025-08-30: Fixed follow visibility and notifications; renamed People page section to "Following" so followed users remain discoverable.

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -42,11 +42,18 @@ export async function followRequest(
       type: 'follow_request',
     });
   } else {
-    await db.insert(notifications).values({
-      toUserId: me,
-      fromUserId: targetId,
-      type: 'follow_accepted',
-    });
+    await db.insert(notifications).values([
+      {
+        toUserId: targetId,
+        fromUserId: me,
+        type: 'follow_request',
+      },
+      {
+        toUserId: me,
+        fromUserId: targetId,
+        type: 'follow_accepted',
+      },
+    ]);
   }
 
   revalidatePath('/people');

--- a/app/(app)/people/inbox/page.tsx
+++ b/app/(app)/people/inbox/page.tsx
@@ -32,12 +32,11 @@ export default async function InboxPage() {
       id: notifications.id,
       handle: users.handle,
       displayName: users.displayName,
+      type: notifications.type,
     })
     .from(notifications)
     .innerJoin(users, eq(users.id, notifications.fromUserId))
-    .where(
-      and(eq(notifications.toUserId, me), eq(notifications.type, 'follow_accepted')),
-    );
+    .where(eq(notifications.toUserId, me));
 
   return (
     <section className="space-y-8">
@@ -51,8 +50,12 @@ export default async function InboxPage() {
             {requests.map((r) => (
               <li key={r.id} className="flex items-center justify-between py-2">
                 <div>
-                  <div className="font-semibold">{r.displayName ?? r.handle}</div>
-                  <div className="text-sm text-muted-foreground">@{r.handle}</div>
+                  <div className="font-semibold">
+                    {r.displayName ?? r.handle}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    @{r.handle}
+                  </div>
                 </div>
                 <div className="flex gap-2">
                   <form action={acceptFollowRequest.bind(null, r.id)}>
@@ -78,8 +81,10 @@ export default async function InboxPage() {
             {activity.map((a) => (
               <li key={a.id} className="py-2">
                 <div className="text-sm">
-                  <span className="font-semibold">@{a.handle}</span> accepted your follow
-                  request
+                  <span className="font-semibold">@{a.handle}</span>{' '}
+                  {a.type === 'follow_accepted'
+                    ? 'accepted your follow request'
+                    : 'started following you'}
                 </div>
               </li>
             ))}

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -46,7 +46,7 @@ export default async function PeoplePage() {
   );
 
   const friends: typeof allUsers = [];
-  const followersList: typeof allUsers = [];
+  const following: ((typeof allUsers)[number] & { status?: string })[] = [];
   const discover: ((typeof allUsers)[number] & { status?: string })[] = [];
 
   for (const u of allUsers) {
@@ -62,12 +62,10 @@ export default async function PeoplePage() {
     }
     if (myStatus === 'accepted' && theirStatus === 'accepted') {
       friends.push(u);
-    } else if (myStatus === 'accepted' && theirStatus !== 'accepted') {
-      followersList.push(u);
-    } else if (myStatus === 'pending') {
-      discover.push({ ...u, status: 'pending' });
-    } else if (!myStatus && !theirStatus) {
-      discover.push(u);
+    } else if (myStatus === 'accepted' || myStatus === 'pending') {
+      following.push({ ...u, status: myStatus });
+    } else {
+      discover.push({ ...u, status: theirStatus });
     }
   }
 
@@ -84,8 +82,8 @@ export default async function PeoplePage() {
         <UserList users={friends} relation="friend" />
       </div>
       <div>
-        <h2 className="text-xl font-semibold mb-2">Followers</h2>
-        <UserList users={followersList} relation="following" />
+        <h2 className="text-xl font-semibold mb-2">Following</h2>
+        <UserList users={following} relation="following" />
       </div>
       <div>
         <h2 className="text-xl font-semibold mb-2">Discover</h2>
@@ -139,14 +137,6 @@ function UserAction({
   switch (relation) {
     case 'friend':
     case 'following':
-      return (
-        <form action={unfollow.bind(null, user.id)}>
-          <Button variant="outline" size="sm">
-            Unfollow
-          </Button>
-        </form>
-      );
-    case 'discover':
       if (user.status === 'pending') {
         return (
           <form action={cancelFollowRequest.bind(null, user.id)}>
@@ -156,6 +146,14 @@ function UserAction({
           </form>
         );
       }
+      return (
+        <form action={unfollow.bind(null, user.id)}>
+          <Button variant="outline" size="sm">
+            Unfollow
+          </Button>
+        </form>
+      );
+    case 'discover':
       return (
         <form action={followRequest.bind(null, user.id)}>
           <Button size="sm">


### PR DESCRIPTION
## Summary
- notify targets when someone follows them
- keep inbound followers visible for follow-back and move follow requests into Following
- show follow events in inbox activity

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68a24401d690832a840eb3827509388f