### PR TITLE
Block People tab in view mode and bind server actions to owner

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -50,3 +50,6 @@ Modal form IDs:
   - `v13wbar-{ownerId}-{viewerId}` → viewer bar root container.
   - `v13wbar-live-{ownerId}-{viewerId}` → live indicator dot.
   - `v13wbar-exit-{ownerId}-{viewerId}` → Exit button.
+- Blocked People view:
+  - `v13w-peep-block-{ownerId}-{viewerId}`
+  - `v13w-peep-exit-{ownerId}-{viewerId}`

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -49,3 +49,4 @@
 - 2025-09-02: Bound owner vs viewer mode to route prefix, added auth-based assertOwner helper, removed uid query params, and scoped People and navigation reads by ownerId.
 - 2025-09-03: Added hrefFor navigation helper so view mode persists across routes and logged viewer bar presence.
 - 2025-09-03: Split owner and viewer layouts with context-based routing, migrated view routes to their own group, and refined viewer bar exit behavior.
+- 2025-09-04: Blocked People tab in view mode and bound ownerId to server actions to prevent stale viewer context after exiting view.

--- a/app/(app)/flavors/[flavorId]/subflavors/actions.ts
+++ b/app/(app)/flavors/[flavorId]/subflavors/actions.ts
@@ -1,7 +1,5 @@
 'use server';
 
