### PR TITLE
feat: add follow back and decline notifications

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -39,3 +39,4 @@
 - 2025-08-30: Added followers API, updated settings menu with live follower count, dark mode toggle fix, and link to new account settings page for visibility changes.
 - 2025-08-30: Fixed follow visibility and notifications; renamed People page section to "Following" so followed users remain discoverable.
 - 2025-08-30: Kept closed-account follows visible, added unfollow notifications, and surfaced them in the inbox.
+- 2025-08-30: Enabled follow-back after accepting requests, added decline notifications, and ensured closed accounts appear in Discover.

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -139,5 +139,10 @@ export async function declineFollowRequest(
         eq(follows.status, 'pending'),
       ),
     );
+  await db.insert(notifications).values({
+    toUserId: requesterId,
+    fromUserId: me,
+    type: 'follow_declined',
+  });
   revalidatePath('/people');
 }

--- a/app/(app)/people/inbox/page.tsx
+++ b/app/(app)/people/inbox/page.tsx
@@ -49,13 +49,11 @@ export default async function InboxPage() {
           <ul className="divide-y">
             {requests.map((r) => (
               <li key={r.id} className="flex items-center justify-between py-2">
-                <div>
-                  <div className="font-semibold">
+                <div className="text-sm">
+                  <span className="font-semibold">
                     {r.displayName ?? r.handle}
-                  </div>
-                  <div className="text-sm text-muted-foreground">
-                    @{r.handle}
-                  </div>
+                  </span>{' '}
+                  (@{r.handle}) wants to follow you
                 </div>
                 <div className="flex gap-2">
                   <form action={acceptFollowRequest.bind(null, r.id)}>
@@ -85,8 +83,10 @@ export default async function InboxPage() {
                   {a.type === 'follow_accepted'
                     ? 'accepted your follow request'
                     : a.type === 'unfollow'
-                    ? 'unfollowed you'
-                    : 'started following you'}
+                      ? 'unfollowed you'
+                      : a.type === 'follow_declined'
+                        ? 'declined your follow request'
+                        : 'started following you'}
                 </div>
               </li>
             ))}

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -53,10 +53,6 @@ export default async function PeoplePage() {
     if (u.accountVisibility === 'private') continue;
     const myStatus = myMap.get(u.id);
     const theirStatus = inboundMap.get(u.id);
-    if (u.accountVisibility !== 'open' && !myStatus && !theirStatus) {
-      // skip closed accounts with no relationship
-      continue;
-    }
     if (myStatus === 'accepted' && theirStatus === 'accepted') {
       friends.push(u);
     } else if (myStatus === 'accepted' || myStatus === 'pending') {
@@ -151,6 +147,13 @@ function UserAction({
         </form>
       );
     case 'discover':
+      if (user.status === 'accepted') {
+        return (
+          <form action={followRequest.bind(null, user.id)}>
+            <Button size="sm">Follow back</Button>
+          </form>
+        );
+      }
       return (
         <form action={followRequest.bind(null, user.id)}>
           <Button size="sm">

--- a/drizzle/0005_add_follow_declined_notification.sql
+++ b/drizzle/0005_add_follow_declined_notification.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "notification_type" ADD VALUE 'follow_declined';

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -15,11 +15,15 @@ export const accountVisibilityEnum = pgEnum('account_visibility', [
   'private',
 ]);
 
-export const followStatusEnum = pgEnum('follow_status', ['pending', 'accepted']);
+export const followStatusEnum = pgEnum('follow_status', [
+  'pending',
+  'accepted',
+]);
 
 export const notificationTypeEnum = pgEnum('notification_type', [
   'follow_request',
   'follow_accepted',
+  'follow_declined',
   'unfollow',
 ]);
 
@@ -75,24 +79,31 @@ export const follows = pgTable(
   'follows',
   {
     id: serial('id').primaryKey(),
-    followerId: integer('follower_id').references(() => users.id).notNull(),
-    followingId: integer('following_id').references(() => users.id).notNull(),
+    followerId: integer('follower_id')
+      .references(() => users.id)
+      .notNull(),
+    followingId: integer('following_id')
+      .references(() => users.id)
+      .notNull(),
     status: followStatusEnum('status').notNull().default('pending'),
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').defaultNow(),
   },
   (table) => ({
-    uniqueFollowerFollowing: uniqueIndex('follows_follower_following_unique').on(
-      table.followerId,
-      table.followingId,
-    ),
+    uniqueFollowerFollowing: uniqueIndex(
+      'follows_follower_following_unique',
+    ).on(table.followerId, table.followingId),
   }),
 );
 
 export const notifications = pgTable('notifications', {
   id: serial('id').primaryKey(),
-  toUserId: integer('to_user_id').references(() => users.id).notNull(),
-  fromUserId: integer('from_user_id').references(() => users.id).notNull(),
+  toUserId: integer('to_user_id')
+    .references(() => users.id)
+    .notNull(),
+  fromUserId: integer('from_user_id')
+    .references(() => users.id)
+    .notNull(),
   type: notificationTypeEnum('type').notNull(),
   createdAt: timestamp('created_at').defaultNow(),
   readAt: timestamp('read_at'),

--- a/tests/people.spec.ts
+++ b/tests/people.spec.ts
@@ -31,7 +31,10 @@ test('people page lists other users', async ({ page, browser }) => {
   await expect(page.getByText(`@${handle2}`)).toBeVisible();
 });
 
-test('following an open account shows inbox notification', async ({ page, browser }) => {
+test('following an open account shows inbox notification', async ({
+  page,
+  browser,
+}) => {
   const ts = Date.now();
   const handle1 = `user${ts}`;
   const email1 = `${handle1}@example.com`;
@@ -107,6 +110,115 @@ test('following a closed account stays visible', async ({ page, browser }) => {
   ).toBeVisible();
 });
 
+test('accepting a follow request allows follow back', async ({
+  page,
+  browser,
+}) => {
+  const ts = Date.now();
+  const handle1 = `user${ts}`;
+  const email1 = `${handle1}@example.com`;
+  const password = 'pass1234';
+
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'User One');
+  await page.fill('input[placeholder="Handle"]', handle1);
+  await page.fill('input[placeholder="Email"]', email1);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.waitForURL('**/flavors');
+
+  const handle2 = `user${ts + 1}`;
+  const email2 = `${handle2}@example.com`;
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  await page2.goto('/signup');
+  await page2.fill('input[placeholder="Name"]', 'User Two');
+  await page2.fill('input[placeholder="Handle"]', handle2);
+  await page2.fill('input[placeholder="Email"]', email2);
+  await page2.fill('input[placeholder="Password"]', password);
+  await page2.click('text=Sign Up');
+  await page2.waitForURL('**/flavors');
+  await page2.goto('/settings/account');
+  await page2.selectOption('select', 'closed');
+  await page2.click('text=Save');
+
+  // user1 requests to follow user2
+  await page.goto('/people');
+  const row = page.locator(`li:has-text("@${handle2}")`);
+  await row.getByRole('button', { name: 'Request to follow' }).click();
+
+  // user2 accepts request
+  await page2.goto('/people/inbox');
+  await expect(
+    page2.getByText(`@${handle1} wants to follow you`),
+  ).toBeVisible();
+  const req = page2.locator(`li:has-text("@${handle1}")`);
+  await req.getByRole('button', { name: 'Accept' }).click();
+
+  // user2 sees follow back option
+  await page2.goto('/people');
+  const row2 = page2.locator(`li:has-text("@${handle1}")`);
+  await expect(row2.getByRole('button', { name: 'Follow back' })).toBeVisible();
+
+  await ctx2.close();
+});
+
+test('declining a follow request notifies requester and allows resend', async ({
+  page,
+  browser,
+}) => {
+  const ts = Date.now();
+  const handle1 = `user${ts}`;
+  const email1 = `${handle1}@example.com`;
+  const password = 'pass1234';
+
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'User One');
+  await page.fill('input[placeholder="Handle"]', handle1);
+  await page.fill('input[placeholder="Email"]', email1);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.waitForURL('**/flavors');
+
+  const handle2 = `user${ts + 1}`;
+  const email2 = `${handle2}@example.com`;
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  await page2.goto('/signup');
+  await page2.fill('input[placeholder="Name"]', 'User Two');
+  await page2.fill('input[placeholder="Handle"]', handle2);
+  await page2.fill('input[placeholder="Email"]', email2);
+  await page2.fill('input[placeholder="Password"]', password);
+  await page2.click('text=Sign Up');
+  await page2.waitForURL('**/flavors');
+  await page2.goto('/settings/account');
+  await page2.selectOption('select', 'closed');
+  await page2.click('text=Save');
+
+  // user1 requests to follow user2
+  await page.goto('/people');
+  let row = page.locator(`li:has-text("@${handle2}")`);
+  await row.getByRole('button', { name: 'Request to follow' }).click();
+
+  // user2 declines
+  await page2.goto('/people/inbox');
+  const req = page2.locator(`li:has-text("@${handle1}")`);
+  await req.getByRole('button', { name: 'Decline' }).click();
+
+  // requester sees decline notification and can resend
+  await page.goto('/people/inbox');
+  await expect(
+    page.getByText(`@${handle2} declined your follow request`),
+  ).toBeVisible();
+  await page.goto('/people');
+  row = page.locator(`li:has-text("@${handle2}")`);
+  await expect(
+    row.getByRole('button', { name: 'Request to follow' }),
+  ).toBeVisible();
+
+  await ctx2.close();
+});
+
 test('unfollowing sends notification', async ({ page, browser }) => {
   const ts = Date.now();
   const handle1 = `user${ts}`;
@@ -139,9 +251,7 @@ test('unfollowing sends notification', async ({ page, browser }) => {
   await row.getByRole('button', { name: 'Unfollow' }).click();
 
   await page2.goto('/people/inbox');
-  await expect(
-    page2.getByText(`@${handle1} unfollowed you`),
-  ).toBeVisible();
+  await expect(page2.getByText(`@${handle1} unfollowed you`)).toBeVisible();
 
   await ctx2.close();
 });


### PR DESCRIPTION
## Summary
- show closed accounts in Discover and offer follow-back after accepting a request
- notify requesters when their follow is declined
- surface follow requests with clear "wants to follow you" messaging

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a24a329748832a8484bffe6272a6a9