### PR TITLE
feat: add view IDs for profile viewing

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -41,3 +41,6 @@
 - 2025-08-30: Kept closed-account follows visible, added unfollow notifications, and surfaced them in the inbox.
 - 2025-08-30: Enabled follow-back after accepting requests, added decline notifications, and ensured closed accounts appear in Discover.
 - 2025-08-30: Fixed profile route params handling and ensured inbox shows follow requests/notifications for all users.
+- 2025-08-31: Added profile overview view-account button and read-only account page respecting visibility settings.
+- 2025-09-01: Redirected profile viewing to full cake page with viewer banner and exit link.
+- 2025-09-02: Added view IDs with cookie-based viewer mode and bottom-left viewer/exit controls.

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { Button } from '@/components/ui/button';
+import { exitViewing } from './viewer/actions';
 
 export default async function AppLayout({
   children,
@@ -12,6 +13,8 @@ export default async function AppLayout({
   if (!session) {
     redirect('/');
   }
+
+  const viewing = (session.user as any).originalId;
 
   return (
     <html lang="en">
@@ -31,6 +34,16 @@ export default async function AppLayout({
           </form>
         </nav>
         <main className="p-4">{children}</main>
+        {viewing && (
+          <div className="fixed left-4 bottom-4 z-50 flex gap-2">
+            <Button variant="outline" disabled>
+              Viewer
+            </Button>
+            <form action={exitViewing}>
+              <Button variant="outline">Exit</Button>
+            </form>
+          </div>
+        )}
       </body>
     </html>
   );

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,10 +1,14 @@
 import { CakeNavigation } from '@/components/cake/cake-navigation';
+import { auth } from '@/lib/auth';
 
-export default function DashboardPage() {
+export default async function DashboardPage() {
+  const session = await auth();
+  const readOnly = Boolean((session?.user as any)?.originalId);
+  const userId = session?.user?.id;
   return (
     <section className="w-full">
       <h1 className="sr-only">Cake</h1>
-      <CakeNavigation />
+      <CakeNavigation userId={userId} readOnly={readOnly} />
     </section>
   );
 }

--- a/app/(app)/u/[handle]/page.tsx
+++ b/app/(app)/u/[handle]/page.tsx
@@ -6,6 +6,7 @@ import {
   cancelFollowRequest,
   unfollow,
 } from '../../people/actions';
+import { viewAccount } from '../../viewer/actions';
 import { eq, and } from 'drizzle-orm';
 import { notFound } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -22,6 +23,7 @@ export default async function ProfilePage({
   const [user] = await db
     .select({
       id: users.id,
+      viewId: users.viewId,
       handle: users.handle,
       displayName: users.displayName,
       accountVisibility: users.accountVisibility,
@@ -88,6 +90,11 @@ export default async function ProfilePage({
     );
   }
 
+  const canViewAccount =
+    viewerId === user.id ||
+    user.accountVisibility === 'open' ||
+    relation === 'accepted';
+
   return (
     <section className="space-y-4">
       <h1 className="text-2xl font-bold">{user.displayName ?? user.handle}</h1>
@@ -109,6 +116,11 @@ export default async function ProfilePage({
           <Button>
             {user.accountVisibility === 'open' ? 'Follow' : 'Request to follow'}
           </Button>
+        </form>
+      )}
+      {canViewAccount && (
+        <form action={viewAccount.bind(null, user.viewId)}>
+          <Button variant="outline">View profile</Button>
         </form>
       )}
     </section>

--- a/app/(app)/viewer/actions.ts
+++ b/app/(app)/viewer/actions.ts
@@ -1,0 +1,17 @@
+'use server';
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+export async function viewAccount(viewId: number) {
+  const store = await cookies();
+  store.set('viewId', String(viewId));
+  redirect('/');
+}
+
+export async function exitViewing() {
+  const store = await cookies();
+  store.delete('viewId');
+  redirect('/');
+}
+

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -6,14 +6,21 @@ import { slices } from './slices';
 import { Cake3D } from './cake-3d';
 import { SettingsButton } from './settings-button';
 
-export function CakeNavigation() {
+interface CakeNavigationProps {
+  userId?: string | number;
+  readOnly?: boolean;
+}
+
+export function CakeNavigation({
+  userId = 'self',
+  readOnly = false,
+}: CakeNavigationProps) {
   const router = useRouter();
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
   const [hoveredSlug, setHoveredSlug] = useState<string | null>(null);
   const [offsetVh, setOffsetVh] = useState(-8);
   const [boxesOffsetVh, setBoxesOffsetVh] = useState(-6);
   const [reduced, setReduced] = useState(false);
-  const userId = '42';
   const clearTimer = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
@@ -79,7 +86,7 @@ export function CakeNavigation() {
       className="relative grid w-full justify-items-center"
       style={{ minHeight: 'calc(100vh - 64px)' }}
     >
-      <SettingsButton />
+      {!readOnly && <SettingsButton />}
       <div
         className="grid w-full place-items-center"
         style={{ marginBottom: 'clamp(24px,3vh,36px)' }}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,6 @@
 import { getServerSession, type NextAuthOptions } from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
+import { cookies } from 'next/headers';
 import { getUserByEmail, verifyPassword } from '@/lib/users';
 
 // NextAuth configuration used both by the route handler and server helpers
@@ -46,6 +47,13 @@ export const authOptions: NextAuthOptions = {
 };
 
 // Helper to retrieve the current session on the server
-export function auth() {
-  return getServerSession(authOptions);
+export async function auth() {
+  const session = await getServerSession(authOptions);
+  const cookieStore = await cookies();
+  const viewId = cookieStore.get('viewId')?.value;
+  if (session?.user && viewId) {
+    (session.user as any).originalId = (session.user as any).id;
+    (session.user as any).id = viewId;
+  }
+  return session;
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -29,6 +29,7 @@ export const notificationTypeEnum = pgEnum('notification_type', [
 
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
+  viewId: serial('view_id').unique(),
   handle: varchar('handle', { length: 50 }).notNull().unique(),
   displayName: text('display_name'),
   avatarUrl: text('avatar_url'),


### PR DESCRIPTION
## Summary
- introduce view IDs and cookie-based viewer mode switch
- show persistent Viewer/Exit controls bottom-left when browsing another profile
- replace account route with server action to enter read-only view using view IDs

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d8a4323c832a9470c95a4673e730