### PR TITLE
feat: add read-only account view

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -41,3 +41,4 @@
 - 2025-08-30: Kept closed-account follows visible, added unfollow notifications, and surfaced them in the inbox.
 - 2025-08-30: Enabled follow-back after accepting requests, added decline notifications, and ensured closed accounts appear in Discover.
 - 2025-08-30: Fixed profile route params handling and ensured inbox shows follow requests/notifications for all users.
+- 2025-08-31: Added profile overview view-account button and read-only account page respecting visibility settings.

--- a/app/(app)/u/[handle]/account/page.tsx
+++ b/app/(app)/u/[handle]/account/page.tsx
@@ -1,0 +1,77 @@
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { users, follows } from '@/lib/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { notFound } from 'next/navigation';
+import { listFlavors } from '@/lib/flavors-store';
+
+export default async function ViewAccountPage({
+  params,
+}: {
+  params: Promise<{ handle: string }>;
+}) {
+  const session = await auth();
+  const viewerId = Number(session?.user?.id);
+  const { handle } = await params;
+
+  const [user] = await db
+    .select({
+      id: users.id,
+      handle: users.handle,
+      displayName: users.displayName,
+      accountVisibility: users.accountVisibility,
+    })
+    .from(users)
+    .where(eq(users.handle, handle));
+
+  if (!user) notFound();
+
+  if (user.accountVisibility === 'private' && viewerId !== user.id) {
+    notFound();
+  }
+
+  let relation: 'self' | 'accepted' | 'pending' | 'none' = 'none';
+  if (viewerId) {
+    if (viewerId === user.id) {
+      relation = 'self';
+    } else {
+      const [outgoing] = await db
+        .select()
+        .from(follows)
+        .where(
+          and(eq(follows.followerId, viewerId), eq(follows.followingId, user.id)),
+        );
+      if (outgoing) relation = outgoing.status as 'accepted' | 'pending';
+    }
+  }
+
+  if (
+    user.accountVisibility === 'closed' &&
+    viewerId !== user.id &&
+    relation !== 'accepted'
+  ) {
+    notFound();
+  }
+
+  const flavors = await listFlavors(user.id.toString());
+
+  return (
+    <section className="space-y-4">
+      <h1 className="text-2xl font-bold">{user.displayName ?? user.handle}</h1>
+      <p>@{user.handle}</p>
+      <h2 className="text-xl font-semibold">Flavors</h2>
+      {flavors.length > 0 ? (
+        <ul className="space-y-2">
+          {flavors.map((f) => (
+            <li key={f.id} className="flex items-center gap-2">
+              <span>{f.icon}</span>
+              <span>{f.name}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-muted-foreground">No flavors yet.</p>
+      )}
+    </section>
+  );
+}

--- a/app/(app)/u/[handle]/page.tsx
+++ b/app/(app)/u/[handle]/page.tsx
@@ -9,6 +9,7 @@ import {
 import { eq, and } from 'drizzle-orm';
 import { notFound } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import Link from 'next/link';
 
 export default async function ProfilePage({
   params,
@@ -88,6 +89,11 @@ export default async function ProfilePage({
     );
   }
 
+  const canViewAccount =
+    viewerId === user.id ||
+    user.accountVisibility === 'open' ||
+    relation === 'accepted';
+
   return (
     <section className="space-y-4">
       <h1 className="text-2xl font-bold">{user.displayName ?? user.handle}</h1>
@@ -110,6 +116,11 @@ export default async function ProfilePage({
             {user.accountVisibility === 'open' ? 'Follow' : 'Request to follow'}
           </Button>
         </form>
+      )}
+      {canViewAccount && (
+        <Link href={`/u/${user.handle}/account`}>
+          <Button variant="outline">View account</Button>
+        </Link>
       )}
     </section>
   );


### PR DESCRIPTION
## Summary
- add View account button on profile overview
- support read-only account page showing flavors when visibility allows

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d8a4323c832a9470c95a4673e730