### PR TITLE
fix: default to own account and streamline owner checks

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -44,3 +44,5 @@
 - 2025-08-31: Added profile overview and read-only View Account pages with visibility rules, introduced viewId and view context utilities, and updated People follow states.
 - 2025-08-31: Refined View Account to land on Cake home, added viewer bar with Exit, dynamic view routing, and navigation helper.
 - 2025-08-31: Added userId query parameter to owner routes and redirect to own account, switching to viewId when viewing others.
+- 2025-09-01: Ensured flavor actions create missing user records to avoid foreign key errors when inserting flavors.
+- 2025-09-01: Removed owner uid query parameters, ensured layout derives viewer from authenticated user, and fixed owner checks to allow flavor actions on one's own account.

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -5,6 +5,7 @@ import {
   createFlavor as createFlavorStore,
   updateFlavor as updateFlavorStore,
 } from '@/lib/flavors-store';
+import { ensureUser } from '@/lib/users';
 import { revalidatePath } from 'next/cache';
 import type { Flavor, FlavorInput } from '@/types/flavor';
 import { assertOwner } from '@/lib/profile';
@@ -57,11 +58,9 @@ function clamp(n: number) {
 
 export async function createFlavor(form: any): Promise<Flavor> {
   const session = await auth();
-  const userId = session?.user?.id;
-  if (!userId) {
-    throw new Error('Please sign in.');
-  }
-  await assertOwner(Number(userId));
+  const self = await ensureUser(session);
+  const userId = String(self.id);
+  await assertOwner(self.id);
   const flavor = await createFlavorStore(userId, sanitize(form));
   revalidatePath('/flavors');
   return flavor;
@@ -69,11 +68,9 @@ export async function createFlavor(form: any): Promise<Flavor> {
 
 export async function updateFlavor(id: string, form: any): Promise<Flavor> {
   const session = await auth();
-  const userId = session?.user?.id;
-  if (!userId) {
-    throw new Error('Please sign in.');
-  }
-  await assertOwner(Number(userId));
+  const self = await ensureUser(session);
+  const userId = String(self.id);
+  await assertOwner(self.id);
   const updated = await updateFlavorStore(userId, id, sanitize(form));
   if (!updated) {
     throw new Error('Not found');

--- a/app/(app)/flavors/page.tsx
+++ b/app/(app)/flavors/page.tsx
@@ -6,25 +6,18 @@ import { redirect } from 'next/navigation';
 
 export default async function FlavorsPage({
   params,
-  searchParams,
 }: {
   params?: { viewId?: string };
-  searchParams?: { uid?: string };
 }) {
   const session = await auth();
   if (!session) redirect('/');
-  const viewerId = Number((session.user as any)?.id);
-  let ownerId = viewerId;
+  const self = await ensureUser(session);
+  let ownerId = self.id;
   if (params?.viewId) {
     const user = await getUserByViewId(params.viewId);
     if (!user) redirect('/');
     ownerId = user.id;
-  } else {
-    const me = await ensureUser(session);
-    if (!searchParams?.uid || Number(searchParams.uid) !== me.id) {
-      redirect(`/flavors?uid=${me.id}`);
-    }
   }
-  const flavors = ownerId ? await listFlavors(String(ownerId)) : [];
+  const flavors = await listFlavors(String(ownerId));
   return <FlavorsClient userId={String(ownerId)} initialFlavors={flavors} />;
 }

--- a/app/(app)/ingredients/page.tsx
+++ b/app/(app)/ingredients/page.tsx
@@ -10,16 +10,9 @@ export function IngredientsHome() {
   );
 }
 
-export default async function IngredientsPage({
-  searchParams,
-}: {
-  searchParams: { uid?: string };
-}) {
+export default async function IngredientsPage() {
   const session = await auth();
   if (!session) redirect('/');
-  const me = await ensureUser(session);
-  if (!searchParams.uid || Number(searchParams.uid) !== me.id) {
-    redirect(`/ingredients?uid=${me.id}`);
-  }
+  await ensureUser(session);
   return <IngredientsHome />;
 }

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -17,25 +17,24 @@ export default async function AppLayout({
   if (!session) {
     redirect('/');
   }
+  const self = await ensureUser(session);
   const { viewId } = await params;
-  const viewerId = Number(session.user.id);
 
   let ctx;
   if (viewId) {
     const user = await getUserByViewId(viewId);
     if (!user) notFound();
     const allowed = await canViewProfile({
-      viewerId,
+      viewerId: self.id,
       targetUser: {
         id: user.id,
         accountVisibility: user.accountVisibility as any,
       },
     });
     if (!allowed) notFound();
-    ctx = buildViewContext(user.id, viewerId, viewId);
+    ctx = buildViewContext(user.id, self.id, viewId);
   } else {
-    const me = await ensureUser(session);
-    ctx = buildViewContext(me.id, viewerId, me.viewId);
+    ctx = buildViewContext(self.id, self.id, self.viewId);
   }
 
   return (

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -12,17 +12,9 @@ export function CakeHome() {
   );
 }
 
-export default async function DashboardPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ uid?: string }>;
-}) {
+export default async function DashboardPage() {
   const session = await auth();
   if (!session) redirect('/');
-  const me = await ensureUser(session);
-  const { uid } = await searchParams;
-  if (!uid || Number(uid) !== me.id) {
-    redirect(`/?uid=${me.id}`);
-  }
+  await ensureUser(session);
   return <CakeHome />;
 }

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -3,16 +3,11 @@ import { follows, users } from '@/lib/db/schema';
 import { auth } from '@/lib/auth';
 import { followRequest, unfollow, cancelFollowRequest } from './actions';
 import { ensureUser } from '@/lib/users';
-import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { eq, ne } from 'drizzle-orm';
 import { Button } from '@/components/ui/button';
 
-export default async function PeoplePage({
-  searchParams,
-}: {
-  searchParams?: { uid?: string };
-}) {
+export default async function PeoplePage() {
   const session = await auth();
   if (!session?.user?.email) {
     return (
@@ -23,9 +18,6 @@ export default async function PeoplePage({
     );
   }
   const self = await ensureUser(session);
-  if (!searchParams?.uid || Number(searchParams.uid) !== self.id) {
-    redirect(`/people?uid=${self.id}`);
-  }
   const me = self.id;
 
   type DBUser = {

--- a/app/(app)/planning/page.tsx
+++ b/app/(app)/planning/page.tsx
@@ -10,16 +10,9 @@ export function PlanningHome() {
   );
 }
 
-export default async function PlanningPage({
-  searchParams,
-}: {
-  searchParams: { uid?: string };
-}) {
+export default async function PlanningPage() {
   const session = await auth();
   if (!session) redirect('/');
-  const me = await ensureUser(session);
-  if (!searchParams.uid || Number(searchParams.uid) !== me.id) {
-    redirect(`/planning?uid=${me.id}`);
-  }
+  await ensureUser(session);
   return <PlanningHome />;
 }

--- a/app/(app)/review/page.tsx
+++ b/app/(app)/review/page.tsx
@@ -10,16 +10,9 @@ export function ReviewHome() {
   );
 }
 
-export default async function ReviewPage({
-  searchParams,
-}: {
-  searchParams: { uid?: string };
-}) {
+export default async function ReviewPage() {
   const session = await auth();
   if (!session) redirect('/');
-  const me = await ensureUser(session);
-  if (!searchParams.uid || Number(searchParams.uid) !== me.id) {
-    redirect(`/review?uid=${me.id}`);
-  }
+  await ensureUser(session);
   return <ReviewHome />;
 }

--- a/app/(app)/visibility/page.tsx
+++ b/app/(app)/visibility/page.tsx
@@ -2,17 +2,10 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { redirect } from 'next/navigation';
 
-export default async function VisibilityPage({
-  searchParams,
-}: {
-  searchParams: { uid?: string };
-}) {
+export default async function VisibilityPage() {
   const session = await auth();
   if (!session) redirect('/');
-  const me = await ensureUser(session);
-  if (!searchParams.uid || Number(searchParams.uid) !== me.id) {
-    redirect(`/visibility?uid=${me.id}`);
-  }
+  await ensureUser(session);
   return (
     <section>
       <h1 className="text-2xl font-bold">Visibility</h1>

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -11,10 +11,5 @@ export type Section =
 
 export function getSectionHref(section: Section, ctx: ViewContext): string {
   const base = ctx.mode === 'viewer' && ctx.viewId ? `/view/${ctx.viewId}` : '';
-  const path = section === 'cake' ? (base || '/') : `${base}/${section}`;
-  if (ctx.mode === 'owner') {
-    const sep = path.includes('?') ? '&' : '?';
-    return `${path}${sep}uid=${ctx.ownerId}`;
-  }
-  return path;
+  return section === 'cake' ? (base || '/') : `${base}/${section}`;
 }

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -2,6 +2,7 @@ import { db } from './db';
 import { follows } from './db/schema';
 import { eq, and } from 'drizzle-orm';
 import { auth } from './auth';
+import { ensureUser } from './users';
 
 export interface ViewContext {
   ownerId: number;
@@ -52,8 +53,8 @@ export async function canViewProfile({
 
 export async function assertOwner(ownerId: number) {
   const session = await auth();
-  const me = Number(session?.user?.id);
-  if (me !== ownerId) {
+  const self = await ensureUser(session);
+  if (self.id !== ownerId) {
     throw new Error("Read-only: you cannot edit another user's account.");
   }
 }


### PR DESCRIPTION
## Summary
- remove `uid` query parameters from owner pages and navigation
- derive viewer context and owner checks from authenticated user to avoid unintended view mode
- keep assertOwner in sync with ensured user records

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f30b9f18832a91929103ae0535e9