### PR TITLE
fix: prevent viewer access to People tab and restore self editing

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -49,3 +49,4 @@
 - 2025-09-02: Bound owner vs viewer mode to route prefix, added auth-based assertOwner helper, removed uid query params, and scoped People and navigation reads by ownerId.
 - 2025-09-03: Added hrefFor navigation helper so view mode persists across routes and logged viewer bar presence.
 - 2025-09-03: Split owner and viewer layouts with context-based routing, migrated view routes to their own group, and refined viewer bar exit behavior.
+- 2025-09-04: Blocked People tab access when viewing others and allowed self-view to enter owner mode for editing.

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -35,10 +35,11 @@ export default async function PeoplePage({
   const ownerId = owner.id;
   const viewerId = viewer.id;
 
+  const mode = ownerId === viewerId ? 'owner' : params?.viewId ? 'viewer' : 'owner';
   const ctx = buildViewContext({
     ownerId,
     viewerId,
-    mode: params?.viewId ? 'viewer' : 'owner',
+    mode,
     viewId: owner.viewId,
   });
 

--- a/app/(view)/view/[viewId]/layout.tsx
+++ b/app/(view)/view/[viewId]/layout.tsx
@@ -27,10 +27,11 @@ export default async function ViewLayout({
   });
   if (!allowed) notFound();
 
+  const mode = viewerId === owner.id ? 'owner' : 'viewer';
   const ctx = buildViewContext({
     ownerId: owner.id,
     viewerId,
-    mode: 'viewer',
+    mode,
     viewId,
   });
 

--- a/app/(view)/view/[viewId]/people/page.tsx
+++ b/app/(view)/view/[viewId]/people/page.tsx
@@ -1,6 +1,7 @@
 import { getUserByViewId } from '@/lib/users';
 import { notFound } from 'next/navigation';
 import PeoplePage from '@/app/(app)/people/page';
+import { auth } from '@/lib/auth';
 
 export default async function ViewPeoplePage({
   params,
@@ -10,6 +11,15 @@ export default async function ViewPeoplePage({
   const { viewId } = await params;
   const user = await getUserByViewId(viewId);
   if (!user) notFound();
+  const session = await auth();
+  const viewerId = session?.user?.id ? Number(session.user.id) : null;
+  if (viewerId !== user.id) {
+    return (
+      <section id={`v13w-peep-${user.id}`}>
+        <p>Not accessible for safety reasons.</p>
+      </section>
+    );
+  }
   return (
     <section id={`v13w-peep-${user.id}`}>
       <PeoplePage params={{ viewId }} />


### PR DESCRIPTION
## Summary
- ensure users cannot access another profile's People tab and show a safety message instead
- treat self-viewing via view routes as owner mode so editing is enabled
- document restriction in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a30db42510832a8deeecee76424a16