### PR TITLE
feat: add planning editor with next-day timeline

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -52,3 +52,4 @@
 - 2025-09-24: Blocked People tab for profile viewers and fixed edit mode detection after exiting view.
 - 2025-09-24: Disabled save and delete buttons in viewing mode to prevent accidental edits.
 - 2025-09-24: Awaited subflavor route params and added view-mode subflavor path so profile viewers can browse without editing.
+- 2025-09-25: Added Planning landing with mode buttons and next-day planner editor with draggable time blocks, metadata panel, persistence, and read-only viewer mode.

--- a/app/(app)/planning/client.tsx
+++ b/app/(app)/planning/client.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useViewContext } from '@/lib/view-context';
+import { Button } from '@/components/ui/button';
+
+export default function PlanningLanding({ userId }: { userId: string }) {
+  const router = useRouter();
+  const { editable } = useViewContext();
+  const tooltip = editable ? undefined : 'Read-only in viewing mode.';
+  return (
+    <section
+      id={`p1an-landing-${userId}`}
+      className="flex items-center justify-center gap-8 py-10"
+    >
+      <Button
+        id={`p1an-btn-next-${userId}`}
+        disabled={!editable}
+        title={tooltip}
+        onClick={() => editable && router.push('/planning/next')}
+      >
+        Planning for Next Day
+      </Button>
+      <div className="flex items-center">
+        <span className="relative mr-2">
+          <span className="absolute -left-3 top-2 h-2 w-2 rounded-full bg-red-500 animate-pulse" />
+        </span>
+        <Button
+          id={`p1an-btn-live-${userId}`}
+          disabled={!editable}
+          title={tooltip}
+        >
+          Live Planning
+        </Button>
+      </div>
+      <Button
+        id={`p1an-btn-review-${userId}`}
+        disabled={!editable}
+        title={tooltip}
+      >
+        Review Today’s Planning
+      </Button>
+    </section>
+  );
+}