-import { auth } from '@/lib/auth';
-import { ensureUser } from '@/lib/users';
 import {
   createSubflavor as createSubflavorStore,
   updateSubflavor as updateSubflavorStore,
@@ -58,14 +56,13 @@ function clamp(n: number) {
 }
 
 export async function createSubflavor(
+  boundOwnerId: number,
   flavorId: string,
   form: any,
 ): Promise<Subflavor> {
-  const session = await auth();
-  const user = await ensureUser(session);
-  await assertOwner(user.id);
+  await assertOwner(boundOwnerId);
   const subflavor = await createSubflavorStore(
-    String(user.id),
+    String(boundOwnerId),
     flavorId,
     sanitize({ ...form, flavorId }),
   );
@@ -74,15 +71,14 @@ export async function createSubflavor(
 }
 
 export async function updateSubflavor(
+  boundOwnerId: number,
   flavorId: string,
   id: string,
   form: any,
 ): Promise<Subflavor> {
-  const session = await auth();
-  const user = await ensureUser(session);
-  await assertOwner(user.id);
+  await assertOwner(boundOwnerId);
   const updated = await updateSubflavorStore(
-    String(user.id),
+    String(boundOwnerId),
     id,
     sanitize(form),
   );

--- a/app/(app)/flavors/[flavorId]/subflavors/page.tsx
+++ b/app/(app)/flavors/[flavorId]/subflavors/page.tsx
@@ -3,6 +3,7 @@ import { ensureUser } from '@/lib/users';
 import { listSubflavors } from '@/lib/subflavors-store';
 import SubflavorsClient from './client';
 import { redirect } from 'next/navigation';
+import { createSubflavor, updateSubflavor } from './actions';
 
 export default async function SubflavorsPage({
   params,
@@ -14,11 +15,16 @@ export default async function SubflavorsPage({
   const me = await ensureUser(session);
   const userId = String(me.id);
   const subflavors = await listSubflavors(userId, params.flavorId);
+  const createAction = createSubflavor.bind(null, me.id, params.flavorId);
+  const updateAction = updateSubflavor.bind(null, me.id, params.flavorId);
   return (
     <SubflavorsClient
       userId={userId}
       flavorId={params.flavorId}
       initialSubflavors={subflavors}
+      createSubflavorAction={createAction}
+      updateSubflavorAction={updateAction}
+      editable={true}
     />
   );
 }

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -1,11 +1,9 @@
 'use server';
 
-import { auth } from '@/lib/auth';
 import {
   createFlavor as createFlavorStore,
   updateFlavor as updateFlavorStore,
 } from '@/lib/flavors-store';
-import { ensureUser } from '@/lib/users';
 import { revalidatePath } from 'next/cache';
 import type { Flavor, FlavorInput } from '@/types/flavor';
 import { assertOwner } from '@/lib/profile';
@@ -56,21 +54,27 @@ function clamp(n: number) {
   return Math.max(0, Math.min(100, Math.round(n)));
 }
 
-export async function createFlavor(form: any): Promise<Flavor> {
-  const session = await auth();
-  const self = await ensureUser(session);
-  await assertOwner(self.id);
-  const flavor = await createFlavorStore(String(self.id), sanitize(form));
+export async function createFlavor(
+  boundOwnerId: number,
+  form: any,
+): Promise<Flavor> {
+  await assertOwner(boundOwnerId);
+  const flavor = await createFlavorStore(
+    String(boundOwnerId),
+    sanitize(form),
+  );
   revalidatePath('/flavors');
   return flavor;
 }
 
-export async function updateFlavor(id: string, form: any): Promise<Flavor> {
-  const session = await auth();
-  const self = await ensureUser(session);
-  await assertOwner(self.id);
+export async function updateFlavor(
+  boundOwnerId: number,
+  id: string,
+  form: any,
+): Promise<Flavor> {
+  await assertOwner(boundOwnerId);
   const updated = await updateFlavorStore(
-    String(self.id),
+    String(boundOwnerId),
     id,
     sanitize(form),
   );

--- a/app/(app)/flavors/page.tsx
+++ b/app/(app)/flavors/page.tsx
@@ -3,6 +3,7 @@ import { auth } from '@/lib/auth';
 import { listFlavors } from '@/lib/flavors-store';
 import FlavorsClient from './client';
 import { getUserByViewId, ensureUser } from '@/lib/users';
+import { createFlavor, updateFlavor } from './actions';
 
 export default async function FlavorsPage({
   params,
@@ -22,5 +23,16 @@ export default async function FlavorsPage({
     ownerId = me.id;
   }
   const flavors = await listFlavors(String(ownerId));
-  return <FlavorsClient userId={String(ownerId)} initialFlavors={flavors} />;
+  const createFlavorAction = createFlavor.bind(null, ownerId);
+  const updateFlavorAction = updateFlavor.bind(null, ownerId);
+  const editable = ownerId === viewerId;
+  return (
+    <FlavorsClient
+      userId={String(ownerId)}
+      initialFlavors={flavors}
+      createFlavorAction={editable ? createFlavorAction : undefined}
+      updateFlavorAction={editable ? updateFlavorAction : undefined}
+      editable={editable}
+    />
+  );
 }

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -1,21 +1,18 @@
 'use server';
 
-import { auth } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { follows, notifications, users } from '@/lib/db/schema';
-import { ensureUser } from '@/lib/users';
 import { and, eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { assertOwner } from '@/lib/profile';
 
 export async function followRequest(
+  boundOwnerId: number,
   targetId: number,
   _formData?: FormData,
 ): Promise<void> {
-  const session = await auth();
-  const self = await ensureUser(session);
-  await assertOwner(self.id);
-  const me = self.id;
+  await assertOwner(boundOwnerId);
+  const me = boundOwnerId;
   if (me === targetId) throw new Error('Cannot follow yourself.');
 
   const [target] = await db
@@ -63,13 +60,12 @@ export async function followRequest(
 }
 
 export async function cancelFollowRequest(
+  boundOwnerId: number,
   targetId: number,
   _formData?: FormData,
 ): Promise<void> {
-  const session = await auth();
-  const self = await ensureUser(session);
-  await assertOwner(self.id);
-  const me = self.id;
+  await assertOwner(boundOwnerId);
+  const me = boundOwnerId;
   await db
     .delete(follows)
     .where(
@@ -84,13 +80,12 @@ export async function cancelFollowRequest(
 }
 
 export async function acceptFollowRequest(
+  boundOwnerId: number,
   requesterId: number,
   _formData?: FormData,
 ): Promise<void> {
-  const session = await auth();
-  const self = await ensureUser(session);
-  await assertOwner(self.id);
-  const me = self.id;
+  await assertOwner(boundOwnerId);
+  const me = boundOwnerId;
   const [req] = await db
     .select()
     .from(follows)
@@ -112,13 +107,12 @@ export async function acceptFollowRequest(
 }
 
 export async function unfollow(
+  boundOwnerId: number,
   targetId: number,
   _formData?: FormData,
 ): Promise<void> {
-  const session = await auth();
-  const self = await ensureUser(session);
-  await assertOwner(self.id);
-  const me = self.id;
+  await assertOwner(boundOwnerId);
+  const me = boundOwnerId;
   await db
     .delete(follows)
     .where(and(eq(follows.followerId, me), eq(follows.followingId, targetId)));
@@ -133,13 +127,12 @@ export async function unfollow(
 }
 
 export async function declineFollowRequest(
+  boundOwnerId: number,
   requesterId: number,
   _formData?: FormData,
 ): Promise<void> {
-  const session = await auth();
-  const self = await ensureUser(session);
-  await assertOwner(self.id);
-  const me = self.id;
+  await assertOwner(boundOwnerId);
+  const me = boundOwnerId;
   await db
     .delete(follows)
     .where(

--- a/app/(app)/people/inbox/page.tsx
+++ b/app/(app)/people/inbox/page.tsx
@@ -58,10 +58,10 @@ export default async function InboxPage() {
                   (@{r.handle}) wants to follow you
                 </div>
                 <div className="flex gap-2">
-                  <form action={acceptFollowRequest.bind(null, r.id)}>
+                  <form action={acceptFollowRequest.bind(null, me, r.id)}>
                     <Button size="sm">Accept</Button>
                   </form>
-                  <form action={declineFollowRequest.bind(null, r.id)}>
+                  <form action={declineFollowRequest.bind(null, me, r.id)}>
                     <Button variant="outline" size="sm">
                       Decline
                     </Button>

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -189,7 +189,7 @@ function UserAction({
   if (user.viewerStatus === 'pending') {
     return (
       <div className="flex gap-2">
-        <form action={cancelFollowRequest.bind(null, user.id)}>
+        <form action={cancelFollowRequest.bind(null, viewerId, user.id)}>
           <Button
             id={`p30pl3-ccl-${user.id}-${viewerId}`}
             variant="outline"
@@ -211,7 +211,7 @@ function UserAction({
   if (user.viewerStatus === 'accepted') {
     return (
       <div className="flex gap-2">
-        <form action={unfollow.bind(null, user.id)}>
+        <form action={unfollow.bind(null, viewerId, user.id)}>
           <Button
             id={`p30pl3-unf-${user.id}-${viewerId}`}
             variant="outline"
@@ -232,7 +232,7 @@ function UserAction({
   }
   return (
     <div className="flex gap-2">
-      <form action={followRequest.bind(null, user.id)}>
+      <form action={followRequest.bind(null, viewerId, user.id)}>
         <Button id={`p30pl3-fol-${user.id}-${viewerId}`} size="sm">
           {user.followsMe
             ? 'Follow back'

--- a/app/(app)/u/[handle]/page.tsx
+++ b/app/(app)/u/[handle]/page.tsx
@@ -90,13 +90,13 @@ export default async function ProfilePage({
         <p>@{user.handle}</p>
         <div className="text-sm">Closed account</div>
         {relation === 'pending' ? (
-          <form action={cancelFollowRequest.bind(null, user.id)}>
+          <form action={cancelFollowRequest.bind(null, viewerId, user.id)}>
             <Button id={`pr0ovr-ccl-${user.id}-${viewerId}`} variant="outline">
               Requested
             </Button>
           </form>
         ) : (
-          <form action={followRequest.bind(null, user.id)}>
+          <form action={followRequest.bind(null, viewerId, user.id)}>
             <Button id={`pr0ovr-req-${user.id}-${viewerId}`}>
               Request to follow
             </Button>
@@ -128,25 +128,25 @@ export default async function ProfilePage({
       </div>
       <div className="flex gap-2">
         {relation === 'self' ? null : relation === 'accepted' ? (
-          <form action={unfollow.bind(null, user.id)}>
+          <form action={unfollow.bind(null, viewerId, user.id)}>
             <Button id={`pr0ovr-unf-${user.id}-${viewerId}`} variant="outline">
               Unfollow
             </Button>
           </form>
         ) : relation === 'pending' ? (
-          <form action={cancelFollowRequest.bind(null, user.id)}>
+          <form action={cancelFollowRequest.bind(null, viewerId, user.id)}>
             <Button id={`pr0ovr-ccl-${user.id}-${viewerId}`} variant="outline">
               Requested
             </Button>
           </form>
         ) : inbound === 'accepted' ? (
-          <form action={followRequest.bind(null, user.id)}>
+          <form action={followRequest.bind(null, viewerId, user.id)}>
             <Button id={`pr0ovr-fol-${user.id}-${viewerId}`}>
               Follow back
             </Button>
           </form>
         ) : (
-          <form action={followRequest.bind(null, user.id)}>
+          <form action={followRequest.bind(null, viewerId, user.id)}>
             <Button
               id={`pr0ovr-${user.accountVisibility === 'open' ? 'fol' : 'req'}-${user.id}-${viewerId}`}
             >

--- a/app/(view)/view/[viewId]/people/page.tsx
+++ b/app/(view)/view/[viewId]/people/page.tsx
@@ -1,18 +1,58 @@
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
 import { getUserByViewId } from '@/lib/users';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import PeoplePage from '@/app/(app)/people/page';
+import { useRouter } from 'next/navigation';
 
-export default async function ViewPeoplePage({
+function ExitButton({ ownerId, viewerId }: { ownerId: number; viewerId: number | null }) {
+  'use client';
+  const router = useRouter();
+  return (
+    <Button
+      id={`v13w-peep-exit-${ownerId}-${viewerId ?? 0}`}
+      onClick={() => {
+        if (window.history.length > 1) router.back();
+        else router.push('/');
+      }}
+    >
+      Exit viewing and return to my account
+    </Button>
+  );
+}
+
+export default async function ViewPeopleBlocked({
   params,
 }: {
   params: Promise<{ viewId: string }>;
 }) {
   const { viewId } = await params;
-  const user = await getUserByViewId(viewId);
-  if (!user) notFound();
+  const session = await auth();
+  const viewerId = session?.user?.id ? Number(session.user.id) : null;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const ctx = buildViewContext({
+    ownerId: owner.id,
+    viewerId,
+    mode: 'viewer',
+    viewId,
+  });
   return (
-    <section id={`v13w-peep-${user.id}`}>
-      <PeoplePage params={{ viewId }} />
+    <section
+      id={`v13w-peep-block-${ctx.ownerId}-${ctx.viewerId ?? 0}`}
+      className="space-y-4"
+    >
+      <h1 className="text-2xl font-bold">Not possible, for security purposes.</h1>
+      <p className="text-sm text-muted-foreground">
+        The People tab is disabled while viewing someone else&apos;s account.
+      </p>
+      <div className="flex gap-2">
+        <ExitButton ownerId={ctx.ownerId} viewerId={ctx.viewerId} />
+        <Link href={`/view/${viewId}`} className="text-sm underline">
+          Go to this profile&apos;s Cake
+        </Link>
+      </div>
     </section>
   );
 }

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -19,6 +19,11 @@ export function hrefFor(
   sectionOrPath: Section | string,
   ctx: ViewContext,
 ): string {
+  if (sectionOrPath === 'people') {
+    return ctx.mode === 'viewer'
+      ? `/view/${ctx.viewId}/people`
+      : '/people';
+  }
   if (sectionOrPath.startsWith('/')) {
     // raw path case
     return ctx.mode === 'viewer'
@@ -39,8 +44,6 @@ export function hrefFor(
         return `${base}/ingredients`;
       case 'review':
         return `${base}/review`;
-      case 'people':
-        return `${base}/people`;
       case 'visibility':
         return base; // no visibility route for viewers
     }
@@ -57,8 +60,6 @@ export function hrefFor(
       return '/ingredients';
     case 'review':
       return '/review';
-    case 'people':
-      return '/people';
     case 'visibility':
       return '/visibility';
   }


### PR DESCRIPTION
## Summary
- Block People section when viewing another user and add exit redirect
- Bind server actions to the owner on the server to prevent stale viewer context
- Hide flavor editing when in view mode and update navigation to point to blocked page

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a309ae2a54832a98c3e37d727cfee0