### PR TITLE
feat: redirect account view with viewer mode

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -41,3 +41,5 @@
 - 2025-08-30: Kept closed-account follows visible, added unfollow notifications, and surfaced them in the inbox.
 - 2025-08-30: Enabled follow-back after accepting requests, added decline notifications, and ensured closed accounts appear in Discover.
 - 2025-08-30: Fixed profile route params handling and ensured inbox shows follow requests/notifications for all users.
+- 2025-08-31: Added profile overview view-account button and read-only account page respecting visibility settings.
+- 2025-09-01: View account now opens the full cake interface in viewer mode with exit control; added read-only profile page.

--- a/app/(app)/u/[handle]/account/page.tsx
+++ b/app/(app)/u/[handle]/account/page.tsx
@@ -1,0 +1,64 @@
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { users, follows } from '@/lib/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { notFound } from 'next/navigation';
+import { ViewerBanner } from '@/components/viewer-banner';
+import { CakeNavigation } from '@/components/cake/cake-navigation';
+
+export default async function ViewAccountPage({
+  params,
+}: {
+  params: Promise<{ handle: string }>;
+}) {
+  const session = await auth();
+  const viewerId = Number(session?.user?.id);
+  const { handle } = await params;
+
+  const [user] = await db
+    .select({
+      id: users.id,
+      handle: users.handle,
+      displayName: users.displayName,
+      accountVisibility: users.accountVisibility,
+    })
+    .from(users)
+    .where(eq(users.handle, handle));
+
+  if (!user) notFound();
+
+  if (user.accountVisibility === 'private' && viewerId !== user.id) {
+    notFound();
+  }
+
+  let relation: 'self' | 'accepted' | 'pending' | 'none' = 'none';
+  if (viewerId) {
+    if (viewerId === user.id) {
+      relation = 'self';
+    } else {
+      const [outgoing] = await db
+        .select()
+        .from(follows)
+        .where(
+          and(eq(follows.followerId, viewerId), eq(follows.followingId, user.id)),
+        );
+      if (outgoing) relation = outgoing.status as 'accepted' | 'pending';
+    }
+  }
+
+  if (
+    user.accountVisibility === 'closed' &&
+    viewerId !== user.id &&
+    relation !== 'accepted'
+  ) {
+    notFound();
+  }
+
+  return (
+    <section className="relative w-full">
+      <h1 className="sr-only">{user.displayName ?? user.handle}</h1>
+      <ViewerBanner exitHref="/" />
+      <CakeNavigation userId={user.id} />
+    </section>
+  );
+}

--- a/app/(app)/u/[handle]/page.tsx
+++ b/app/(app)/u/[handle]/page.tsx
@@ -9,6 +9,7 @@ import {
 import { eq, and } from 'drizzle-orm';
 import { notFound } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import Link from 'next/link';
 
 export default async function ProfilePage({
   params,
@@ -88,6 +89,11 @@ export default async function ProfilePage({
     );
   }
 
+  const canViewAccount =
+    viewerId === user.id ||
+    user.accountVisibility === 'open' ||
+    relation === 'accepted';
+
   return (
     <section className="space-y-4">
       <h1 className="text-2xl font-bold">{user.displayName ?? user.handle}</h1>
@@ -110,6 +116,16 @@ export default async function ProfilePage({
             {user.accountVisibility === 'open' ? 'Follow' : 'Request to follow'}
           </Button>
         </form>
+      )}
+      {canViewAccount && (
+        <div className="flex gap-2">
+          <Link href={`/u/${user.handle}/account`}>
+            <Button variant="outline">View account</Button>
+          </Link>
+          <Link href={`/u/${user.handle}/profile`}>
+            <Button variant="outline">View profile</Button>
+          </Link>
+        </div>
       )}
     </section>
   );

--- a/app/(app)/u/[handle]/profile/page.tsx
+++ b/app/(app)/u/[handle]/profile/page.tsx
@@ -1,0 +1,79 @@
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { users, follows } from '@/lib/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { notFound } from 'next/navigation';
+import { listFlavors } from '@/lib/flavors-store';
+import { ViewerBanner } from '@/components/viewer-banner';
+
+export default async function ViewProfilePage({
+  params,
+}: {
+  params: Promise<{ handle: string }>;
+}) {
+  const session = await auth();
+  const viewerId = Number(session?.user?.id);
+  const { handle } = await params;
+
+  const [user] = await db
+    .select({
+      id: users.id,
+      handle: users.handle,
+      displayName: users.displayName,
+      accountVisibility: users.accountVisibility,
+    })
+    .from(users)
+    .where(eq(users.handle, handle));
+
+  if (!user) notFound();
+
+  if (user.accountVisibility === 'private' && viewerId !== user.id) {
+    notFound();
+  }
+
+  let relation: 'self' | 'accepted' | 'pending' | 'none' = 'none';
+  if (viewerId) {
+    if (viewerId === user.id) {
+      relation = 'self';
+    } else {
+      const [outgoing] = await db
+        .select()
+        .from(follows)
+        .where(
+          and(eq(follows.followerId, viewerId), eq(follows.followingId, user.id)),
+        );
+      if (outgoing) relation = outgoing.status as 'accepted' | 'pending';
+    }
+  }
+
+  if (
+    user.accountVisibility === 'closed' &&
+    viewerId !== user.id &&
+    relation !== 'accepted'
+  ) {
+    notFound();
+  }
+
+  const flavors = await listFlavors(user.id.toString());
+
+  return (
+    <section className="relative space-y-4">
+      <ViewerBanner exitHref="/" />
+      <h1 className="text-2xl font-bold">{user.displayName ?? user.handle}</h1>
+      <p>@{user.handle}</p>
+      <h2 className="text-xl font-semibold">Flavors</h2>
+      {flavors.length > 0 ? (
+        <ul className="space-y-2">
+          {flavors.map((f) => (
+            <li key={f.id} className="flex items-center gap-2">
+              <span>{f.icon}</span>
+              <span>{f.name}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-muted-foreground">No flavors yet.</p>
+      )}
+    </section>
+  );
+}

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -6,14 +6,17 @@ import { slices } from './slices';
 import { Cake3D } from './cake-3d';
 import { SettingsButton } from './settings-button';
 
-export function CakeNavigation() {
+export function CakeNavigation({
+  userId = '42',
+}: {
+  userId?: string | number;
+}) {
   const router = useRouter();
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
   const [hoveredSlug, setHoveredSlug] = useState<string | null>(null);
   const [offsetVh, setOffsetVh] = useState(-8);
   const [boxesOffsetVh, setBoxesOffsetVh] = useState(-6);
   const [reduced, setReduced] = useState(false);
-  const userId = '42';
   const clearTimer = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {

--- a/components/viewer-banner.tsx
+++ b/components/viewer-banner.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export function ViewerBanner({ exitHref = '/' }: { exitHref?: string }) {
+  return (
+    <div className="fixed left-4 top-4 z-50 flex gap-2">
+      <Button variant="outline" size="sm" disabled>
+        Viewer
+      </Button>
+      <Link href={exitHref}>
+        <Button size="sm">Exit</Button>
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- redirect View account to full cake interface with viewer/exit overlay
- add read-only profile page and button to access it
- allow CakeNavigation to target specific user ids

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d8a4323c832a9470c95a4673e730