### PR TITLE
fix: persist follow visibility and notify on unfollow

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -32,8 +32,10 @@
 - 2025-08-27: Introduced social "People" pages with follow system, inbox for requests, and profile visibility enforcement.
 - 2025-08-27: Fixed sign-up flow to require unique handle, enabling multiple user accounts; updated Playwright tests and added people listing test.
 - 2025-08-27: Added account visibility API and settings control; only open accounts are visible in People page.
- - 2025-08-27: Validated follower existence in follow action to prevent foreign key errors.
- - 2025-08-27: Auto-created missing user records during follow to avoid "User not found" errors.
+- 2025-08-27: Validated follower existence in follow action to prevent foreign key errors.
+- 2025-08-27: Auto-created missing user records during follow to avoid "User not found" errors.
 - 2025-08-27: Reconciled session users with DB via email, preventing duplicate records and hiding self on People page.
 - 2025-08-28: Enabled class-based dark mode toggle, added account visibility API route, and sent inbox notifications for auto-accepted follows.
 - 2025-08-30: Added followers API, updated settings menu with live follower count, dark mode toggle fix, and link to new account settings page for visibility changes.
+- 2025-08-30: Fixed follow visibility and notifications; renamed People page section to "Following" so followed users remain discoverable.
+- 2025-08-30: Kept closed-account follows visible, added unfollow notifications, and surfaced them in the inbox.

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -42,11 +42,18 @@ export async function followRequest(
       type: 'follow_request',
     });
   } else {
-    await db.insert(notifications).values({
-      toUserId: me,
-      fromUserId: targetId,
-      type: 'follow_accepted',
-    });
+    await db.insert(notifications).values([
+      {
+        toUserId: targetId,
+        fromUserId: me,
+        type: 'follow_request',
+      },
+      {
+        toUserId: me,
+        fromUserId: targetId,
+        type: 'follow_accepted',
+      },
+    ]);
   }
 
   revalidatePath('/people');
@@ -107,6 +114,12 @@ export async function unfollow(
   await db
     .delete(follows)
     .where(and(eq(follows.followerId, me), eq(follows.followingId, targetId)));
+
+  await db.insert(notifications).values({
+    toUserId: targetId,
+    fromUserId: me,
+    type: 'unfollow',
+  });
   revalidatePath('/people');
 }
 

--- a/app/(app)/people/inbox/page.tsx
+++ b/app/(app)/people/inbox/page.tsx
@@ -32,12 +32,11 @@ export default async function InboxPage() {
       id: notifications.id,
       handle: users.handle,
       displayName: users.displayName,
+      type: notifications.type,
     })
     .from(notifications)
     .innerJoin(users, eq(users.id, notifications.fromUserId))
