### PR TITLE
Restrict People tab in view mode and fix edit permission detection

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -49,3 +49,4 @@
 - 2025-09-02: Bound owner vs viewer mode to route prefix, added auth-based assertOwner helper, removed uid query params, and scoped People and navigation reads by ownerId.
 - 2025-09-03: Added hrefFor navigation helper so view mode persists across routes and logged viewer bar presence.
 - 2025-09-03: Split owner and viewer layouts with context-based routing, migrated view routes to their own group, and refined viewer bar exit behavior.
+- 2025-09-24: Blocked People tab for profile viewers and fixed edit mode detection after exiting view.

--- a/app/(app)/flavors/[flavorId]/subflavors/actions.ts
+++ b/app/(app)/flavors/[flavorId]/subflavors/actions.ts
@@ -63,7 +63,7 @@ export async function createSubflavor(
 ): Promise<Subflavor> {
   const session = await auth();
   const user = await ensureUser(session);
-  await assertOwner(user.id);
+  await assertOwner(user.id, user.id);
   const subflavor = await createSubflavorStore(
     String(user.id),
     flavorId,
@@ -80,7 +80,7 @@ export async function updateSubflavor(
 ): Promise<Subflavor> {
   const session = await auth();
   const user = await ensureUser(session);
-  await assertOwner(user.id);
+  await assertOwner(user.id, user.id);
   const updated = await updateSubflavorStore(
     String(user.id),
     id,

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -59,7 +59,7 @@ function clamp(n: number) {
 export async function createFlavor(form: any): Promise<Flavor> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const flavor = await createFlavorStore(String(self.id), sanitize(form));
   revalidatePath('/flavors');
   return flavor;
@@ -68,7 +68,7 @@ export async function createFlavor(form: any): Promise<Flavor> {
 export async function updateFlavor(id: string, form: any): Promise<Flavor> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const updated = await updateFlavorStore(
     String(self.id),
     id,

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -14,7 +14,7 @@ export async function followRequest(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const me = self.id;
   if (me === targetId) throw new Error('Cannot follow yourself.');
 
@@ -68,7 +68,7 @@ export async function cancelFollowRequest(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const me = self.id;
   await db
     .delete(follows)
@@ -89,7 +89,7 @@ export async function acceptFollowRequest(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const me = self.id;
   const [req] = await db
     .select()
@@ -117,7 +117,7 @@ export async function unfollow(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const me = self.id;
   await db
     .delete(follows)
@@ -138,7 +138,7 @@ export async function declineFollowRequest(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const me = self.id;
   await db
     .delete(follows)

--- a/app/(view)/view/[viewId]/people/page.tsx
+++ b/app/(view)/view/[viewId]/people/page.tsx
@@ -1,6 +1,5 @@
 import { getUserByViewId } from '@/lib/users';
 import { notFound } from 'next/navigation';
-import PeoplePage from '@/app/(app)/people/page';
 
 export default async function ViewPeoplePage({
   params,
@@ -11,8 +10,9 @@ export default async function ViewPeoplePage({
   const user = await getUserByViewId(viewId);
   if (!user) notFound();
   return (
-    <section id={`v13w-peep-${user.id}`}>
-      <PeoplePage params={{ viewId }} />
+    <section id={`v13w-peep-${user.id}`} className="space-y-4">
+      <h1 className="text-2xl font-bold">People</h1>
+      <p>Not accessible for safety reasons.</p>
     </section>
   );
 }

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -55,8 +55,14 @@ export async function canViewProfile({
   }
 }
 
-export async function assertOwner(ownerId: number) {
-  const me = Number((await auth())?.user?.id);
+export async function assertOwner(
+  ownerId: number,
+  viewerId?: number | null,
+) {
+  const me =
+    viewerId !== undefined && viewerId !== null
+      ? viewerId
+      : Number((await auth())?.user?.id);
   if (me !== ownerId) {
     throw new Error("Read-only: cannot edit another user's account.");
   }


### PR DESCRIPTION
## Summary
- Block People page for profile viewers with a safety message
- Accept viewer id in `assertOwner` and update actions so owners can edit after leaving view mode
- Update changelog

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*
- `pnpm format` *(fails: Command "format" not found)*
- `pnpm type-check` *(fails: Command "type-check" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a30db42510832a8deeecee76424a16