### PR TITLE
feat: refine read-only profile view

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -20,6 +20,7 @@ Examples:
 - `cak3titleText` → page heading text.
 
 Modal form IDs:
+
 - `f7avourmdl-{mode}-{userId}` → flavor modal root (`mode`: new|edit).
 - `f7avourn4me-frm-{userId}` → flavor form name input.
 - `f7avourde5cr-frm-{userId}` → flavor form description textarea.
@@ -27,3 +28,25 @@ Modal form IDs:
 - `f7avourt4rg-frm-{userId}` → flavor form target percentage input.
 - `f7avoursav-frm-{userId}` → flavor form save button.
 - `f7avourcnl-frm-{userId}` → flavor form cancel button.
+
+## Profile Viewing
+
+- `pr0ovr-{ownerId}-{viewerId}` → profile overview root container.
+- `pr0ovr-view-{ownerId}-{viewerId}` → View Account button in overview.
+- `pr0ovr-fol-{ownerId}-{viewerId}` → Follow button in overview.
+- `pr0ovr-req-{ownerId}-{viewerId}` → Request to follow button in overview.
+- `pr0ovr-unf-{ownerId}-{viewerId}` → Unfollow button in overview.
+- `pr0ovr-ccl-{ownerId}-{viewerId}` → Cancel request button in overview.
+- `p30pl3-view-{ownerId}-{viewerId}` → View Account quick action in People lists.
+- `v13wctx-{ownerId}-{viewerId}` → View Account page root container.
+- Viewer bar on View Account pages:
+  - `v13wbar-{ownerId}-{viewerId}` → viewer bar root.
+  - `v13wbar-live-{ownerId}-{viewerId}` → live indicator dot.
+  - `v13wbar-exit-{ownerId}-{viewerId}` → exit button.
+- Section anchors on View Account pages:
+  - `v13w-cake-{ownerId}`
+  - `v13w-plan-{ownerId}`
+  - `v13w-flav-{ownerId}`
+  - `v13w-igrd-{ownerId}`
+  - `v13w-revw-{ownerId}`
+  - `v13w-peep-{ownerId}`

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -41,3 +41,5 @@
 - 2025-08-30: Kept closed-account follows visible, added unfollow notifications, and surfaced them in the inbox.
 - 2025-08-30: Enabled follow-back after accepting requests, added decline notifications, and ensured closed accounts appear in Discover.
 - 2025-08-30: Fixed profile route params handling and ensured inbox shows follow requests/notifications for all users.
+- 2025-08-31: Added profile overview and read-only View Account pages with visibility rules, introduced viewId and view context utilities, and updated People follow states.
+- 2025-08-31: Refined View Account flow with section routing, bottom-left viewer bar, and navigation rewrites for read-only mode.

--- a/app/(app)/flavors/[flavorId]/subflavors/actions.ts
+++ b/app/(app)/flavors/[flavorId]/subflavors/actions.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/subflavors-store';
 import { revalidatePath } from 'next/cache';
 import type { Subflavor, SubflavorInput } from '@/types/subflavor';
