### PR TITLE
fix: decouple view mode from session user

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -46,3 +46,5 @@
 - 2025-08-31: Added userId query parameter to owner routes and redirect to own account, switching to viewId when viewing others.
 - 2025-09-01: Ensured flavor actions create missing user records to avoid foreign key errors when inserting flavors.
 - 2025-09-01: Fixed view context to default to the current user, added viewer check helper, and awaited People page search params to silence runtime warnings.
+- 2025-09-02: Bound owner vs viewer mode to route prefix, added auth-based assertOwner helper, removed uid query params, and scoped People and navigation reads by ownerId.
+- 2025-09-02: Introduced hrefFor helper to keep viewer mode across navigation and added persistent viewer bar with smarter exit behavior.

--- a/app/(app)/flavors/[flavorId]/subflavors/page.tsx
+++ b/app/(app)/flavors/[flavorId]/subflavors/page.tsx
@@ -1,6 +1,8 @@
 import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
 import { listSubflavors } from '@/lib/subflavors-store';
 import SubflavorsClient from './client';
+import { redirect } from 'next/navigation';
 
 export default async function SubflavorsPage({
   params,
@@ -8,10 +10,10 @@ export default async function SubflavorsPage({
   params: { flavorId: string };
 }) {
   const session = await auth();
-  const userId = (session?.user as any)?.id || '';
-  const subflavors = userId
-    ? await listSubflavors(userId, params.flavorId)
-    : [];
+  if (!session) redirect('/');
+  const me = await ensureUser(session);
+  const userId = String(me.id);
+  const subflavors = await listSubflavors(userId, params.flavorId);
   return (
     <SubflavorsClient
       userId={userId}

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -59,9 +59,8 @@ function clamp(n: number) {
 export async function createFlavor(form: any): Promise<Flavor> {
   const session = await auth();
   const self = await ensureUser(session);
-  const userId = String(self.id);
-  assertOwner(self.id, self.id);
-  const flavor = await createFlavorStore(userId, sanitize(form));
+  await assertOwner(self.id);
+  const flavor = await createFlavorStore(String(self.id), sanitize(form));
   revalidatePath('/flavors');
   return flavor;
 }
@@ -69,9 +68,12 @@ export async function createFlavor(form: any): Promise<Flavor> {
 export async function updateFlavor(id: string, form: any): Promise<Flavor> {
   const session = await auth();
   const self = await ensureUser(session);
-  const userId = String(self.id);
-  assertOwner(self.id, self.id);
-  const updated = await updateFlavorStore(userId, id, sanitize(form));
+  await assertOwner(self.id);
+  const updated = await updateFlavorStore(
+    String(self.id),
+    id,
+    sanitize(form),
+  );
   if (!updated) {
     throw new Error('Not found');
   }

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { useViewContext } from '@/lib/view-context';
+import { hrefFor } from '@/lib/navigation';
 import type { Flavor, Visibility } from '@/types/flavor';
 import { createFlavor, updateFlavor } from './actions';
 
@@ -48,6 +50,7 @@ export default function FlavorsClient({
   initialFlavors: Flavor[];
 }) {
   const router = useRouter();
+  const ctx = useViewContext();
   const [flavors, setFlavors] = useState<Flavor[]>(sortFlavors(initialFlavors));
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<Flavor | null>(null);
@@ -254,7 +257,7 @@ export default function FlavorsClient({
                 className="mt-2 text-xs text-blue-600 underline"
                 onClick={(e) => {
                   e.stopPropagation();
-                  router.push(`/flavors/${f.id}/subflavors`);
+                  router.push(hrefFor(`/flavors/${f.id}/subflavors`, ctx));
                 }}
               >
                 View Subflavors

--- a/app/(app)/flavors/page.tsx
+++ b/app/(app)/flavors/page.tsx
@@ -1,30 +1,26 @@
+import { notFound } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { listFlavors } from '@/lib/flavors-store';
 import FlavorsClient from './client';
 import { getUserByViewId, ensureUser } from '@/lib/users';
-import { redirect } from 'next/navigation';
 
 export default async function FlavorsPage({
   params,
-  searchParams,
 }: {
   params?: { viewId?: string };
-  searchParams?: { uid?: string };
 }) {
   const session = await auth();
-  if (!session) redirect('/');
+  if (!session) notFound();
   const viewerId = Number((session.user as any)?.id);
   let ownerId = viewerId;
   if (params?.viewId) {
     const user = await getUserByViewId(params.viewId);
-    if (!user) redirect('/');
+    if (!user) notFound();
     ownerId = user.id;
   } else {
     const me = await ensureUser(session);
-    if (!searchParams?.uid || Number(searchParams.uid) !== me.id) {
-      redirect(`/flavors?uid=${me.id}`);
-    }
+    ownerId = me.id;
   }
-  const flavors = ownerId ? await listFlavors(String(ownerId)) : [];
+  const flavors = await listFlavors(String(ownerId));
   return <FlavorsClient userId={String(ownerId)} initialFlavors={flavors} />;
 }

--- a/app/(app)/ingredients/page.tsx
+++ b/app/(app)/ingredients/page.tsx
@@ -1,7 +1,3 @@
-import { auth } from '@/lib/auth';
-import { ensureUser } from '@/lib/users';
-import { redirect } from 'next/navigation';
-
 export function IngredientsHome() {
   return (
     <section>
@@ -10,16 +6,6 @@ export function IngredientsHome() {
   );
 }
 
-export default async function IngredientsPage({
-  searchParams,
-}: {
-  searchParams: { uid?: string };
-}) {
-  const session = await auth();
-  if (!session) redirect('/');
-  const me = await ensureUser(session);
-  if (!searchParams.uid || Number(searchParams.uid) !== me.id) {
-    redirect(`/ingredients?uid=${me.id}`);
-  }
+export default function IngredientsPage() {
   return <IngredientsHome />;
 }

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -37,10 +37,20 @@ export default async function AppLayout({
       },
     });
     if (!allowed) notFound();
-    ctx = buildViewContext(user.id, viewerId, viewId);
+    ctx = buildViewContext({
+      ownerId: user.id,
+      viewerId,
+      mode: 'viewer',
+      viewId,
+    });
   } else {
     const me = self ?? (await ensureUser(session));
-    ctx = buildViewContext(me.id, viewerId, me.viewId);
+    ctx = buildViewContext({
+      ownerId: me.id,
+      viewerId,
+      mode: 'owner',
+      viewId: me.viewId,
+    });
   }
 
   return (

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,7 +1,4 @@
 import { CakeNavigation } from '@/components/cake/cake-navigation';
-import { auth } from '@/lib/auth';
-import { ensureUser } from '@/lib/users';
-import { redirect } from 'next/navigation';
 
 export function CakeHome() {
   return (
@@ -12,17 +9,6 @@ export function CakeHome() {
   );
 }
 
-export default async function DashboardPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ uid?: string }>;
-}) {
-  const session = await auth();
-  if (!session) redirect('/');
-  const me = await ensureUser(session);
-  const { uid } = await searchParams;
-  if (!uid || Number(uid) !== me.id) {
-    redirect(`/?uid=${me.id}`);
-  }
+export default function DashboardPage() {
   return <CakeHome />;
 }

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -14,8 +14,8 @@ export async function followRequest(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
+  await assertOwner(self.id);
   const me = self.id;
-  assertOwner(me, me);
   if (me === targetId) throw new Error('Cannot follow yourself.');
 
   const [target] = await db
@@ -68,8 +68,8 @@ export async function cancelFollowRequest(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
+  await assertOwner(self.id);
   const me = self.id;
-  assertOwner(me, me);
   await db
     .delete(follows)
     .where(
@@ -89,8 +89,8 @@ export async function acceptFollowRequest(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
+  await assertOwner(self.id);
   const me = self.id;
-  assertOwner(me, me);
   const [req] = await db
     .select()
     .from(follows)
@@ -117,8 +117,8 @@ export async function unfollow(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
+  await assertOwner(self.id);
   const me = self.id;
-  assertOwner(me, me);
   await db
     .delete(follows)
     .where(and(eq(follows.followerId, me), eq(follows.followingId, targetId)));
@@ -138,8 +138,8 @@ export async function declineFollowRequest(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
+  await assertOwner(self.id);
   const me = self.id;
-  assertOwner(me, me);
   await db
     .delete(follows)
     .where(

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -2,18 +2,19 @@ import { db } from '@/lib/db';
 import { follows, users } from '@/lib/db/schema';
 import { auth } from '@/lib/auth';
 import { followRequest, unfollow, cancelFollowRequest } from './actions';
-import { ensureUser } from '@/lib/users';
-import { redirect } from 'next/navigation';
+import { ensureUser, getUserByViewId } from '@/lib/users';
 import Link from 'next/link';
 import { eq, ne } from 'drizzle-orm';
 import { Button } from '@/components/ui/button';
+import { notFound } from 'next/navigation';
+import { hrefFor } from '@/lib/navigation';
+import { buildViewContext } from '@/lib/profile';
 
 export default async function PeoplePage({
-  searchParams,
+  params,
 }: {
-  searchParams: Promise<{ uid?: string }>;
+  params?: { viewId?: string };
 }) {
-  const params = await searchParams;
   const session = await auth();
   if (!session?.user?.email) {
     return (
@@ -23,11 +24,21 @@ export default async function PeoplePage({
       </section>
     );
   }
-  const self = await ensureUser(session);
-  if (!params?.uid || Number(params.uid) !== self.id) {
-    redirect(`/people?uid=${self.id}`);
+  const viewer = await ensureUser(session);
+  let owner = viewer;
+  if (params?.viewId) {
+    const user = await getUserByViewId(params.viewId);
+    if (!user) notFound();
+    owner = user;
   }
-  const me = self.id;
+  const ownerId = owner.id;
+  const viewerId = viewer.id;
+  const ctx = buildViewContext({
+    ownerId,
+    viewerId,
+    mode: ownerId === viewerId ? 'owner' : 'viewer',
+    viewId: owner.viewId,
+  });
 
   type DBUser = {
     id: number;
@@ -36,6 +47,7 @@ export default async function PeoplePage({
     accountVisibility: string;
     viewId: string;
   };
+
   const allUsers: DBUser[] = await db
     .select({
       id: users.id,
@@ -45,38 +57,59 @@ export default async function PeoplePage({
       viewId: users.viewId,
     })
     .from(users)
-    .where(ne(users.id, me));
+    .where(ne(users.id, ownerId));
 
-  const myFollows = await db
+  const ownerFollows = await db
     .select({ followingId: follows.followingId, status: follows.status })
     .from(follows)
-    .where(eq(follows.followerId, me));
+    .where(eq(follows.followerId, ownerId));
 
-  const inboundFollows = await db
+  const ownerInbound = await db
     .select({ followerId: follows.followerId, status: follows.status })
     .from(follows)
-    .where(eq(follows.followingId, me));
+    .where(eq(follows.followingId, ownerId));
 
-  const myMap = new Map(myFollows.map((f) => [f.followingId, f.status]));
-  const inboundMap = new Map(
-    inboundFollows.map((f) => [f.followerId, f.status]),
+  const ownerMap = new Map(ownerFollows.map((f) => [f.followingId, f.status]));
+  const ownerInboundMap = new Map(
+    ownerInbound.map((f) => [f.followerId, f.status]),
+  );
+
+  const viewerFollows = await db
+    .select({ followingId: follows.followingId, status: follows.status })
+    .from(follows)
+    .where(eq(follows.followerId, viewerId));
+
+  const viewerInbound = await db
+    .select({ followerId: follows.followerId, status: follows.status })
+    .from(follows)
+    .where(eq(follows.followingId, viewerId));
+
+  const viewerMap = new Map(
+    viewerFollows.map((f) => [f.followingId, f.status]),
+  );
+  const viewerInboundMap = new Map(
+    viewerInbound.map((f) => [f.followerId, f.status]),
   );
 
   const friends: UserInfo[] = [];
-  const following: (UserInfo & { status?: string })[] = [];
-  const discover: (UserInfo & { status?: string })[] = [];
+  const following: UserInfo[] = [];
+  const discover: UserInfo[] = [];
 
   for (const u of allUsers) {
     if (u.accountVisibility === 'private') continue;
-    const myStatus = myMap.get(u.id);
-    const theirStatus = inboundMap.get(u.id);
-    const canView = u.accountVisibility === 'open' || myStatus === 'accepted';
-    if (myStatus === 'accepted' && theirStatus === 'accepted') {
-      friends.push({ ...u, canView });
-    } else if (myStatus === 'accepted' || myStatus === 'pending') {
-      following.push({ ...u, status: myStatus, canView });
+    const ownerStatus = ownerMap.get(u.id);
+    const ownerInboundStatus = ownerInboundMap.get(u.id);
+    const viewerStatus = viewerMap.get(u.id);
+    const followsMe = viewerInboundMap.get(u.id) === 'accepted';
+    const canView =
+      u.accountVisibility === 'open' || viewerStatus === 'accepted';
+    const entry = { ...u, canView, viewerStatus, followsMe };
+    if (ownerStatus === 'accepted' && ownerInboundStatus === 'accepted') {
+      friends.push(entry);
+    } else if (ownerStatus === 'accepted' || ownerStatus === 'pending') {
+      following.push(entry);
     } else {
-      discover.push({ ...u, status: theirStatus, canView });
+      discover.push(entry);
     }
   }
 
@@ -84,21 +117,23 @@ export default async function PeoplePage({
     <section className="space-y-8">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">People</h1>
-        <Link href="/people/inbox" className="text-sm underline">
-          Inbox
-        </Link>
+        {ownerId === viewerId && (
+          <Link href={hrefFor('/people/inbox', ctx)} className="text-sm underline">
+            Inbox
+          </Link>
+        )}
       </div>
       <div>
         <h2 className="text-xl font-semibold mb-2">Friends</h2>
-        <UserList viewerId={me} users={friends} relation="friend" />
+        <UserList viewerId={viewerId} users={friends} />
       </div>
       <div>
         <h2 className="text-xl font-semibold mb-2">Following</h2>
-        <UserList viewerId={me} users={following} relation="following" />
+        <UserList viewerId={viewerId} users={following} />
       </div>
       <div>
         <h2 className="text-xl font-semibold mb-2">Discover</h2>
-        <UserList viewerId={me} users={discover} relation="discover" />
+        <UserList viewerId={viewerId} users={discover} />
       </div>
     </section>
   );
@@ -111,16 +146,16 @@ interface UserInfo {
   accountVisibility: string;
   viewId: string;
   canView: boolean;
+  viewerStatus?: string;
+  followsMe?: boolean;
 }
 
 function UserList({
   viewerId,
   users,
-  relation,
 }: {
   viewerId: number;
-  users: (UserInfo & { status?: string })[];
-  relation: 'friend' | 'following' | 'discover';
+  users: UserInfo[];
 }) {
   if (users.length === 0) {
     return <p className="text-sm text-muted-foreground">No users.</p>;
@@ -130,12 +165,12 @@ function UserList({
       {users.map((u) => (
         <li key={u.id} className="flex items-center justify-between py-2">
           <div>
-            <Link href={`/u/${u.handle}`} className="font-semibold">
+            <Link href={`/view/${u.viewId}`} className="font-semibold">
               {u.displayName ?? u.handle}
             </Link>
             <div className="text-sm text-muted-foreground">@{u.handle}</div>
           </div>
-          <UserAction viewerId={viewerId} user={u} relation={relation} />
+          <UserAction viewerId={viewerId} user={u} />
         </li>
       ))}
     </ul>
@@ -145,97 +180,81 @@ function UserList({
 function UserAction({
   viewerId,
   user,
-  relation,
 }: {
   viewerId: number;
-  user: UserInfo & { status?: string };
-  relation: 'friend' | 'following' | 'discover';
+  user: UserInfo;
 }) {
-  switch (relation) {
-    case 'friend':
-    case 'following':
-      if (user.status === 'pending') {
-        return (
-          <div className="flex gap-2">
-            <form action={cancelFollowRequest.bind(null, user.id)}>
-              <Button
-                id={`p30pl3-ccl-${user.id}-${viewerId}`}
-                variant="outline"
-                size="sm"
-              >
-                Requested
-              </Button>
-            </form>
-          </div>
-        );
-      }
-      return (
-        <div className="flex gap-2">
-          <form action={unfollow.bind(null, user.id)}>
-            <Button
-              id={`p30pl3-unf-${user.id}-${viewerId}`}
-              variant="outline"
-              size="sm"
-            >
-              Unfollow
-            </Button>
-          </form>
-          {user.canView && (
-            <Link
-              id={`p30pl3-view-${user.id}-${viewerId}`}
-              href={`/view/${user.viewId}`}
-              className="text-sm underline"
-              aria-label={`View @${user.handle}'s account (read-only)`}
-            >
-              View
-            </Link>
-          )}
-        </div>
-      );
-    case 'discover':
-      if (user.status === 'accepted') {
-        return (
-          <div className="flex gap-2">
-            <form action={followRequest.bind(null, user.id)}>
-              <Button id={`p30pl3-fol-${user.id}-${viewerId}`} size="sm">
-                Follow back
-              </Button>
-            </form>
-            {user.canView && (
-              <Link
-                id={`p30pl3-view-${user.id}-${viewerId}`}
-                href={`/view/${user.viewId}`}
-                className="text-sm underline"
-                aria-label={`View @${user.handle}'s account (read-only)`}
-              >
-                View
-              </Link>
-            )}
-          </div>
-        );
-      }
-      return (
-        <div className="flex gap-2">
-          <form action={followRequest.bind(null, user.id)}>
-            <Button id={`p30pl3-fol-${user.id}-${viewerId}`} size="sm">
-              {user.accountVisibility === 'open'
-                ? 'Follow'
-                : 'Request to follow'}
-            </Button>
-          </form>
-          {user.canView && (
-            <Link
-              id={`p30pl3-view-${user.id}-${viewerId}`}
-              href={`/view/${user.viewId}`}
-              className="text-sm underline"
-              aria-label={`View @${user.handle}'s account (read-only)`}
-            >
-              View
-            </Link>
-          )}
-        </div>
-      );
-    default:
-      return null;
+  if (user.viewerStatus === 'pending') {
+    return (
+      <div className="flex gap-2">
+        <form action={cancelFollowRequest.bind(null, user.id)}>
+          <Button
+            id={`p30pl3-ccl-${user.id}-${viewerId}`}
+            variant="outline"
+            size="sm"
+          >
+            Requested
+          </Button>
+        </form>
+        {user.canView && (
+          <Link
+            id={`p30pl3-view-${user.id}-${viewerId}`}
+            href={`/view/${user.viewId}`}
+            className="text-sm underline"
+            aria-label={`View @${user.handle}'s account (read-only)`}
+          >
+            View
+          </Link>
+        )}
+      </div>
+    );
   }
+  if (user.viewerStatus === 'accepted') {
+    return (
+      <div className="flex gap-2">
+        <form action={unfollow.bind(null, user.id)}>
+          <Button
+            id={`p30pl3-unf-${user.id}-${viewerId}`}
+            variant="outline"
+            size="sm"
+          >
+            Unfollow
+          </Button>
+        </form>
+        {user.canView && (
+          <Link
+            id={`p30pl3-view-${user.id}-${viewerId}`}
+            href={`/view/${user.viewId}`}
+            className="text-sm underline"
+            aria-label={`View @${user.handle}'s account (read-only)`}
+          >
+            View
+          </Link>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div className="flex gap-2">
+      <form action={followRequest.bind(null, user.id)}>
+        <Button id={`p30pl3-fol-${user.id}-${viewerId}`} size="sm">
+          {user.followsMe
+            ? 'Follow back'
+            : user.accountVisibility === 'open'
+            ? 'Follow'
+            : 'Request to follow'}
+        </Button>
+      </form>
+      {user.canView && (
+        <Link
+          id={`p30pl3-view-${user.id}-${viewerId}`}
+          href={`/view/${user.viewId}`}
+          className="text-sm underline"
+          aria-label={`View @${user.handle}'s account (read-only)`}
+        >
+          View
+        </Link>
+      )}
+    </div>
+  );
 }

--- a/app/(app)/planning/page.tsx
+++ b/app/(app)/planning/page.tsx
@@ -1,7 +1,3 @@
-import { auth } from '@/lib/auth';
-import { ensureUser } from '@/lib/users';
-import { redirect } from 'next/navigation';
-
 export function PlanningHome() {
   return (
     <section>
@@ -10,16 +6,6 @@ export function PlanningHome() {
   );
 }
 
-export default async function PlanningPage({
-  searchParams,
-}: {
-  searchParams: { uid?: string };
-}) {
-  const session = await auth();
-  if (!session) redirect('/');
-  const me = await ensureUser(session);
-  if (!searchParams.uid || Number(searchParams.uid) !== me.id) {
-    redirect(`/planning?uid=${me.id}`);
-  }
+export default function PlanningPage() {
   return <PlanningHome />;
 }

--- a/app/(app)/review/page.tsx
+++ b/app/(app)/review/page.tsx
@@ -1,7 +1,3 @@
-import { auth } from '@/lib/auth';
-import { ensureUser } from '@/lib/users';
-import { redirect } from 'next/navigation';
-
 export function ReviewHome() {
   return (
     <section>
@@ -10,16 +6,6 @@ export function ReviewHome() {
   );
 }
 
-export default async function ReviewPage({
-  searchParams,
-}: {
-  searchParams: { uid?: string };
-}) {
-  const session = await auth();
-  if (!session) redirect('/');
-  const me = await ensureUser(session);
-  if (!searchParams.uid || Number(searchParams.uid) !== me.id) {
-    redirect(`/review?uid=${me.id}`);
-  }
+export default function ReviewPage() {
   return <ReviewHome />;
 }

--- a/app/(app)/view/[viewId]/people/page.tsx
+++ b/app/(app)/view/[viewId]/people/page.tsx
@@ -12,7 +12,7 @@ export default async function ViewPeoplePage({
   if (!user) notFound();
   return (
     <section id={`v13w-peep-${user.id}`}>
-      <PeoplePage searchParams={Promise.resolve({ uid: String(user.id) })} />
+      <PeoplePage params={{ viewId }} />
     </section>
   );
 }

--- a/app/(app)/visibility/page.tsx
+++ b/app/(app)/visibility/page.tsx
@@ -1,18 +1,4 @@
-import { auth } from '@/lib/auth';
-import { ensureUser } from '@/lib/users';
-import { redirect } from 'next/navigation';
-
-export default async function VisibilityPage({
-  searchParams,
-}: {
-  searchParams: { uid?: string };
-}) {
-  const session = await auth();
-  if (!session) redirect('/');
-  const me = await ensureUser(session);
-  if (!searchParams.uid || Number(searchParams.uid) !== me.id) {
-    redirect(`/visibility?uid=${me.id}`);
-  }
+export default function VisibilityPage() {
   return (
     <section>
       <h1 className="text-2xl font-bold">Visibility</h1>

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -2,7 +2,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useViewContext } from '@/lib/view-context';
-import { getSectionHref, type Section } from '@/lib/navigation';
+import { hrefFor, type Section } from '@/lib/navigation';
 import { Button } from '@/components/ui/button';
 
 const labels: Record<Section, string> = {
@@ -27,7 +27,7 @@ export function AppNav() {
     <nav className="flex items-center justify-between border-b p-4">
       <ul className="flex gap-4">
         {sections.map((sec) => {
-          const href = getSectionHref(sec, ctx);
+          const href = hrefFor(sec, ctx);
           const active = pathname === href;
           return (
             <li key={sec}>

--- a/components/cake/cake-3d.tsx
+++ b/components/cake/cake-3d.tsx
@@ -4,7 +4,7 @@ import React, { CSSProperties, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { slices } from './slices';
 import { useViewContext } from '@/lib/view-context';
-import { getSectionHref, type Section } from '@/lib/navigation';
+import { hrefFor, type Section } from '@/lib/navigation';
 
 interface Cake3DProps {
   activeSlug: string | null;
@@ -99,12 +99,12 @@ export function Cake3D({
               role="link"
               tabIndex={0}
               onClick={() =>
-                router.push(getSectionHref(slice.slug as Section, ctx))
+                router.push(hrefFor(slice.slug as Section, ctx))
               }
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
-                  router.push(getSectionHref(slice.slug as Section, ctx));
+                  router.push(hrefFor(slice.slug as Section, ctx));
                 }
               }}
               onPointerEnter={() => onHover(slice.slug)}

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -6,7 +6,7 @@ import { slices } from './slices';
 import { Cake3D } from './cake-3d';
 import { SettingsButton } from './settings-button';
 import { useViewContext } from '@/lib/view-context';
-import { getSectionHref, type Section } from '@/lib/navigation';
+import { hrefFor, type Section } from '@/lib/navigation';
 
 export function CakeNavigation() {
   const router = useRouter();
@@ -134,9 +134,7 @@ export function CakeNavigation() {
                 data-popped={popped ? true : undefined}
                 aria-label={slice.label}
                 onClick={() =>
-                  router.push(
-                    getSectionHref(slice.slug as Section, ctx),
-                  )
+                  router.push(hrefFor(slice.slug as Section, ctx))
                 }
                 onMouseEnter={() => handleEnter(slice.slug)}
                 onMouseLeave={handleLeave}

--- a/components/cake/settings-button.tsx
+++ b/components/cake/settings-button.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useViewContext } from '@/lib/view-context';
+import { hrefFor } from '@/lib/navigation';
 import { signOut } from 'next-auth/react';
 
 function GearIcon(props: React.SVGProps<SVGSVGElement>) {
@@ -25,6 +27,7 @@ export function SettingsButton() {
   const [open, setOpen] = useState(false);
   const [dark, setDark] = useState(false);
   const [followers, setFollowers] = useState(0);
+  const ctx = useViewContext();
 
   useEffect(() => {
     const storedTheme = localStorage.getItem('color-mode');
@@ -82,7 +85,7 @@ export function SettingsButton() {
             />
           </div>
           <Link
-            href="/settings/account"
+            href={hrefFor('/settings/account', ctx)}
             className="mb-2 block rounded bg-[var(--surface)] px-3 py-1 text-center hover:bg-[var(--accent)] hover:text-white"
           >
             Account settings

--- a/components/viewer-bar.tsx
+++ b/components/viewer-bar.tsx
@@ -13,17 +13,33 @@ export function ViewerBar() {
       className="fixed bottom-4 left-4 z-40 rounded-md bg-black/30 px-3 py-2 text-sm text-white backdrop-blur-sm shadow-sm dark:bg-white/40 dark:text-black"
     >
       <span className="flex items-center gap-2">
-        Viewing
+        Viewing (live)
         <span
           id={`v13wbar-live-${ctx.ownerId}-${ctx.viewerId || 0}`}
           aria-label="live"
           className="h-2 w-2 rounded-full bg-green-500"
         />
+        &bull;
         <button
           id={`v13wbar-exit-${ctx.ownerId}-${ctx.viewerId || 0}`}
-          onClick={() => router.push('/')}
+          onClick={() => {
+            const ref = document.referrer;
+            if (ref) {
+              try {
+                const url = new URL(ref);
+                if (
+                  url.origin === window.location.origin &&
+                  !url.pathname.startsWith('/view')
+                ) {
+                  router.back();
+                  return;
+                }
+              } catch {}
+            }
+            router.push('/');
+          }}
           aria-label="Exit viewing and return to my account"
-          className="ml-2 underline"
+          className="underline"
         >
           Exit
         </button>

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -9,12 +9,50 @@ export type Section =
   | 'people'
   | 'visibility';
 
-export function getSectionHref(section: Section, ctx: ViewContext): string {
-  const base = ctx.mode === 'viewer' && ctx.viewId ? `/view/${ctx.viewId}` : '';
-  const path = section === 'cake' ? (base || '/') : `${base}/${section}`;
-  if (ctx.mode === 'owner') {
-    const sep = path.includes('?') ? '&' : '?';
-    return `${path}${sep}uid=${ctx.ownerId}`;
+export function hrefFor(
+  sectionOrPath: Section | string,
+  ctx: ViewContext,
+): string {
+  if (sectionOrPath.startsWith('/')) {
+    return ctx.mode === 'viewer'
+      ? `/view/${ctx.viewId}${sectionOrPath === '/' ? '' : sectionOrPath}`
+      : sectionOrPath;
   }
-  return path;
+  if (ctx.mode === 'viewer') {
+    const base = `/view/${ctx.viewId}`;
+    switch (sectionOrPath) {
+      case 'cake':
+      default:
+        return base;
+      case 'planning':
+        return `${base}/planning`;
+      case 'flavors':
+        return `${base}/flavors`;
+      case 'ingredients':
+        return `${base}/ingredients`;
+      case 'review':
+        return `${base}/review`;
+      case 'people':
+        return `${base}/people`;
+      case 'visibility':
+        return `${base}/visibility`;
+    }
+  }
+  switch (sectionOrPath) {
+    case 'cake':
+    default:
+      return '/';
+    case 'planning':
+      return '/planning';
+    case 'flavors':
+      return '/flavors';
+    case 'ingredients':
+      return '/ingredients';
+    case 'review':
+      return '/review';
+    case 'people':
+      return '/people';
+    case 'visibility':
+      return '/visibility';
+  }
 }

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -11,12 +11,17 @@ export interface ViewContext {
   editable: boolean;
 }
 
-export function buildViewContext(
-  ownerId: number,
-  viewerId: number | null,
-  viewId?: string,
-): ViewContext {
-  const mode = viewerId === ownerId ? 'owner' : 'viewer';
+export function buildViewContext({
+  ownerId,
+  viewerId,
+  mode,
+  viewId,
+}: {
+  ownerId: number;
+  viewerId: number | null;
+  mode: 'owner' | 'viewer';
+  viewId?: string;
+}): ViewContext {
   return { ownerId, viewerId, viewId, mode, editable: mode === 'owner' };
 }
 
@@ -50,8 +55,9 @@ export async function canViewProfile({
   }
 }
 
-export function assertOwner(viewerId: number, ownerId: number) {
-  if (viewerId !== ownerId) {
-    throw new Error("Read-only: you cannot edit another user's account.");
+export async function assertOwner(ownerId: number) {
+  const me = Number((await auth())?.user?.id);
+  if (me !== ownerId) {
+    throw new Error("Read-only: cannot edit another user's account.");
   }
 }

--- a/lib/view-context.tsx
+++ b/lib/view-context.tsx
@@ -5,6 +5,7 @@ import type { ViewContext } from './profile';
 const Ctx = createContext<ViewContext>({
   ownerId: 0,
   viewerId: null,
+  viewId: undefined,
   mode: 'owner',
   editable: true,
 });


### PR DESCRIPTION
## Summary
- keep viewer mode across navigation via unified `hrefFor` helper
- make People links and cake navigation respect view context
- add viewer bar exit guard that avoids bouncing between view routes

## Testing
- `pnpm lint`
- `pnpm exec tsc -p tsconfig.json --noEmit && echo 'type-check passed'`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fc11bda4832a8dab7c41ebfa6da8