### PR TITLE
feat: add viewer mode for profiles

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -41,3 +41,5 @@
 - 2025-08-30: Kept closed-account follows visible, added unfollow notifications, and surfaced them in the inbox.
 - 2025-08-30: Enabled follow-back after accepting requests, added decline notifications, and ensured closed accounts appear in Discover.
 - 2025-08-30: Fixed profile route params handling and ensured inbox shows follow requests/notifications for all users.
+- 2025-08-31: Added profile overview view-account button and read-only account page respecting visibility settings.
+- 2025-09-01: Redirected profile viewing to full cake page with viewer banner and exit link.

--- a/app/(app)/u/[handle]/account/page.tsx
+++ b/app/(app)/u/[handle]/account/page.tsx
@@ -1,0 +1,71 @@
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { users, follows } from '@/lib/db/schema';
+import { eq, and } from 'drizzle-orm';
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { CakeNavigation } from '@/components/cake/cake-navigation';
+
+export default async function ViewAccountPage({
+  params,
+}: {
+  params: Promise<{ handle: string }>;
+}) {
+  const session = await auth();
+  const viewerId = Number(session?.user?.id);
+  const { handle } = await params;
+
+  const [user] = await db
+    .select({
+      id: users.id,
+      handle: users.handle,
+      displayName: users.displayName,
+      accountVisibility: users.accountVisibility,
+    })
+    .from(users)
+    .where(eq(users.handle, handle));
+
+  if (!user) notFound();
+
+  if (user.accountVisibility === 'private' && viewerId !== user.id) {
+    notFound();
+  }
+
+  let relation: 'self' | 'accepted' | 'pending' | 'none' = 'none';
+  if (viewerId) {
+    if (viewerId === user.id) {
+      relation = 'self';
+    } else {
+      const [outgoing] = await db
+        .select()
+        .from(follows)
+        .where(
+          and(eq(follows.followerId, viewerId), eq(follows.followingId, user.id)),
+        );
+      if (outgoing) relation = outgoing.status as 'accepted' | 'pending';
+    }
+  }
+
+  if (
+    user.accountVisibility === 'closed' &&
+    viewerId !== user.id &&
+    relation !== 'accepted'
+  ) {
+    notFound();
+  }
+
+  return (
+    <div className="relative">
+      <div className="fixed left-4 top-4 z-50 flex gap-2">
+        <Button variant="outline" disabled>
+          Viewer
+        </Button>
+        <Link href="/">
+          <Button variant="outline">Exit</Button>
+        </Link>
+      </div>
+      <CakeNavigation userId={user.id} readOnly />
+    </div>
+  );
+}

--- a/app/(app)/u/[handle]/page.tsx
+++ b/app/(app)/u/[handle]/page.tsx
@@ -9,6 +9,7 @@ import {
 import { eq, and } from 'drizzle-orm';
 import { notFound } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import Link from 'next/link';
 
 export default async function ProfilePage({
   params,
@@ -88,6 +89,11 @@ export default async function ProfilePage({
     );
   }
 
+  const canViewAccount =
+    viewerId === user.id ||
+    user.accountVisibility === 'open' ||
+    relation === 'accepted';
+
   return (
     <section className="space-y-4">
       <h1 className="text-2xl font-bold">{user.displayName ?? user.handle}</h1>
@@ -110,6 +116,11 @@ export default async function ProfilePage({
             {user.accountVisibility === 'open' ? 'Follow' : 'Request to follow'}
           </Button>
         </form>
+      )}
+      {canViewAccount && (
+        <Link href={`/u/${user.handle}/account`}>
+          <Button variant="outline">View profile</Button>
+        </Link>
       )}
     </section>
   );

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -6,14 +6,21 @@ import { slices } from './slices';
 import { Cake3D } from './cake-3d';
 import { SettingsButton } from './settings-button';
 
-export function CakeNavigation() {
+interface CakeNavigationProps {
+  userId?: string | number;
+  readOnly?: boolean;
+}
+
+export function CakeNavigation({
+  userId = 'self',
+  readOnly = false,
+}: CakeNavigationProps) {
   const router = useRouter();
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
   const [hoveredSlug, setHoveredSlug] = useState<string | null>(null);
   const [offsetVh, setOffsetVh] = useState(-8);
   const [boxesOffsetVh, setBoxesOffsetVh] = useState(-6);
   const [reduced, setReduced] = useState(false);
-  const userId = '42';
   const clearTimer = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
@@ -79,7 +86,7 @@ export function CakeNavigation() {
       className="relative grid w-full justify-items-center"
       style={{ minHeight: 'calc(100vh - 64px)' }}
     >
-      <SettingsButton />
+      {!readOnly && <SettingsButton />}
       <div
         className="grid w-full place-items-center"
         style={{ marginBottom: 'clamp(24px,3vh,36px)' }}


### PR DESCRIPTION
## Summary
- show "View profile" on user overview when viewer can access
- redirect profile view to full cake page with viewer and exit buttons
- hide settings in cake navigation when viewing another user

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d8a4323c832a9470c95a4673e730