-    .where(
-      and(eq(notifications.toUserId, me), eq(notifications.type, 'follow_accepted')),
-    );
+    .where(eq(notifications.toUserId, me));
 
   return (
     <section className="space-y-8">
@@ -51,8 +50,12 @@ export default async function InboxPage() {
             {requests.map((r) => (
               <li key={r.id} className="flex items-center justify-between py-2">
                 <div>
-                  <div className="font-semibold">{r.displayName ?? r.handle}</div>
-                  <div className="text-sm text-muted-foreground">@{r.handle}</div>
+                  <div className="font-semibold">
+                    {r.displayName ?? r.handle}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    @{r.handle}
+                  </div>
                 </div>
                 <div className="flex gap-2">
                   <form action={acceptFollowRequest.bind(null, r.id)}>
@@ -78,8 +81,12 @@ export default async function InboxPage() {
             {activity.map((a) => (
               <li key={a.id} className="py-2">
                 <div className="text-sm">
-                  <span className="font-semibold">@{a.handle}</span> accepted your follow
-                  request
+                  <span className="font-semibold">@{a.handle}</span>{' '}
+                  {a.type === 'follow_accepted'
+                    ? 'accepted your follow request'
+                    : a.type === 'unfollow'
+                    ? 'unfollowed you'
+                    : 'started following you'}
                 </div>
               </li>
             ))}

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -46,28 +46,23 @@ export default async function PeoplePage() {
   );
 
   const friends: typeof allUsers = [];
-  const followersList: typeof allUsers = [];
+  const following: ((typeof allUsers)[number] & { status?: string })[] = [];
   const discover: ((typeof allUsers)[number] & { status?: string })[] = [];
 
   for (const u of allUsers) {
     if (u.accountVisibility === 'private') continue;
     const myStatus = myMap.get(u.id);
     const theirStatus = inboundMap.get(u.id);
-    if (
-      u.accountVisibility !== 'open' &&
-      myStatus !== 'accepted' &&
-      theirStatus !== 'accepted'
-    ) {
+    if (u.accountVisibility !== 'open' && !myStatus && !theirStatus) {
+      // skip closed accounts with no relationship
       continue;
     }
     if (myStatus === 'accepted' && theirStatus === 'accepted') {
       friends.push(u);
-    } else if (myStatus === 'accepted' && theirStatus !== 'accepted') {
-      followersList.push(u);
-    } else if (myStatus === 'pending') {
-      discover.push({ ...u, status: 'pending' });
-    } else if (!myStatus && !theirStatus) {
-      discover.push(u);
+    } else if (myStatus === 'accepted' || myStatus === 'pending') {
+      following.push({ ...u, status: myStatus });
+    } else {
+      discover.push({ ...u, status: theirStatus });
     }
   }
 
@@ -84,8 +79,8 @@ export default async function PeoplePage() {
         <UserList users={friends} relation="friend" />
       </div>
       <div>
-        <h2 className="text-xl font-semibold mb-2">Followers</h2>
-        <UserList users={followersList} relation="following" />
+        <h2 className="text-xl font-semibold mb-2">Following</h2>
+        <UserList users={following} relation="following" />
       </div>
       <div>
         <h2 className="text-xl font-semibold mb-2">Discover</h2>
@@ -139,14 +134,6 @@ function UserAction({
   switch (relation) {
     case 'friend':
     case 'following':
-      return (
-        <form action={unfollow.bind(null, user.id)}>
-          <Button variant="outline" size="sm">
-            Unfollow
-          </Button>
-        </form>
-      );
-    case 'discover':
       if (user.status === 'pending') {
         return (
           <form action={cancelFollowRequest.bind(null, user.id)}>
@@ -156,6 +143,14 @@ function UserAction({
           </form>
         );
       }
+      return (
+        <form action={unfollow.bind(null, user.id)}>
+          <Button variant="outline" size="sm">
+            Unfollow
+          </Button>
+        </form>
+      );
+    case 'discover':
       return (
         <form action={followRequest.bind(null, user.id)}>
           <Button size="sm">

--- a/drizzle/0004_add_unfollow_notification.sql
+++ b/drizzle/0004_add_unfollow_notification.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "notification_type" ADD VALUE 'unfollow';

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -20,6 +20,7 @@ export const followStatusEnum = pgEnum('follow_status', ['pending', 'accepted'])
 export const notificationTypeEnum = pgEnum('notification_type', [
   'follow_request',
   'follow_accepted',
+  'unfollow',
 ]);
 
 export const users = pgTable('users', {

--- a/tests/people.spec.ts
+++ b/tests/people.spec.ts
@@ -68,3 +68,80 @@ test('following an open account shows inbox notification', async ({ page, browse
     page.getByText(`@${handle2} accepted your follow request`),
   ).toBeVisible();
 });
+
+test('following a closed account stays visible', async ({ page, browser }) => {
+  const ts = Date.now();
+  const handle1 = `user${ts}`;
+  const email1 = `${handle1}@example.com`;
+  const password = 'pass1234';
+
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'User One');
+  await page.fill('input[placeholder="Handle"]', handle1);
+  await page.fill('input[placeholder="Email"]', email1);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.waitForURL('**/flavors');
+
+  const handle2 = `user${ts + 1}`;
+  const email2 = `${handle2}@example.com`;
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  await page2.goto('/signup');
+  await page2.fill('input[placeholder="Name"]', 'User Two');
+  await page2.fill('input[placeholder="Handle"]', handle2);
+  await page2.fill('input[placeholder="Email"]', email2);
+  await page2.fill('input[placeholder="Password"]', password);
+  await page2.click('text=Sign Up');
+  await page2.waitForURL('**/flavors');
+  await page2.goto('/settings/account');
+  await page2.selectOption('select', 'closed');
+  await page2.click('text=Save');
+  await ctx2.close();
+
+  await page.goto('/people');
+  const row = page.locator(`li:has-text("@${handle2}")`);
+  await row.getByRole('button', { name: 'Request to follow' }).click();
+  await expect(
+    row.getByRole('button', { name: 'Cancel request' }),
+  ).toBeVisible();
+});
+
+test('unfollowing sends notification', async ({ page, browser }) => {
+  const ts = Date.now();
+  const handle1 = `user${ts}`;
+  const email1 = `${handle1}@example.com`;
+  const password = 'pass1234';
+
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'User One');
+  await page.fill('input[placeholder="Handle"]', handle1);
+  await page.fill('input[placeholder="Email"]', email1);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.waitForURL('**/flavors');
+
+  const handle2 = `user${ts + 1}`;
+  const email2 = `${handle2}@example.com`;
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  await page2.goto('/signup');
+  await page2.fill('input[placeholder="Name"]', 'User Two');
+  await page2.fill('input[placeholder="Handle"]', handle2);
+  await page2.fill('input[placeholder="Email"]', email2);
+  await page2.fill('input[placeholder="Password"]', password);
+  await page2.click('text=Sign Up');
+  await page2.waitForURL('**/flavors');
+
+  await page.goto('/people');
+  const row = page.locator(`li:has-text("@${handle2}")`);
+  await row.getByRole('button', { name: 'Follow' }).click();
+  await row.getByRole('button', { name: 'Unfollow' }).click();
+
+  await page2.goto('/people/inbox');
+  await expect(
+    page2.getByText(`@${handle1} unfollowed you`),
+  ).toBeVisible();
+
+  await ctx2.close();
+});


### PR DESCRIPTION
## Summary
- keep follows to closed accounts visible under Following
- send and display inbox notifications when someone unfollows you
- cover pending follow requests and unfollow notifications with tests

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68a24401d690832a840eb3827509388f