### PR TITLE
fix: ensure user exists before flavor actions

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -44,3 +44,4 @@
 - 2025-08-31: Added profile overview and read-only View Account pages with visibility rules, introduced viewId and view context utilities, and updated People follow states.
 - 2025-08-31: Refined View Account to land on Cake home, added viewer bar with Exit, dynamic view routing, and navigation helper.
 - 2025-08-31: Added userId query parameter to owner routes and redirect to own account, switching to viewId when viewing others.
+- 2025-09-01: Ensured flavor actions create missing user records to avoid foreign key errors when inserting flavors.

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -5,6 +5,7 @@ import {
   createFlavor as createFlavorStore,
   updateFlavor as updateFlavorStore,
 } from '@/lib/flavors-store';
+import { ensureUser } from '@/lib/users';
 import { revalidatePath } from 'next/cache';
 import type { Flavor, FlavorInput } from '@/types/flavor';
 import { assertOwner } from '@/lib/profile';
@@ -57,11 +58,9 @@ function clamp(n: number) {
 
 export async function createFlavor(form: any): Promise<Flavor> {
   const session = await auth();
-  const userId = session?.user?.id;
-  if (!userId) {
-    throw new Error('Please sign in.');
-  }
-  await assertOwner(Number(userId));
+  const self = await ensureUser(session);
+  const userId = String(self.id);
+  await assertOwner(self.id);
   const flavor = await createFlavorStore(userId, sanitize(form));
   revalidatePath('/flavors');
   return flavor;
@@ -69,11 +68,9 @@ export async function createFlavor(form: any): Promise<Flavor> {
 
 export async function updateFlavor(id: string, form: any): Promise<Flavor> {
   const session = await auth();
-  const userId = session?.user?.id;
-  if (!userId) {
-    throw new Error('Please sign in.');
-  }
-  await assertOwner(Number(userId));
+  const self = await ensureUser(session);
+  const userId = String(self.id);
+  await assertOwner(self.id);
   const updated = await updateFlavorStore(userId, id, sanitize(form));
   if (!updated) {
     throw new Error('Not found');


### PR DESCRIPTION
## Summary
- ensure flavor creation/update actions create a user record if missing to avoid FK errors

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f30b9f18832a91929103ae0535e9