+import { assertOwner } from '@/lib/profile';
 
 function sanitize(body: any): SubflavorInput {
   if (
@@ -64,6 +65,7 @@ export async function createSubflavor(
   if (!userId) {
     throw new Error('Please sign in.');
   }
+  await assertOwner(Number(userId));
   const subflavor = await createSubflavorStore(
     userId,
     flavorId,
@@ -83,6 +85,7 @@ export async function updateSubflavor(
   if (!userId) {
     throw new Error('Please sign in.');
   }
+  await assertOwner(Number(userId));
   const updated = await updateSubflavorStore(userId, id, sanitize(form));
   if (!updated) {
     throw new Error('Not found');

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -7,6 +7,7 @@ import {
 } from '@/lib/flavors-store';
 import { revalidatePath } from 'next/cache';
 import type { Flavor, FlavorInput } from '@/types/flavor';
+import { assertOwner } from '@/lib/profile';
 
 function sanitize(body: any): FlavorInput {
   if (
@@ -60,6 +61,7 @@ export async function createFlavor(form: any): Promise<Flavor> {
   if (!userId) {
     throw new Error('Please sign in.');
   }
+  await assertOwner(Number(userId));
   const flavor = await createFlavorStore(userId, sanitize(form));
   revalidatePath('/flavors');
   return flavor;
@@ -71,6 +73,7 @@ export async function updateFlavor(id: string, form: any): Promise<Flavor> {
   if (!userId) {
     throw new Error('Please sign in.');
   }
+  await assertOwner(Number(userId));
   const updated = await updateFlavorStore(userId, id, sanitize(form));
   if (!updated) {
     throw new Error('Not found');

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,7 +1,9 @@
-import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth';
-import { Button } from '@/components/ui/button';
+import AppNav from '@/components/app-nav';
+import { ensureUser } from '@/lib/users';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
 
 export default async function AppLayout({
   children,
@@ -12,25 +14,16 @@ export default async function AppLayout({
   if (!session) {
     redirect('/');
   }
+  const me = await ensureUser(session);
+  const ctx = buildViewContext(me.id, me.viewId, me.id);
 
   return (
     <html lang="en">
       <body>
-        <nav className="flex items-center justify-between border-b p-4">
-          <ul className="flex gap-4">
-            <li><Link href="/">Cake</Link></li>
-            <li><Link href="/planning">Planning</Link></li>
-            <li><Link href="/flavors">Flavors</Link></li>
-            <li><Link href="/ingredients">Ingredients</Link></li>
-            <li><Link href="/review">Review</Link></li>
-            <li><Link href="/people">People</Link></li>
-            <li><Link href="/visibility">Visibility</Link></li>
-          </ul>
-          <form action="/api/auth/signout" method="post">
-            <Button type="submit">Sign out</Button>
-          </form>
-        </nav>
-        <main className="p-4">{children}</main>
+        <ViewContextProvider value={ctx}>
+          <AppNav />
+          <main className="p-4">{children}</main>
+        </ViewContextProvider>
       </body>
     </html>
   );

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -6,6 +6,7 @@ import { follows, notifications, users } from '@/lib/db/schema';
 import { ensureUser } from '@/lib/users';
 import { and, eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
+import { assertOwner } from '@/lib/profile';
 
 export async function followRequest(
   targetId: number,
@@ -14,6 +15,7 @@ export async function followRequest(
   const session = await auth();
   const self = await ensureUser(session);
   const me = self.id;
+  await assertOwner(me);
   if (me === targetId) throw new Error('Cannot follow yourself.');
 
   const [target] = await db
@@ -67,6 +69,7 @@ export async function cancelFollowRequest(
   const session = await auth();
   const self = await ensureUser(session);
   const me = self.id;
+  await assertOwner(me);
   await db
     .delete(follows)
     .where(
@@ -87,6 +90,7 @@ export async function acceptFollowRequest(
   const session = await auth();
   const self = await ensureUser(session);
   const me = self.id;
+  await assertOwner(me);
   const [req] = await db
     .select()
     .from(follows)
@@ -114,6 +118,7 @@ export async function unfollow(
   const session = await auth();
   const self = await ensureUser(session);
   const me = self.id;
+  await assertOwner(me);
   await db
     .delete(follows)
     .where(and(eq(follows.followerId, me), eq(follows.followingId, targetId)));
@@ -134,6 +139,7 @@ export async function declineFollowRequest(
   const session = await auth();
   const self = await ensureUser(session);
   const me = self.id;
+  await assertOwner(me);
   await db
     .delete(follows)
     .where(

--- a/app/(app)/view/[viewId]/flavors/page.tsx
+++ b/app/(app)/view/[viewId]/flavors/page.tsx
@@ -1,0 +1,24 @@
+import { getUserByViewId } from '@/lib/users';
+import { listFlavors } from '@/lib/flavors-store';
+import { notFound } from 'next/navigation';
+
+export default async function ViewFlavorsPage({
+  params,
+}: {
+  params: Promise<{ viewId: string }>;
+}) {
+  const { viewId } = await params;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const flavors = await listFlavors(String(user.id));
+  return (
+    <section id={`v13w-flav-${user.id}`} className="space-y-4">
+      <h1 className="text-2xl font-bold">Flavors</h1>
+      <ul className="list-disc pl-4">
+        {flavors.map((f) => (
+          <li key={f.id}>{f.name}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/app/(app)/view/[viewId]/ingredients/page.tsx
+++ b/app/(app)/view/[viewId]/ingredients/page.tsx
@@ -1,0 +1,17 @@
+import { getUserByViewId } from '@/lib/users';
+import { notFound } from 'next/navigation';
+
+export default async function ViewIngredientsPage({
+  params,
+}: {
+  params: Promise<{ viewId: string }>;
+}) {
+  const { viewId } = await params;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  return (
+    <section id={`v13w-igrd-${user.id}`}>
+      <h1 className="text-2xl font-bold">Ingredients</h1>
+    </section>
+  );
+}

--- a/app/(app)/view/[viewId]/layout.tsx
+++ b/app/(app)/view/[viewId]/layout.tsx
@@ -1,0 +1,34 @@
+import { getUserByViewId } from '@/lib/users';
+import { auth } from '@/lib/auth';
+import { buildViewContext, canViewProfile } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import ViewerBar from '@/components/viewer-bar';
+import { notFound } from 'next/navigation';
+
+export default async function ViewLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ viewId: string }>;
+}) {
+  const { viewId } = await params;
+  const session = await auth();
+  const viewerId = session?.user?.id ? Number(session.user.id) : null;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const allowed = await canViewProfile({
+    viewerId,
+    targetUser: { id: user.id, accountVisibility: user.accountVisibility as any },
+  });
+  if (!allowed) notFound();
+  const ctx = buildViewContext(user.id, user.viewId, viewerId);
+  return (
+    <ViewContextProvider value={ctx}>
+      <div id={`v13wctx-${user.id}-${viewerId || 0}`} className="relative">
+        {children}
+        <ViewerBar />
+      </div>
+    </ViewContextProvider>
+  );
+}

--- a/app/(app)/view/[viewId]/page.tsx
+++ b/app/(app)/view/[viewId]/page.tsx
@@ -1,0 +1,19 @@
+import { getUserByViewId } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { CakeNavigation } from '@/components/cake/cake-navigation';
+
+export default async function ViewPage({
+  params,
+}: {
+  params: Promise<{ viewId: string }>;
+}) {
+  const { viewId } = await params;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  return (
+    <section id={`v13w-cake-${user.id}`} className="w-full">
+      <h1 className="sr-only">Cake</h1>
+      <CakeNavigation />
+    </section>
+  );
+}

--- a/app/(app)/view/[viewId]/people/page.tsx
+++ b/app/(app)/view/[viewId]/people/page.tsx
@@ -1,0 +1,17 @@
+import { getUserByViewId } from '@/lib/users';
+import { notFound } from 'next/navigation';
+
+export default async function ViewPeoplePage({
+  params,
+}: {
+  params: Promise<{ viewId: string }>;
+}) {
+  const { viewId } = await params;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  return (
+    <section id={`v13w-peep-${user.id}`}>
+      <h1 className="text-2xl font-bold">People</h1>
+    </section>
+  );
+}

--- a/app/(app)/view/[viewId]/planning/page.tsx
+++ b/app/(app)/view/[viewId]/planning/page.tsx
@@ -1,0 +1,17 @@
+import { getUserByViewId } from '@/lib/users';
+import { notFound } from 'next/navigation';
+
+export default async function ViewPlanningPage({
+  params,
+}: {
+  params: Promise<{ viewId: string }>;
+}) {
+  const { viewId } = await params;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  return (
+    <section id={`v13w-plan-${user.id}`}>
+      <h1 className="text-2xl font-bold">Planning</h1>
+    </section>
+  );
+}

--- a/app/(app)/view/[viewId]/review/page.tsx
+++ b/app/(app)/view/[viewId]/review/page.tsx
@@ -1,0 +1,17 @@
+import { getUserByViewId } from '@/lib/users';
+import { notFound } from 'next/navigation';
+
+export default async function ViewReviewPage({
+  params,
+}: {
+  params: Promise<{ viewId: string }>;
+}) {
+  const { viewId } = await params;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  return (
+    <section id={`v13w-revw-${user.id}`}>
+      <h1 className="text-2xl font-bold">Review</h1>
+    </section>
+  );
+}

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export function AppNav() {
+  const pathname = usePathname();
+  const match = pathname.match(/^\/view\/([^/]+)/);
+  const base = match ? `/view/${match[1]}` : '';
+  const links = [
+    { label: 'Cake', href: base || '/' },
+    { label: 'Planning', href: base ? `${base}/planning` : '/planning' },
+    { label: 'Flavors', href: base ? `${base}/flavors` : '/flavors' },
+    { label: 'Ingredients', href: base ? `${base}/ingredients` : '/ingredients' },
+    { label: 'Review', href: base ? `${base}/review` : '/review' },
+    { label: 'People', href: base ? `${base}/people` : '/people' },
+    { label: 'Visibility', href: base ? `${base}/visibility` : '/visibility' },
+  ];
+  return (
+    <nav className="flex items-center justify-between border-b p-4">
+      <ul className="flex gap-4">
+        {links.map((l) => (
+          <li key={l.label}>
+            <Link
+              href={l.href}
+              className={pathname === l.href ? 'font-bold' : ''}
+            >
+              {l.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <form action="/api/auth/signout" method="post">
+        <button type="submit" className="underline">
+          Sign out
+        </button>
+      </form>
+    </nav>
+  );
+}
+
+export default AppNav;

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -5,15 +5,18 @@ import { useRouter } from 'next/navigation';
 import { slices } from './slices';
 import { Cake3D } from './cake-3d';
 import { SettingsButton } from './settings-button';
+import { useViewContext } from '@/lib/view-context';
+import { getSectionHref, Section } from '@/lib/profile';
 
 export function CakeNavigation() {
   const router = useRouter();
+  const ctx = useViewContext();
   const [activeSlug, setActiveSlug] = useState<string | null>(null);
   const [hoveredSlug, setHoveredSlug] = useState<string | null>(null);
   const [offsetVh, setOffsetVh] = useState(-8);
   const [boxesOffsetVh, setBoxesOffsetVh] = useState(-6);
   const [reduced, setReduced] = useState(false);
-  const userId = '42';
+  const userId = String(ctx.ownerId);
   const clearTimer = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
@@ -130,7 +133,11 @@ export function CakeNavigation() {
                 id={`n4vbox-${slice.slug}-${userId}`}
                 data-popped={popped ? true : undefined}
                 aria-label={slice.label}
-                onClick={() => router.push(slice.href)}
+                onClick={() =>
+                  router.push(
+                    getSectionHref(slice.slug as Section, ctx),
+                  )
+                }
                 onMouseEnter={() => handleEnter(slice.slug)}
                 onMouseLeave={handleLeave}
                 onFocus={() => handleEnter(slice.slug)}

--- a/components/viewer-bar.tsx
+++ b/components/viewer-bar.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useViewContext } from '@/lib/view-context';
+
+export function ViewerBar() {
+  const router = useRouter();
+  const ctx = useViewContext();
+  const owner = ctx.ownerId;
+  const viewer = ctx.viewerId || 0;
+  function exit() {
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/');
+    }
+  }
+  return (
+    <div
+      id={`v13wbar-${owner}-${viewer}`}
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-4 left-4 z-40 flex items-center gap-3 rounded-md bg-white/40 p-2 text-sm shadow-sm backdrop-blur-sm dark:bg-black/30"
+    >
+      <span
+        id={`v13wbar-live-${owner}-${viewer}`}
+        className="h-2 w-2 rounded-full bg-green-500"
+        aria-label="live"
+      />
+      <span>Viewing (live)</span>
+      <span className="px-1">|</span>
+      <button
+        id={`v13wbar-exit-${owner}-${viewer}`}
+        onClick={exit}
+        className="underline"
+        aria-label="Exit viewing and return to my account"
+      >
+        Exit
+      </button>
+    </div>
+  );
+}
+
+export default ViewerBar;

--- a/drizzle/0006_add_view_id.sql
+++ b/drizzle/0006_add_view_id.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users ADD COLUMN view_id text;
+UPDATE users SET view_id = gen_random_uuid();
+ALTER TABLE users ALTER COLUMN view_id SET NOT NULL;
+ALTER TABLE users ADD CONSTRAINT users_view_id_unique UNIQUE (view_id);

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -32,6 +32,7 @@ export const users = pgTable('users', {
   handle: varchar('handle', { length: 50 }).notNull().unique(),
   displayName: text('display_name'),
   avatarUrl: text('avatar_url'),
+  viewId: text('view_id').notNull().unique(),
   accountVisibility: accountVisibilityEnum('account_visibility')
     .notNull()
     .default('open'),

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -1,0 +1,75 @@
+import { db } from './db';
+import { follows } from './db/schema';
+import { eq, and } from 'drizzle-orm';
+import { auth } from './auth';
+
+export interface ViewContext {
+  ownerId: number;
+  viewerId: number | null;
+  mode: 'owner' | 'viewer';
+  editable: boolean;
+  viewId: string;
+}
+
+export function buildViewContext(
+  ownerId: number,
+  viewId: string,
+  viewerId: number | null,
+): ViewContext {
+  const mode = viewerId === ownerId ? 'owner' : 'viewer';
+  return { ownerId, viewerId, mode, editable: mode === 'owner', viewId };
+}
+
+export async function canViewProfile({
+  viewerId,
+  targetUser,
+}: {
+  viewerId: number | null;
+  targetUser: { id: number; accountVisibility: 'open' | 'closed' | 'private' };
+}) {
+  if (viewerId === targetUser.id) return true;
+  switch (targetUser.accountVisibility) {
+    case 'open':
+      return true;
+    case 'closed':
+      if (!viewerId) return false;
+      const [f] = await db
+        .select()
+        .from(follows)
+        .where(
+          and(
+            eq(follows.followerId, viewerId),
+            eq(follows.followingId, targetUser.id),
+          ),
+        );
+      return f?.status === 'accepted';
+    case 'private':
+      return false;
+    default:
+      return false;
+  }
+}
+
+export async function assertOwner(ownerId: number) {
+  const session = await auth();
+  const me = Number(session?.user?.id);
+  if (me !== ownerId) {
+    throw new Error("Read-only: you cannot edit another user's account.");
+  }
+}
+
+export type Section =
+  | 'cake'
+  | 'planning'
+  | 'flavors'
+  | 'ingredients'
+  | 'review'
+  | 'people'
+  | 'visibility';
+
+export function getSectionHref(section: Section, ctx: ViewContext) {
+  if (ctx.mode === 'viewer') {
+    return `/view/${ctx.viewId}${section === 'cake' ? '' : `/${section}`}`;
+  }
+  return `/${section === 'cake' ? '' : section}`;
+}

--- a/lib/view-context.tsx
+++ b/lib/view-context.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { createContext, useContext } from 'react';
+import type { ViewContext } from './profile';
+
+const Ctx = createContext<ViewContext>({
+  ownerId: 0,
+  viewerId: null,
+  mode: 'owner',
+  editable: true,
+  viewId: '',
+});
+
+export function ViewContextProvider({
+  value,
+  children,
+}: {
+  value: ViewContext;
+  children: React.ReactNode;
+}) {
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useViewContext() {
+  return useContext(Ctx);
+}


### PR DESCRIPTION
## Summary
- add viewer bar and view context routing for read-only accounts
- route all navigation through view paths and land directly on Cake home
- expose view section IDs and navigation helper for gating

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Module not found: Can't resolve 'fs')*


------
https://chatgpt.com/codex/tasks/task_e_68a2e608a950832aae7461b2f54048df