### PR TITLE
fix: guard People view and bind flavor actions

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -50,3 +50,5 @@ Modal form IDs:
   - `v13wbar-{ownerId}-{viewerId}` → viewer bar root container.
   - `v13wbar-live-{ownerId}-{viewerId}` → live indicator dot.
   - `v13wbar-exit-{ownerId}-{viewerId}` → Exit button.
+  - `v13w-peep-block-{ownerId}-{viewerId}` → blocked People view page root.
+  - `v13w-peep-exit-{ownerId}-{viewerId}` → Exit button in blocked People view.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -49,3 +49,4 @@
 - 2025-09-02: Bound owner vs viewer mode to route prefix, added auth-based assertOwner helper, removed uid query params, and scoped People and navigation reads by ownerId.
 - 2025-09-03: Added hrefFor navigation helper so view mode persists across routes and logged viewer bar presence.
 - 2025-09-03: Split owner and viewer layouts with context-based routing, migrated view routes to their own group, and refined viewer bar exit behavior.
+- 2025-09-04: Blocked People access in view mode and bound flavor actions to server owner ID to prevent stale viewer context.

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -1,11 +1,9 @@
 'use server';
 
-import { auth } from '@/lib/auth';
 import {
   createFlavor as createFlavorStore,
   updateFlavor as updateFlavorStore,
 } from '@/lib/flavors-store';
-import { ensureUser } from '@/lib/users';
 import { revalidatePath } from 'next/cache';
 import type { Flavor, FlavorInput } from '@/types/flavor';
 import { assertOwner } from '@/lib/profile';
@@ -56,21 +54,27 @@ function clamp(n: number) {
   return Math.max(0, Math.min(100, Math.round(n)));
 }
 
-export async function createFlavor(form: any): Promise<Flavor> {
-  const session = await auth();
-  const self = await ensureUser(session);
-  await assertOwner(self.id);
-  const flavor = await createFlavorStore(String(self.id), sanitize(form));
+export async function createFlavor(
+  boundOwnerId: number,
+  form: any,
+): Promise<Flavor> {
+  await assertOwner(boundOwnerId);
+  const flavor = await createFlavorStore(
+    String(boundOwnerId),
+    sanitize(form),
+  );
   revalidatePath('/flavors');
   return flavor;
 }
 
-export async function updateFlavor(id: string, form: any): Promise<Flavor> {
-  const session = await auth();
-  const self = await ensureUser(session);
-  await assertOwner(self.id);
+export async function updateFlavor(
+  boundOwnerId: number,
+  id: string,
+  form: any,
+): Promise<Flavor> {
+  await assertOwner(boundOwnerId);
   const updated = await updateFlavorStore(
-    String(self.id),
+    String(boundOwnerId),
     id,
     sanitize(form),
   );

--- a/app/(app)/flavors/page.tsx
+++ b/app/(app)/flavors/page.tsx
@@ -3,6 +3,7 @@ import { auth } from '@/lib/auth';
 import { listFlavors } from '@/lib/flavors-store';
 import FlavorsClient from './client';
 import { getUserByViewId, ensureUser } from '@/lib/users';
+import { createFlavor, updateFlavor } from './actions';
 
 export default async function FlavorsPage({
   params,
@@ -22,5 +23,16 @@ export default async function FlavorsPage({
     ownerId = me.id;
   }
   const flavors = await listFlavors(String(ownerId));
-  return <FlavorsClient userId={String(ownerId)} initialFlavors={flavors} />;
+  const editable = ownerId === viewerId;
+  const createAction = createFlavor.bind(null, ownerId);
+  const updateAction = updateFlavor.bind(null, ownerId);
+  return (
+    <FlavorsClient
+      userId={String(ownerId)}
+      initialFlavors={flavors}
+      editable={editable}
+      createAction={editable ? createAction : undefined}
+      updateAction={editable ? updateAction : undefined}
+    />
+  );
 }

--- a/app/(view)/view/[viewId]/people/page.tsx
+++ b/app/(view)/view/[viewId]/people/page.tsx
@@ -1,18 +1,66 @@
+import { auth } from '@/lib/auth';
+import { buildViewContext, type ViewContext } from '@/lib/profile';
 import { getUserByViewId } from '@/lib/users';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import PeoplePage from '@/app/(app)/people/page';
+import { useRouter } from 'next/navigation';
 
-export default async function ViewPeoplePage({
+function ExitButtons({ ctx }: { ctx: ViewContext }) {
+  'use client';
+  const router = useRouter();
+  return (
+    <div className="mt-4 flex gap-4">
+      <button
+        id={`v13w-peep-exit-${ctx.ownerId}-${ctx.viewerId || 0}`}
+        onClick={() => {
+          const prev = document.referrer;
+          if (prev && !prev.includes('/view/')) router.back();
+          else router.push('/');
+        }}
+        aria-label="Exit viewing and return to my account"
+        className="rounded border px-3 py-1"
+      >
+        Exit
+      </button>
+      <Link
+        href={`/view/${ctx.viewId}`}
+        className="rounded border px-3 py-1 underline"
+      >
+        Go to this profile’s Cake
+      </Link>
+    </div>
+  );
+}
+
+export default async function ViewPeopleBlockedPage({
   params,
 }: {
   params: Promise<{ viewId: string }>;
 }) {
   const { viewId } = await params;
-  const user = await getUserByViewId(viewId);
-  if (!user) notFound();
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const session = await auth();
+  const viewerId = session?.user?.id ? Number(session.user.id) : null;
+  const ctx = buildViewContext({
+    ownerId: owner.id,
+    viewerId,
+    mode: 'viewer',
+    viewId,
+  });
   return (
-    <section id={`v13w-peep-${user.id}`}>
-      <PeoplePage params={{ viewId }} />
+    <section
+      id={`v13w-peep-block-${ctx.ownerId}-${ctx.viewerId || 0}`}
+      className="space-y-2"
+    >
+      <h1 className="text-lg font-semibold">
+        Not possible, for security purposes.
+      </h1>
+      <p className="text-sm text-gray-500">
+        The People tab is disabled while viewing someone else&apos;s account.
+      </p>
+      <ExitButtons ctx={ctx} />
     </section>
   );
 }
+

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -40,6 +40,7 @@ export function hrefFor(
       case 'review':
         return `${base}/review`;
       case 'people':
+        // viewer hits blocked People page
         return `${base}/people`;
       case 'visibility':
         return base; // no visibility route for viewers


### PR DESCRIPTION
## Summary
- Block People tab when viewing another profile and provide an exit back to own account
- Bind flavor server actions to the session owner and disable editing in viewer mode
- Document new IDs for blocked People view

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a309ae2a54832a98c3e37d727cfee0