### PR TITLE
Fix profile params and ensure inbox shows follow updates

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -40,3 +40,4 @@
 - 2025-08-30: Fixed follow visibility and notifications; renamed People page section to "Following" so followed users remain discoverable.
 - 2025-08-30: Kept closed-account follows visible, added unfollow notifications, and surfaced them in the inbox.
 - 2025-08-30: Enabled follow-back after accepting requests, added decline notifications, and ensured closed accounts appear in Discover.
+- 2025-08-30: Fixed profile route params handling and ensured inbox shows follow requests/notifications for all users.

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -57,6 +57,7 @@ export async function followRequest(
   }
 
   revalidatePath('/people');
+  revalidatePath('/people/inbox');
 }
 
 export async function cancelFollowRequest(
@@ -76,6 +77,7 @@ export async function cancelFollowRequest(
       ),
     );
   revalidatePath('/people');
+  revalidatePath('/people/inbox');
 }
 
 export async function acceptFollowRequest(
@@ -102,6 +104,7 @@ export async function acceptFollowRequest(
     type: 'follow_accepted',
   });
   revalidatePath('/people');
+  revalidatePath('/people/inbox');
 }
 
 export async function unfollow(
@@ -121,6 +124,7 @@ export async function unfollow(
     type: 'unfollow',
   });
   revalidatePath('/people');
+  revalidatePath('/people/inbox');
 }
 
 export async function declineFollowRequest(
@@ -145,4 +149,5 @@ export async function declineFollowRequest(
     type: 'follow_declined',
   });
   revalidatePath('/people');
+  revalidatePath('/people/inbox');
 }

--- a/app/(app)/people/inbox/page.tsx
+++ b/app/(app)/people/inbox/page.tsx
@@ -1,14 +1,14 @@
 import { db } from '@/lib/db';
 import { follows, notifications, users } from '@/lib/db/schema';
 import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
 import { acceptFollowRequest, declineFollowRequest } from '../actions';
 import { eq, and } from 'drizzle-orm';
 import { Button } from '@/components/ui/button';
 
 export default async function InboxPage() {
   const session = await auth();
-  const me = Number(session?.user?.id);
-  if (!me) {
+  if (!session?.user?.email) {
     return (
       <section>
         <h1 className="text-2xl font-bold">Inbox</h1>
@@ -16,6 +16,8 @@ export default async function InboxPage() {
       </section>
     );
   }
+  const self = await ensureUser(session);
+  const me = self.id;
 
   const requests = await db
     .select({

--- a/app/(app)/u/[handle]/page.tsx
+++ b/app/(app)/u/[handle]/page.tsx
@@ -13,11 +13,11 @@ import { Button } from '@/components/ui/button';
 export default async function ProfilePage({
   params,
 }: {
-  params: { handle: string };
+  params: Promise<{ handle: string }>;
 }) {
   const session = await auth();
   const viewerId = Number(session?.user?.id);
-  const handle = params.handle;
+  const { handle } = await params;
 
   const [user] = await db
     .select({


### PR DESCRIPTION
## Summary
- fix profile page to await dynamic route params
- ensure inbox page creates user records and show requests/notifications
- revalidate inbox path for follow actions

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d436afe0832a8304e336f6d783e3