### PR TITLE
Refactor view context to be route-driven

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -46,3 +46,4 @@
 - 2025-08-31: Added userId query parameter to owner routes and redirect to own account, switching to viewId when viewing others.
 - 2025-09-01: Ensured flavor actions create missing user records to avoid foreign key errors when inserting flavors.
 - 2025-09-01: Fixed view context to default to the current user, added viewer check helper, and awaited People page search params to silence runtime warnings.
+- 2025-09-01: Reworked view context to be route-driven, split owner/viewer layouts, enforced owner checks, and cleaned navigation/viewer bar logic.

--- a/app/(app)/flavors/[flavorId]/subflavors/actions.ts
+++ b/app/(app)/flavors/[flavorId]/subflavors/actions.ts
@@ -65,7 +65,7 @@ export async function createSubflavor(
   if (!userId) {
     throw new Error('Please sign in.');
   }
-  assertOwner(Number(userId), Number(userId));
+  await assertOwner(Number(userId));
   const subflavor = await createSubflavorStore(
     userId,
     flavorId,
@@ -85,7 +85,7 @@ export async function updateSubflavor(
   if (!userId) {
     throw new Error('Please sign in.');
   }
-  assertOwner(Number(userId), Number(userId));
+  await assertOwner(Number(userId));
   const updated = await updateSubflavorStore(userId, id, sanitize(form));
   if (!updated) {
     throw new Error('Not found');

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -60,7 +60,7 @@ export async function createFlavor(form: any): Promise<Flavor> {
   const session = await auth();
   const self = await ensureUser(session);
   const userId = String(self.id);
-  assertOwner(self.id, self.id);
+  await assertOwner(self.id);
   const flavor = await createFlavorStore(userId, sanitize(form));
   revalidatePath('/flavors');
   return flavor;
@@ -70,7 +70,7 @@ export async function updateFlavor(id: string, form: any): Promise<Flavor> {
   const session = await auth();
   const self = await ensureUser(session);
   const userId = String(self.id);
-  assertOwner(self.id, self.id);
+  await assertOwner(self.id);
   const updated = await updateFlavorStore(userId, id, sanitize(form));
   if (!updated) {
     throw new Error('Not found');

--- a/app/(app)/flavors/page.tsx
+++ b/app/(app)/flavors/page.tsx
@@ -1,30 +1,13 @@
 import { auth } from '@/lib/auth';
 import { listFlavors } from '@/lib/flavors-store';
 import FlavorsClient from './client';
-import { getUserByViewId, ensureUser } from '@/lib/users';
+import { ensureUser } from '@/lib/users';
 import { redirect } from 'next/navigation';
 
-export default async function FlavorsPage({
-  params,
-  searchParams,
-}: {
-  params?: { viewId?: string };
-  searchParams?: { uid?: string };
-}) {
+export default async function FlavorsPage() {
   const session = await auth();
   if (!session) redirect('/');
-  const viewerId = Number((session.user as any)?.id);
-  let ownerId = viewerId;
-  if (params?.viewId) {
-    const user = await getUserByViewId(params.viewId);
-    if (!user) redirect('/');
-    ownerId = user.id;
-  } else {
-    const me = await ensureUser(session);
-    if (!searchParams?.uid || Number(searchParams.uid) !== me.id) {
-      redirect(`/flavors?uid=${me.id}`);
-    }
-  }
-  const flavors = ownerId ? await listFlavors(String(ownerId)) : [];
-  return <FlavorsClient userId={String(ownerId)} initialFlavors={flavors} />;
+  const me = await ensureUser(session);
+  const flavors = await listFlavors(String(me.id));
+  return <FlavorsClient userId={String(me.id)} initialFlavors={flavors} />;
 }

--- a/app/(app)/ingredients/page.tsx
+++ b/app/(app)/ingredients/page.tsx
@@ -10,16 +10,9 @@ export function IngredientsHome() {
   );
 }
 
-export default async function IngredientsPage({
-  searchParams,
-}: {
-  searchParams: { uid?: string };
-}) {
+export default async function IngredientsPage() {
   const session = await auth();
   if (!session) redirect('/');
-  const me = await ensureUser(session);
-  if (!searchParams.uid || Number(searchParams.uid) !== me.id) {
-    redirect(`/ingredients?uid=${me.id}`);
-  }
+  await ensureUser(session);
   return <IngredientsHome />;
 }

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,48 +1,22 @@
-import { redirect, notFound } from 'next/navigation';
+import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth';
-import { ensureUser, getUserByViewId } from '@/lib/users';
-import { buildViewContext, canViewProfile } from '@/lib/profile';
+import { ensureUser } from '@/lib/users';
+import { buildViewContext } from '@/lib/profile';
 import { ViewContextProvider } from '@/lib/view-context';
 import { AppNav } from '@/components/app-nav';
-import { ViewerBar } from '@/components/viewer-bar';
 
 export default async function AppLayout({
   children,
-  params,
 }: {
   children: React.ReactNode;
-  params: Promise<{ viewId?: string }>;
 }) {
   const session = await auth();
-  if (!session) {
-    redirect('/');
+  if (!session) redirect('/');
+  const me = await ensureUser(session);
+  const ctx = buildViewContext('owner', me.id, me.id);
+  if (process.env.NODE_ENV !== 'production') {
+    console.log({ pathname: '/', mode: ctx.mode, ownerId: ctx.ownerId, viewerId: ctx.viewerId });
   }
-  const { viewId } = await params;
-  let viewerId = Number(session.user.id);
-  let self;
-  if (Number.isNaN(viewerId)) {
-    self = await ensureUser(session);
-    viewerId = self.id;
-  }
-
-  let ctx;
-  if (viewId) {
-    const user = await getUserByViewId(viewId);
-    if (!user) notFound();
-    const allowed = await canViewProfile({
-      viewerId,
-      targetUser: {
-        id: user.id,
-        accountVisibility: user.accountVisibility as any,
-      },
-    });
-    if (!allowed) notFound();
-    ctx = buildViewContext(user.id, viewerId, viewId);
-  } else {
-    const me = self ?? (await ensureUser(session));
-    ctx = buildViewContext(me.id, viewerId, me.viewId);
-  }
-
   return (
     <html lang="en">
       <body>
@@ -51,7 +25,6 @@ export default async function AppLayout({
           <main className="p-4">
             <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId || 0}`}>{children}</div>
           </main>
-          {ctx.mode === 'viewer' && <ViewerBar />}
         </ViewContextProvider>
       </body>
     </html>

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -12,17 +12,9 @@ export function CakeHome() {
   );
 }
 
-export default async function DashboardPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ uid?: string }>;
-}) {
+export default async function DashboardPage() {
   const session = await auth();
   if (!session) redirect('/');
-  const me = await ensureUser(session);
-  const { uid } = await searchParams;
-  if (!uid || Number(uid) !== me.id) {
-    redirect(`/?uid=${me.id}`);
-  }
+  await ensureUser(session);
   return <CakeHome />;
 }

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -15,7 +15,7 @@ export async function followRequest(
   const session = await auth();
   const self = await ensureUser(session);
   const me = self.id;
-  assertOwner(me, me);
+  await assertOwner(me);
   if (me === targetId) throw new Error('Cannot follow yourself.');
 
   const [target] = await db
@@ -69,7 +69,7 @@ export async function cancelFollowRequest(
   const session = await auth();
   const self = await ensureUser(session);
   const me = self.id;
-  assertOwner(me, me);
+  await assertOwner(me);
   await db
     .delete(follows)
     .where(
@@ -90,7 +90,7 @@ export async function acceptFollowRequest(
   const session = await auth();
   const self = await ensureUser(session);
   const me = self.id;
-  assertOwner(me, me);
+  await assertOwner(me);
   const [req] = await db
     .select()
     .from(follows)
@@ -118,7 +118,7 @@ export async function unfollow(
   const session = await auth();
   const self = await ensureUser(session);
   const me = self.id;
-  assertOwner(me, me);
+  await assertOwner(me);
   await db
     .delete(follows)
     .where(and(eq(follows.followerId, me), eq(follows.followingId, targetId)));
@@ -139,7 +139,7 @@ export async function declineFollowRequest(
   const session = await auth();
   const self = await ensureUser(session);
   const me = self.id;
-  assertOwner(me, me);
+  await assertOwner(me);
   await db
     .delete(follows)
     .where(

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -3,7 +3,6 @@ import { follows, users } from '@/lib/db/schema';
 import { auth } from '@/lib/auth';
 import { followRequest, unfollow, cancelFollowRequest } from './actions';
 import { ensureUser } from '@/lib/users';
-import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { eq, ne } from 'drizzle-orm';
 import { Button } from '@/components/ui/button';
@@ -11,9 +10,9 @@ import { Button } from '@/components/ui/button';
 export default async function PeoplePage({
   searchParams,
 }: {
-  searchParams: Promise<{ uid?: string }>;
+  searchParams?: Promise<{ uid?: string }>;
 }) {
-  const params = await searchParams;
+  const params = (await searchParams) || {};
   const session = await auth();
   if (!session?.user?.email) {
     return (
@@ -24,10 +23,9 @@ export default async function PeoplePage({
     );
   }
   const self = await ensureUser(session);
-  if (!params?.uid || Number(params.uid) !== self.id) {
-    redirect(`/people?uid=${self.id}`);
-  }
-  const me = self.id;
+  const viewerId = self.id;
+  const ownerId = params.uid ? Number(params.uid) : viewerId;
+  const me = ownerId;
 
   type DBUser = {
     id: number;
@@ -90,15 +88,15 @@ export default async function PeoplePage({
       </div>
       <div>
         <h2 className="text-xl font-semibold mb-2">Friends</h2>
-        <UserList viewerId={me} users={friends} relation="friend" />
+        <UserList viewerId={viewerId} users={friends} relation="friend" />
       </div>
       <div>
         <h2 className="text-xl font-semibold mb-2">Following</h2>
-        <UserList viewerId={me} users={following} relation="following" />
+        <UserList viewerId={viewerId} users={following} relation="following" />
       </div>
       <div>
         <h2 className="text-xl font-semibold mb-2">Discover</h2>
-        <UserList viewerId={me} users={discover} relation="discover" />
+        <UserList viewerId={viewerId} users={discover} relation="discover" />
       </div>
     </section>
   );
@@ -184,6 +182,7 @@ function UserAction({
             <Link
               id={`p30pl3-view-${user.id}-${viewerId}`}
               href={`/view/${user.viewId}`}
+              onClick={() => console.log(`/view/${user.viewId}`)}
               className="text-sm underline"
               aria-label={`View @${user.handle}'s account (read-only)`}
             >
@@ -205,6 +204,7 @@ function UserAction({
               <Link
                 id={`p30pl3-view-${user.id}-${viewerId}`}
                 href={`/view/${user.viewId}`}
+                onClick={() => console.log(`/view/${user.viewId}`)}
                 className="text-sm underline"
                 aria-label={`View @${user.handle}'s account (read-only)`}
               >
@@ -227,6 +227,7 @@ function UserAction({
             <Link
               id={`p30pl3-view-${user.id}-${viewerId}`}
               href={`/view/${user.viewId}`}
+              onClick={() => console.log(`/view/${user.viewId}`)}
               className="text-sm underline"
               aria-label={`View @${user.handle}'s account (read-only)`}
             >

--- a/app/(app)/planning/page.tsx
+++ b/app/(app)/planning/page.tsx
@@ -10,16 +10,9 @@ export function PlanningHome() {
   );
 }
 
-export default async function PlanningPage({
-  searchParams,
-}: {
-  searchParams: { uid?: string };
-}) {
+export default async function PlanningPage() {
   const session = await auth();
   if (!session) redirect('/');
-  const me = await ensureUser(session);
-  if (!searchParams.uid || Number(searchParams.uid) !== me.id) {
-    redirect(`/planning?uid=${me.id}`);
-  }
+  await ensureUser(session);
   return <PlanningHome />;
 }

--- a/app/(app)/review/page.tsx
+++ b/app/(app)/review/page.tsx
@@ -10,16 +10,9 @@ export function ReviewHome() {
   );
 }
 
-export default async function ReviewPage({
-  searchParams,
-}: {
-  searchParams: { uid?: string };
-}) {
+export default async function ReviewPage() {
   const session = await auth();
   if (!session) redirect('/');
-  const me = await ensureUser(session);
-  if (!searchParams.uid || Number(searchParams.uid) !== me.id) {
-    redirect(`/review?uid=${me.id}`);
-  }
+  await ensureUser(session);
   return <ReviewHome />;
 }

--- a/app/(app)/view/[viewId]/flavors/page.tsx
+++ b/app/(app)/view/[viewId]/flavors/page.tsx
@@ -1,6 +1,7 @@
 import { getUserByViewId } from '@/lib/users';
 import { notFound } from 'next/navigation';
-import FlavorsPage from '../../../flavors/page';
+import { listFlavors } from '@/lib/flavors-store';
+import FlavorsClient from '../../../flavors/client';
 
 export default async function ViewFlavorsPage({
   params,
@@ -10,9 +11,10 @@ export default async function ViewFlavorsPage({
   const { viewId } = await params;
   const user = await getUserByViewId(viewId);
   if (!user) notFound();
+  const flavors = await listFlavors(String(user.id));
   return (
     <section id={`v13w-flav-${user.id}`}>
-      <FlavorsPage params={{ viewId }} />
+      <FlavorsClient userId={String(user.id)} initialFlavors={flavors} />
     </section>
   );
 }

--- a/app/(app)/view/[viewId]/layout.tsx
+++ b/app/(app)/view/[viewId]/layout.tsx
@@ -1,0 +1,43 @@
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { getUserByViewId } from '@/lib/users';
+import { buildViewContext, canViewProfile } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { AppNav } from '@/components/app-nav';
+import { ViewerBar } from '@/components/viewer-bar';
+
+export default async function ViewLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ viewId: string }>;
+}) {
+  const session = await auth();
+  const { viewId } = await params;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const viewerId = session?.user?.id ? Number(session.user.id) : null;
+  const allowed = await canViewProfile({
+    viewerId,
+    targetUser: { id: user.id, accountVisibility: user.accountVisibility as any },
+  });
+  if (!allowed) notFound();
+  const ctx = buildViewContext('viewer', user.id, viewerId, viewId);
+  if (process.env.NODE_ENV !== 'production') {
+    console.log({ pathname: `/view/${viewId}`, mode: ctx.mode, ownerId: ctx.ownerId, viewerId: ctx.viewerId, viewId });
+  }
+  return (
+    <html lang="en">
+      <body>
+        <ViewContextProvider value={ctx}>
+          <AppNav />
+          <main className="p-4">
+            <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId || 0}`}>{children}</div>
+          </main>
+          <ViewerBar />
+        </ViewContextProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/(app)/visibility/page.tsx
+++ b/app/(app)/visibility/page.tsx
@@ -2,17 +2,10 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { redirect } from 'next/navigation';
 
-export default async function VisibilityPage({
-  searchParams,
-}: {
-  searchParams: { uid?: string };
-}) {
+export default async function VisibilityPage() {
   const session = await auth();
   if (!session) redirect('/');
-  const me = await ensureUser(session);
-  if (!searchParams.uid || Number(searchParams.uid) !== me.id) {
-    redirect(`/visibility?uid=${me.id}`);
-  }
+  await ensureUser(session);
   return (
     <section>
       <h1 className="text-2xl font-bold">Visibility</h1>

--- a/components/viewer-bar.tsx
+++ b/components/viewer-bar.tsx
@@ -13,17 +13,21 @@ export function ViewerBar() {
       className="fixed bottom-4 left-4 z-40 rounded-md bg-black/30 px-3 py-2 text-sm text-white backdrop-blur-sm shadow-sm dark:bg-white/40 dark:text-black"
     >
       <span className="flex items-center gap-2">
-        Viewing
+        Viewing (live)
         <span
           id={`v13wbar-live-${ctx.ownerId}-${ctx.viewerId || 0}`}
           aria-label="live"
           className="h-2 w-2 rounded-full bg-green-500"
         />
+        •
         <button
           id={`v13wbar-exit-${ctx.ownerId}-${ctx.viewerId || 0}`}
-          onClick={() => router.push('/')}
+          onClick={() => {
+            if (window.history.length > 1) router.back();
+            else router.push('/');
+          }}
           aria-label="Exit viewing and return to my account"
-          className="ml-2 underline"
+          className="underline"
         >
           Exit
         </button>

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -10,11 +10,9 @@ export type Section =
   | 'visibility';
 
 export function getSectionHref(section: Section, ctx: ViewContext): string {
-  const base = ctx.mode === 'viewer' && ctx.viewId ? `/view/${ctx.viewId}` : '';
-  const path = section === 'cake' ? (base || '/') : `${base}/${section}`;
-  if (ctx.mode === 'owner') {
-    const sep = path.includes('?') ? '&' : '?';
-    return `${path}${sep}uid=${ctx.ownerId}`;
+  if (ctx.mode === 'viewer') {
+    const base = `/view/${ctx.viewId}`;
+    return section === 'cake' ? base : `${base}/${section}`;
   }
-  return path;
+  return section === 'cake' ? '/' : `/${section}`;
 }

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -12,11 +12,11 @@ export interface ViewContext {
 }
 
 export function buildViewContext(
+  mode: 'owner' | 'viewer',
   ownerId: number,
   viewerId: number | null,
   viewId?: string,
 ): ViewContext {
-  const mode = viewerId === ownerId ? 'owner' : 'viewer';
   return { ownerId, viewerId, viewId, mode, editable: mode === 'owner' };
 }
 
@@ -50,8 +50,9 @@ export async function canViewProfile({
   }
 }
 
-export function assertOwner(viewerId: number, ownerId: number) {
-  if (viewerId !== ownerId) {
-    throw new Error("Read-only: you cannot edit another user's account.");
+export async function assertOwner(ownerId: number) {
+  const me = Number((await auth())?.user?.id);
+  if (me !== ownerId) {
+    throw new Error("Read-only: cannot edit another user's account.");
   }
 }


### PR DESCRIPTION
## Summary
- Split owner and viewer layouts so the URL alone chooses mode
- Add server-side ownership assertion helper and use ctx.ownerId for reads
- Clean up navigation/viewer bar and log "View Account" links

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fc11bda4832a8dab7c41ebfa6da8