### PR TITLE
Restrict People tab in view mode and fix edit permission detection

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -49,3 +49,5 @@
 - 2025-09-02: Bound owner vs viewer mode to route prefix, added auth-based assertOwner helper, removed uid query params, and scoped People and navigation reads by ownerId.
 - 2025-09-03: Added hrefFor navigation helper so view mode persists across routes and logged viewer bar presence.
 - 2025-09-03: Split owner and viewer layouts with context-based routing, migrated view routes to their own group, and refined viewer bar exit behavior.
+- 2025-09-24: Blocked People tab for profile viewers and fixed edit mode detection after exiting view.
+- 2025-09-24: Disabled save/update controls in viewer mode to prevent unintended edits.

--- a/app/(app)/flavors/[flavorId]/subflavors/actions.ts
+++ b/app/(app)/flavors/[flavorId]/subflavors/actions.ts
@@ -63,7 +63,7 @@ export async function createSubflavor(
 ): Promise<Subflavor> {
   const session = await auth();
   const user = await ensureUser(session);
-  await assertOwner(user.id);
+  await assertOwner(user.id, user.id);
   const subflavor = await createSubflavorStore(
     String(user.id),
     flavorId,
@@ -80,7 +80,7 @@ export async function updateSubflavor(
 ): Promise<Subflavor> {
   const session = await auth();
   const user = await ensureUser(session);
-  await assertOwner(user.id);
+  await assertOwner(user.id, user.id);
   const updated = await updateSubflavorStore(
     String(user.id),
     id,

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -59,7 +59,7 @@ function clamp(n: number) {
 export async function createFlavor(form: any): Promise<Flavor> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const flavor = await createFlavorStore(String(self.id), sanitize(form));
   revalidatePath('/flavors');
   return flavor;
@@ -68,7 +68,7 @@ export async function createFlavor(form: any): Promise<Flavor> {
 export async function updateFlavor(id: string, form: any): Promise<Flavor> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const updated = await updateFlavorStore(
     String(self.id),
     id,

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import type { Flavor, Visibility } from '@/types/flavor';
 import { createFlavor, updateFlavor } from './actions';
+import { useViewContext } from '@/lib/view-context';
 
 const ICONS = ['⭐', '❤️', '🌞', '🌙', '📚'];
 const VISIBILITIES: Visibility[] = [
@@ -48,6 +49,7 @@ export default function FlavorsClient({
   initialFlavors: Flavor[];
 }) {
   const router = useRouter();
+  const ctx = useViewContext();
   const [flavors, setFlavors] = useState<Flavor[]>(sortFlavors(initialFlavors));
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<Flavor | null>(null);
@@ -80,6 +82,7 @@ export default function FlavorsClient({
   const mode = editing ? 'edit' : 'new';
 
   function openCreate(e: HTMLElement) {
+    if (!ctx.editable) return;
     triggerRef.current = e;
     setEditing(null);
     const blank = {
@@ -98,6 +101,7 @@ export default function FlavorsClient({
   }
 
   function openEdit(f: Flavor, e: HTMLElement) {
+    if (!ctx.editable) return;
     triggerRef.current = e;
     const current = {
       name: f.name,
@@ -116,6 +120,7 @@ export default function FlavorsClient({
   }
 
   async function remove(f: Flavor) {
+    if (!ctx.editable) return;
     if (!confirm(`Delete '${f.name}'? This can't be undone.`)) return;
     await fetch(`/api/flavors/${f.id}`, { method: 'DELETE' });
     setFlavors((prev) => prev.filter((p) => p.id !== f.id));
@@ -135,6 +140,7 @@ export default function FlavorsClient({
   }, []);
 
   async function save() {
+    if (!ctx.editable) return;
     setSubmitting(true);
     setError('');
     try {
@@ -204,8 +210,9 @@ export default function FlavorsClient({
     <section>
       <div className="mb-4 flex justify-end">
         <button
-          onClick={(e) => openCreate(e.currentTarget)}
-          className="rounded bg-orange-500 px-3 py-2 text-white"
+          onClick={(e) => ctx.editable && openCreate(e.currentTarget)}
+          className="rounded bg-orange-500 px-3 py-2 text-white disabled:opacity-50"
+          disabled={!ctx.editable}
           id={`f7avoured1tnew-${userId}`}
         >
           New Flavor
@@ -216,15 +223,21 @@ export default function FlavorsClient({
           <li
             key={f.id}
             id={`f7avourrow${f.id}-${userId}`}
-            role="button"
-            tabIndex={0}
-            onClick={(e) => openEdit(f, e.currentTarget)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter')
-                openEdit(f, e.currentTarget as HTMLElement);
-              if (e.key === 'Delete') remove(f);
-            }}
-            className="flex items-center gap-4 p-2 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
+            role={ctx.editable ? 'button' : undefined}
+            tabIndex={ctx.editable ? 0 : -1}
+            onClick={ctx.editable ? (e) => openEdit(f, e.currentTarget) : undefined}
+            onKeyDown={
+              ctx.editable
+                ? (e) => {
+                    if (e.key === 'Enter')
+                      openEdit(f, e.currentTarget as HTMLElement);
+                    if (e.key === 'Delete') remove(f);
+                  }
+                : undefined
+            }
+            className={`flex items-center gap-4 p-2 ${
+              ctx.editable ? 'hover:bg-gray-50 focus:bg-gray-50 focus:outline-none' : ''
+            }`}
           >
             <div className="flex flex-col items-center">
               <div
@@ -279,29 +292,31 @@ export default function FlavorsClient({
                 <span>{f.visibility}</span>
               </div>
             </div>
-            <div
-              className="ml-auto flex gap-2"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <button
-                id={`f7avoured1t${f.id}-${userId}`}
-                className="text-sm text-blue-600 underline"
-                onClick={(e) => openEdit(f, e.currentTarget)}
+            {ctx.editable && (
+              <div
+                className="ml-auto flex gap-2"
+                onClick={(e) => e.stopPropagation()}
               >
-                Edit ▸
-              </button>
-              <button
-                id={`f7avourd3l${f.id}-${userId}`}
-                className="text-sm text-red-600 underline"
-                onClick={() => remove(f)}
-              >
-                Delete
-              </button>
-            </div>
+                <button
+                  id={`f7avoured1t${f.id}-${userId}`}
+                  className="text-sm text-blue-600 underline"
+                  onClick={(e) => openEdit(f, e.currentTarget)}
+                >
+                  Edit ▸
+                </button>
+                <button
+                  id={`f7avourd3l${f.id}-${userId}`}
+                  className="text-sm text-red-600 underline"
+                  onClick={() => remove(f)}
+                >
+                  Delete
+                </button>
+              </div>
+            )}
           </li>
         ))}
       </ul>
-      {modalOpen && (
+      {modalOpen && ctx.editable && (
         <div
           id={`f7avourmdl-${mode}-${userId}`}
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 backdrop-blur-md"
@@ -498,7 +513,7 @@ export default function FlavorsClient({
                 <button
                   id={`f7avoursav-frm-${userId}`}
                   type="submit"
-                  disabled={submitting}
+                  disabled={submitting || !ctx.editable}
                   className="rounded bg-orange-500 px-3 py-1 text-white disabled:opacity-50"
                 >
                   Save

--- a/app/(app)/people/actions.ts
+++ b/app/(app)/people/actions.ts
@@ -14,7 +14,7 @@ export async function followRequest(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const me = self.id;
   if (me === targetId) throw new Error('Cannot follow yourself.');
 
@@ -68,7 +68,7 @@ export async function cancelFollowRequest(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const me = self.id;
   await db
     .delete(follows)
@@ -89,7 +89,7 @@ export async function acceptFollowRequest(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const me = self.id;
   const [req] = await db
     .select()
@@ -117,7 +117,7 @@ export async function unfollow(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const me = self.id;
   await db
     .delete(follows)
@@ -138,7 +138,7 @@ export async function declineFollowRequest(
 ): Promise<void> {
   const session = await auth();
   const self = await ensureUser(session);
-  await assertOwner(self.id);
+  await assertOwner(self.id, self.id);
   const me = self.id;
   await db
     .delete(follows)

--- a/app/(view)/view/[viewId]/people/page.tsx
+++ b/app/(view)/view/[viewId]/people/page.tsx
@@ -1,6 +1,5 @@
 import { getUserByViewId } from '@/lib/users';
 import { notFound } from 'next/navigation';
-import PeoplePage from '@/app/(app)/people/page';
 
 export default async function ViewPeoplePage({
   params,
@@ -11,8 +10,9 @@ export default async function ViewPeoplePage({
   const user = await getUserByViewId(viewId);
   if (!user) notFound();
   return (
-    <section id={`v13w-peep-${user.id}`}>
-      <PeoplePage params={{ viewId }} />
+    <section id={`v13w-peep-${user.id}`} className="space-y-4">
+      <h1 className="text-2xl font-bold">People</h1>
+      <p>Not accessible for safety reasons.</p>
     </section>
   );
 }

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -55,8 +55,14 @@ export async function canViewProfile({
   }
 }
 
-export async function assertOwner(ownerId: number) {
-  const me = Number((await auth())?.user?.id);
+export async function assertOwner(
+  ownerId: number,
+  viewerId?: number | null,
+) {
+  const me =
+    viewerId !== undefined && viewerId !== null
+      ? viewerId
+      : Number((await auth())?.user?.id);
   if (me !== ownerId) {
     throw new Error("Read-only: cannot edit another user's account.");
   }


### PR DESCRIPTION
## Summary
- Block People page for profile viewers with a safety message
- Accept viewer id in `assertOwner` and update actions so owners can edit after leaving view mode
- Disable editing buttons when viewing another profile
- Update changelog

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*
- `pnpm format` *(fails: Command "format" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a30db42510832a8deeecee76424a16