--- a/app/(app)/planning/next/actions.ts
+++ b/app/(app)/planning/next/actions.ts
@@ -1,0 +1,20 @@
+'use server';
+
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { assertOwner } from '@/lib/profile';
+import { savePlan } from '@/lib/plans-store';
+import type { PlanBlockInput } from '@/types/plan';
+import { revalidatePath } from 'next/cache';
+
+export async function savePlanAction(
+  date: string,
+  blocks: PlanBlockInput[],
+) {
+  const session = await auth();
+  const self = await ensureUser(session);
+  await assertOwner(self.id, self.id);
+  const plan = await savePlan(String(self.id), date, blocks);
+  revalidatePath('/planning');
+  return plan;
+}

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -1,0 +1,399 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { useViewContext } from '@/lib/view-context';
+import type { Plan, PlanBlock, PlanBlockInput } from '@/types/plan';
+import { savePlanAction } from './actions';
+
+const COLORS = [
+  '#F87171',
+  '#FBBF24',
+  '#34D399',
+  '#60A5FA',
+  '#A78BFA',
+  '#F472B6',
+  '#FB923C',
+  '#4ADE80',
+  '#2DD4BF',
+  '#94A3B8',
+];
+
+const PIXELS_PER_MINUTE = 2;
+
+interface Props {
+  userId: string;
+  date: string; // YYYY-MM-DD
+  initialPlan: Plan | null;
+}
+
+export default function EditorClient({ userId, date, initialPlan }: Props) {
+  const { editable } = useViewContext();
+  const [blocks, setBlocks] = useState<PlanBlock[]>(
+    initialPlan?.blocks ?? [],
+  );
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = useMemo(
+    () => blocks.find((b) => b.id === selectedId) || null,
+    [blocks, selectedId],
+  );
+
+  function minutesFromIso(iso: string) {
+    const d = new Date(iso);
+    return d.getHours() * 60 + d.getMinutes();
+  }
+  function isoFromMinutes(min: number) {
+    const base = new Date(`${date}T00:00:00`);
+    return new Date(base.getTime() + min * 60000).toISOString();
+  }
+
+  function updateBlock(id: string, updates: Partial<PlanBlock>) {
+    setBlocks((prev) =>
+      prev.map((b) => (b.id === id ? { ...b, ...updates } : b)),
+    );
+  }
+
+  function addBlock() {
+    if (!editable) return;
+    const sorted = [...blocks].sort(
+      (a, b) => minutesFromIso(a.start) - minutesFromIso(b.start),
+    );
+    let start = 0;
+    if (sorted.length) {
+      const last = sorted.reduce((p, c) =>
+        minutesFromIso(c.end) > minutesFromIso(p.end) ? c : p,
+      );
+      start = minutesFromIso(last.end);
+    }
+    const duration = 60;
+    let candidate = start;
+    function isFree(s: number, e: number) {
+      return !sorted.some(
+        (b) =>
+          Math.max(s, minutesFromIso(b.start)) <
+          Math.min(e, minutesFromIso(b.end)),
+      );
+    }
+    let placed = false;
+    while (candidate + duration <= 24 * 60) {
+      if (isFree(candidate, candidate + duration)) {
+        placed = true;
+        break;
+      }
+      candidate += 15;
+    }
+    if (!placed) {
+      candidate = 0;
+      while (candidate + duration <= 24 * 60) {
+        if (isFree(candidate, candidate + duration)) {
+          placed = true;
+          break;
+        }
+        candidate += 15;
+      }
+    }
+    if (!placed) {
+      alert('No 1-hour slot available.');
+      return;
+    }
+    const id = crypto.randomUUID();
+    const newBlock: PlanBlock = {
+      id,
+      planId: initialPlan?.id || '',
+      start: isoFromMinutes(candidate),
+      end: isoFromMinutes(candidate + duration),
+      title: '',
+      description: '',
+      color: COLORS[0],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    setBlocks((b) => [...b, newBlock]);
+    setSelectedId(id);
+  }
+
+  function onSave() {
+    const payload: PlanBlockInput[] = blocks.map((b) => ({
+      id: b.id,
+      start: b.start,
+      end: b.end,
+      title: b.title,
+      description: b.description,
+      color: b.color,
+    }));
+    savePlanAction(date, payload).then(() => {
+      window.location.href = '/planning';
+    });
+  }
+
+  function handleTimeChange(id: string, field: 'start' | 'end', value: string) {
+    const [h, m] = value.split(':').map((n) => parseInt(n, 10));
+    const minutes = h * 60 + m;
+    const iso = isoFromMinutes(minutes);
+    if (field === 'start') {
+      const dur = minutesFromIso(selected!.end) - minutesFromIso(selected!.start);
+      const newStart = Math.min(Math.max(minutes, 0), 24 * 60 - 15);
+      updateBlock(id, {
+        start: isoFromMinutes(newStart),
+        end: isoFromMinutes(newStart + dur),
+      });
+    } else {
+      const newEnd = Math.min(Math.max(minutes, minutesFromIso(selected!.start) + 15), 24 * 60);
+      updateBlock(id, { end: isoFromMinutes(newEnd) });
+    }
+  }
+
+  function onDragStart(e: React.PointerEvent, b: PlanBlock, mode: 'move' | 'start' | 'end') {
+    if (!editable) return;
+    e.preventDefault();
+    const startY = e.clientY;
+    const initStart = minutesFromIso(b.start);
+    const initEnd = minutesFromIso(b.end);
+    function onMove(ev: PointerEvent) {
+      const delta = Math.round((ev.clientY - startY) / PIXELS_PER_MINUTE / 15) * 15;
+      if (mode === 'move') {
+        let newStart = initStart + delta;
+        newStart = Math.max(0, Math.min(newStart, 24 * 60 - (initEnd - initStart)));
+        updateBlock(b.id, {
+          start: isoFromMinutes(newStart),
+          end: isoFromMinutes(newStart + (initEnd - initStart)),
+        });
+      } else if (mode === 'start') {
+        let newStart = initStart + delta;
+        newStart = Math.max(0, Math.min(newStart, initEnd - 15));
+        updateBlock(b.id, { start: isoFromMinutes(newStart) });
+      } else {
+        let newEnd = initEnd + delta;
+        newEnd = Math.max(initStart + 15, Math.min(newEnd, 24 * 60));
+        updateBlock(b.id, { end: isoFromMinutes(newEnd) });
+      }
+    }
+    function onUp() {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+    }
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  }
+
+  const sortedBlocks = useMemo(
+    () =>
+      [...blocks].sort(
+        (a, b) => minutesFromIso(a.start) - minutesFromIso(b.start),
+      ),
+    [blocks],
+  );
+
+  return (
+    <div className="flex h-full">
+      <div
+        className={`relative overflow-y-auto ${selected ? 'w-1/2' : 'w-full'}`}
+        id={`p1an-timecol-${userId}`}
+        onClick={() => setSelectedId(null)}
+      >
+        {editable ? (
+          <button
+            id={`p1an-add-top-${userId}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              addBlock();
+            }}
+            className="sticky top-0 z-10 w-full bg-gray-100 py-2 text-sm"
+            disabled={!editable}
+          >
+            + Add timeslot
+          </button>
+        ) : (
+          <button
+            id={`p1an-add-top-${userId}`}
+            className="sticky top-0 z-10 w-full bg-gray-100 py-2 text-sm"
+            disabled
+            title="Read-only in viewing mode"
+          >
+            + Add timeslot
+          </button>
+        )}
+        <div style={{ height: 24 * 60 * PIXELS_PER_MINUTE }} className="relative">
+          {Array.from({ length: 24 }).map((_, h) => (
+            <div key={h}>
+              <div
+                id={`p1an-hour-${h}-${userId}`}
+                className="absolute left-0 right-0 border-t border-gray-300"
+                style={{ top: h * 60 * PIXELS_PER_MINUTE }}
+              />
+              {[15, 30, 45].map((m) => (
+                <div
+                  key={m}
+                  className="absolute left-0 right-0 border-t border-gray-100"
+                  style={{ top: (h * 60 + m) * PIXELS_PER_MINUTE }}
+                />
+              ))}
+            </div>
+          ))}
+          {sortedBlocks.map((b) => {
+            const top = minutesFromIso(b.start) * PIXELS_PER_MINUTE;
+            const height =
+              (minutesFromIso(b.end) - minutesFromIso(b.start)) *
+              PIXELS_PER_MINUTE;
+            const z = 10000 - minutesFromIso(b.start);
+            const textColor = '#000000';
+            return (
+              <div
+                key={b.id}
+                id={`p1an-blk-${b.id}-${userId}`}
+                data-selected={selectedId === b.id ? 'true' : 'false'}
+                aria-label={`${b.title}, ${b.start} to ${b.end}`}
+                className="absolute left-1 right-1 cursor-pointer rounded p-1 text-xs"
+                style={{
+                  top,
+                  height,
+                  background: b.color,
+                  zIndex: z,
+                  color: textColor,
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!editable) return;
+                  setSelectedId(b.id);
+                }}
+                onPointerDown={(e) => onDragStart(e, b, 'move')}
+              >
+                <div
+                  className="absolute left-0 right-0 top-0 h-2 cursor-n-resize"
+                  onPointerDown={(e) => onDragStart(e, b, 'start')}
+                />
+                <div
+                  className="absolute bottom-0 left-0 right-0 h-2 cursor-s-resize"
+                  onPointerDown={(e) => onDragStart(e, b, 'end')}
+                />
+                <span className="pointer-events-none block truncate">
+                  {b.title}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+        {editable ? (
+          <button
+            id={`p1an-add-fab-${userId}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              addBlock();
+            }}
+            className="absolute bottom-4 right-4 h-10 w-10 rounded-full bg-orange-500 text-white"
+            disabled={!editable}
+          >
+            +
+          </button>
+        ) : (
+          <button
+            id={`p1an-add-fab-${userId}`}
+            className="absolute bottom-4 right-4 h-10 w-10 rounded-full bg-orange-500 text-white"
+            disabled
+            title="Read-only in viewing mode"
+          >
+            +
+          </button>
+        )}
+      </div>
+      {selected ? (
+        <div
+          className="w-1/2 border-l p-4"
+          id={`p1an-meta-${selected.id}-${userId}`}
+        >
+          <div className="mb-2 text-sm text-gray-500">
+            {editable ? null : 'Read-only (viewing mode)'}
+          </div>
+          <label className="block text-sm font-medium" htmlFor={`p1an-meta-ttl-${selected.id}-${userId}`}>
+            Activity
+          </label>
+          <input
+            id={`p1an-meta-ttl-${selected.id}-${userId}`}
+            className="mb-2 w-full border p-1"
+            value={selected.title}
+            maxLength={60}
+            disabled={!editable}
+            onChange={(e) => updateBlock(selected.id, { title: e.target.value })}
+          />
+          <label className="block text-sm font-medium" htmlFor={`p1an-meta-dsc-${selected.id}-${userId}`}>
+            Description
+          </label>
+          <textarea
+            id={`p1an-meta-dsc-${selected.id}-${userId}`}
+            className="mb-2 w-full border p-1"
+            value={selected.description}
+            disabled={!editable}
+            maxLength={500}
+            rows={6}
+            onChange={(e) =>
+              updateBlock(selected.id, { description: e.target.value })
+            }
+          />
+          <label className="block text-sm font-medium">Color</label>
+          <div
+            id={`p1an-meta-col-${selected.id}-${userId}`}
+            className="mb-2 flex flex-wrap gap-1"
+          >
+            {COLORS.map((c) => (
+              <button
+                key={c}
+                className="h-6 w-6 rounded"
+                style={{ background: c }}
+                onClick={() => editable && updateBlock(selected.id, { color: c })}
+                disabled={!editable}
+              />
+            ))}
+          </div>
+          <div className="mb-2 flex gap-2">
+            <div>
+              <label className="block text-sm font-medium" htmlFor={`p1an-meta-tms-${selected.id}-${userId}`}>
+                Start
+              </label>
+              <input
+                type="time"
+                id={`p1an-meta-tms-${selected.id}-${userId}`}
+                value={selected.start.substring(11, 16)}
+                disabled={!editable}
+                onChange={(e) => handleTimeChange(selected.id, 'start', e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium" htmlFor={`p1an-meta-tme-${selected.id}-${userId}`}>
+                End
+              </label>
+              <input
+                type="time"
+                id={`p1an-meta-tme-${selected.id}-${userId}`}
+                value={selected.end.substring(11, 16)}
+                disabled={!editable}
+                onChange={(e) => handleTimeChange(selected.id, 'end', e.target.value)}
+              />
+            </div>
+          </div>
+          <div className="mt-4 flex gap-2">
+            {editable ? (
+              <Button id={`p1an-meta-save-${userId}`} onClick={onSave}>
+                Save
+              </Button>
+            ) : (
+              <Button
+                id={`p1an-meta-save-${userId}`}
+                disabled
+                title="Read-only in viewing mode"
+              >
+                Save
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              id={`p1an-meta-close-${userId}`}
+              onClick={() => setSelectedId(null)}
+            >
+              X
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -1,0 +1,18 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { getPlan } from '@/lib/plans-store';
+import EditorClient from './client';
+
+export default async function PlanningNextPage() {
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const now = new Date();
+  const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+  const date = tomorrow.toISOString().slice(0, 10);
+  const plan = await getPlan(String(me.id), date);
+  return (
+    <EditorClient userId={String(me.id)} date={date} initialPlan={plan} />
+  );
+}

--- a/app/(app)/planning/page.tsx
+++ b/app/(app)/planning/page.tsx
@@ -1,11 +1,11 @@
-export function PlanningHome() {
-  return (
-    <section>
-      <h1 className="text-2xl font-bold">Planning</h1>
-    </section>
-  );
-}
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import PlanningLanding from './client';
 
-export default function PlanningPage() {
-  return <PlanningHome />;
+export default async function PlanningPage() {
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  return <PlanningLanding userId={String(me.id)} />;
 }

--- a/app/(view)/view/[viewId]/planning/next/page.tsx
+++ b/app/(view)/view/[viewId]/planning/next/page.tsx
@@ -1,0 +1,23 @@
+import { getUserByViewId } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { getPlan } from '@/lib/plans-store';
+import EditorClient from '@/app/(app)/planning/next/client';
+
+export default async function ViewPlanningNextPage({
+  params,
+}: {
+  params: Promise<{ viewId: string }>;
+}) {
+  const { viewId } = await params;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const now = new Date();
+  const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+  const date = tomorrow.toISOString().slice(0, 10);
+  const plan = await getPlan(String(user.id), date);
+  return (
+    <section id={`v13w-plan-${user.id}`}>
+      <EditorClient userId={String(user.id)} date={date} initialPlan={plan} />
+    </section>
+  );
+}

--- a/app/(view)/view/[viewId]/planning/page.tsx
+++ b/app/(view)/view/[viewId]/planning/page.tsx
@@ -1,6 +1,6 @@
 import { getUserByViewId } from '@/lib/users';
 import { notFound } from 'next/navigation';
-import { PlanningHome } from '@/app/(app)/planning/page';
+import PlanningLanding from '@/app/(app)/planning/client';
 
 export default async function ViewPlanningPage({
   params,
@@ -12,7 +12,7 @@ export default async function ViewPlanningPage({
   if (!user) notFound();
   return (
     <section id={`v13w-plan-${user.id}`}>
-      <PlanningHome />
+      <PlanningLanding userId={String(user.id)} />
     </section>
   );
 }

--- a/drizzle/0007_add_plans.sql
+++ b/drizzle/0007_add_plans.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS plans (
+  id serial PRIMARY KEY,
+  user_id integer REFERENCES users(id) NOT NULL,
+  date date NOT NULL,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now(),
+  CONSTRAINT plans_user_date_unique UNIQUE(user_id, date)
+);
+
+CREATE TABLE IF NOT EXISTS plan_blocks (
+  id text PRIMARY KEY,
+  plan_id integer REFERENCES plans(id) NOT NULL,
+  start timestamp NOT NULL,
+  "end" timestamp NOT NULL,
+  title varchar(60),
+  description text,
+  color varchar(10),
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now()
+);

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -4,6 +4,7 @@ import {
   text,
   varchar,
   timestamp,
+  date,
   integer,
   pgEnum,
   uniqueIndex,
@@ -108,4 +109,33 @@ export const notifications = pgTable('notifications', {
   type: notificationTypeEnum('type').notNull(),
   createdAt: timestamp('created_at').defaultNow(),
   readAt: timestamp('read_at'),
+});
+
+export const plans = pgTable(
+  'plans',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id').references(() => users.id).notNull(),
+    date: date('date').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+    updatedAt: timestamp('updated_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserDate: uniqueIndex('plans_user_date_unique').on(
+      table.userId,
+      table.date,
+    ),
+  }),
+);
+
+export const planBlocks = pgTable('plan_blocks', {
+  id: text('id').primaryKey(),
+  planId: integer('plan_id').references(() => plans.id).notNull(),
+  start: timestamp('start').notNull(),
+  end: timestamp('end').notNull(),
+  title: varchar('title', { length: 60 }),
+  description: text('description'),
+  color: varchar('color', { length: 10 }),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
 });

--- a/lib/plans-store.ts
+++ b/lib/plans-store.ts
@@ -1,0 +1,112 @@
+import { db } from './db';
+import { plans, planBlocks } from './db/schema';
+import { eq, and, inArray } from 'drizzle-orm';
+import type { Plan, PlanBlock, PlanBlockInput } from '@/types/plan';
+
+function toPlanBlock(row: typeof planBlocks.$inferSelect): PlanBlock {
+  return {
+    id: row.id,
+    planId: row.planId?.toString() ?? '',
+    start: row.start.toISOString(),
+    end: row.end.toISOString(),
+    title: row.title ?? '',
+    description: row.description ?? '',
+    color: row.color ?? '#888888',
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+    updatedAt: row.updatedAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+export async function getPlan(
+  userId: string,
+  dateStr: string,
+): Promise<Plan | null> {
+  const dateKey = new Date(dateStr).toISOString().slice(0, 10);
+  const [planRow] = await db
+    .select()
+    .from(plans)
+    .where(and(eq(plans.userId, Number(userId)), eq(plans.date, dateKey)));
+  if (!planRow) return null;
+  const blockRows = await db
+    .select()
+    .from(planBlocks)
+    .where(eq(planBlocks.planId, planRow.id));
+  return {
+    id: planRow.id.toString(),
+    userId: userId,
+    date: planRow.date,
+    blocks: blockRows.map(toPlanBlock),
+  };
+}
+
+export async function savePlan(
+  userId: string,
+  dateStr: string,
+  blocks: PlanBlockInput[],
+): Promise<Plan> {
+  const dateKey = new Date(dateStr).toISOString().slice(0, 10);
+  let [planRow] = await db
+    .select()
+    .from(plans)
+    .where(and(eq(plans.userId, Number(userId)), eq(plans.date, dateKey)));
+  if (!planRow) {
+    const inserted = await db
+      .insert(plans)
+      .values({ userId: Number(userId), date: dateKey })
+      .returning();
+    planRow = inserted[0];
+  }
+  const existing = await db
+    .select({ id: planBlocks.id })
+    .from(planBlocks)
+    .where(eq(planBlocks.planId, planRow.id));
+  const existingIds = new Set(existing.map((b) => b.id));
+  const incomingIds = new Set(blocks.filter((b) => b.id).map((b) => b.id as string));
+  // delete removed
+  const toDelete = [...existingIds].filter((id) => !incomingIds.has(id));
+  if (toDelete.length) {
+    await db.delete(planBlocks).where(inArray(planBlocks.id, toDelete));
+  }
+  const now = new Date();
+  const results: PlanBlock[] = [];
+  for (const blk of blocks) {
+    if (blk.id && existingIds.has(blk.id)) {
+      const [row] = await db
+        .update(planBlocks)
+        .set({
+          start: new Date(blk.start),
+          end: new Date(blk.end),
+          title: blk.title.slice(0, 60),
+          description: blk.description.slice(0, 500),
+          color: blk.color,
+          updatedAt: now,
+        })
+        .where(eq(planBlocks.id, blk.id))
+        .returning();
+      results.push(toPlanBlock(row));
+    } else {
+      const id = blk.id ?? crypto.randomUUID();
+      const [row] = await db
+        .insert(planBlocks)
+        .values({
+          id,
+          planId: planRow.id,
+          start: new Date(blk.start),
+          end: new Date(blk.end),
+          title: blk.title.slice(0, 60),
+          description: blk.description.slice(0, 500),
+          color: blk.color,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
+      results.push(toPlanBlock(row));
+    }
+  }
+  return {
+    id: planRow.id.toString(),
+    userId,
+    date: planRow.date,
+    blocks: results,
+  };
+}

--- a/tests/planning.spec.ts
+++ b/tests/planning.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+const PPM = 2; // pixels per minute, must match client
+
+function yFor(h: number, m = 0) {
+  return (h * 60 + m) * PPM;
+}
+
+test('next day planning flow', async ({ page }) => {
+  const handle = `user${Date.now()}`;
+  const email = `${handle}@example.com`;
+  const password = 'pass1234';
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Tester');
+  await page.fill('input[placeholder="Handle"]', handle);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.goto('/planning');
+
+  await expect(page.locator('[id^="p1an-btn-next-"]')).toBeVisible();
+  await expect(page.locator('span.bg-red-500')).toBeVisible();
+  await expect(page.locator('[id^="p1an-btn-review-"]')).toBeVisible();
+
+  await page.click('[id^="p1an-btn-next-"]');
+  await expect(page.locator('[id^="p1an-timecol-"]')).toBeVisible();
+  await page.click('[id^="p1an-add-top-"]');
+  const block = page.locator('[id^="p1an-blk-"]');
+  await expect(block).toHaveCount(1);
+  const top = await block.evaluate((el) => getComputedStyle(el).top);
+  expect(parseInt(top)).toBe(0);
+  await expect(page.locator('[id^="p1an-meta-"]')).toBeVisible();
+  await page.fill('input[id^="p1an-meta-ttl-"]', 'Workout');
+  await page.locator('[id^="p1an-meta-col-"] button').nth(1).click();
+
+  // drag to 07:00
+  const box = await block.boundingBox();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box!.x + box!.width / 2, box!.y + yFor(7) + box!.height / 2);
+  await page.mouse.up();
+
+  // resize end to 08:30
+  const box2 = await block.boundingBox();
+  await page.mouse.move(box2!.x + box2!.width / 2, box2!.y + box2!.height);
+  await page.mouse.down();
+  await page.mouse.move(box2!.x + box2!.width / 2, yFor(8, 30));
+  await page.mouse.up();
+
+  await page.click('button[id^="p1an-meta-save-"]');
+  await expect(page).toHaveURL('/planning');
+  await page.click('[id^="p1an-btn-next-"]');
+  const blk2 = page.locator('[id^="p1an-blk-"]');
+  const top2 = await blk2.evaluate((el) => parseInt(getComputedStyle(el).top));
+  expect(top2).toBe(yFor(7));
+});

--- a/types/plan.ts
+++ b/types/plan.ts
@@ -1,0 +1,27 @@
+export interface Plan {
+  id: string;
+  userId: string;
+  date: string; // ISO date YYYY-MM-DD
+  blocks: PlanBlock[];
+}
+
+export interface PlanBlock {
+  id: string;
+  planId: string;
+  start: string; // ISO datetime
+  end: string;   // ISO datetime
+  title: string;
+  description: string;
+  color: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PlanBlockInput {
+  id?: string;
+  start: string;
+  end: string;
+  title: string;
+  description: string;
+  color: string;
+}


### PR DESCRIPTION
## Summary
- add plans and plan_blocks tables for scheduling data
- create planning landing with next-day/live/review buttons
- implement next-day planner editor with draggable time blocks and metadata panel

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a338be512c832aa18d1cdf74dc9a5d