### PR TITLE
feat: add planning next-day editor

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -52,3 +52,4 @@
 - 2025-09-24: Blocked People tab for profile viewers and fixed edit mode detection after exiting view.
 - 2025-09-24: Disabled save and delete buttons in viewing mode to prevent accidental edits.
 - 2025-09-24: Awaited subflavor route params and added view-mode subflavor path so profile viewers can browse without editing.
+- 2025-09-25: Added planning landing and next-day editor with draggable time blocks, metadata panel, and persistence; introduced Plan and PlanBlock schema with migrations and basic Playwright coverage.

--- a/app/(app)/planning/landing.tsx
+++ b/app/(app)/planning/landing.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import Link from 'next/link';
+import { useViewContext } from '@/lib/view-context';
+import { hrefFor } from '@/lib/navigation';
+
+export default function PlanningLanding() {
+  const ctx = useViewContext();
+  const { ownerId, editable } = ctx;
+  const userId = String(ownerId);
+  const nextHref = hrefFor('/planning/next', ctx);
+  const liveHref = hrefFor('/planning/live', ctx);
+  const reviewHref = hrefFor('/planning/review', ctx);
+  const common = 'rounded border px-4 py-8 text-center text-lg font-medium';
+  return (
+    <section
+      id={`p1an-landing-${userId}`}
+      className="flex flex-col items-center justify-center gap-8 p-8"
+    >
+      <div className="flex gap-8">
+        <Link
+          id={`p1an-btn-next-${userId}`}
+          href={nextHref}
+          className={`${common} ${editable ? '' : 'cursor-not-allowed opacity-50'}`}
+          onClick={(e) => {
+            if (!editable) e.preventDefault();
+          }}
+          title={editable ? undefined : 'Read-only in viewing mode'}
+          aria-disabled={!editable}
+        >
+          Planning for Next Day
+        </Link>
+        <Link
+          id={`p1an-btn-live-${userId}`}
+          href={liveHref}
+          className={`${common} flex items-center justify-center gap-2 ${editable ? '' : 'cursor-not-allowed opacity-50'}`}
+          onClick={(e) => {
+            if (!editable) e.preventDefault();
+          }}
+          title={editable ? undefined : 'Read-only in viewing mode'}
+          aria-disabled={!editable}
+        >
+          <span
+            className="h-3 w-3 animate-pulse rounded-full bg-red-500"
+            aria-hidden="true"
+          />
+          Live Planning
+        </Link>
+        <Link
+          id={`p1an-btn-review-${userId}`}
+          href={reviewHref}
+          className={`${common} ${editable ? '' : 'cursor-not-allowed opacity-50'}`}
+          onClick={(e) => {
+            if (!editable) e.preventDefault();
+          }}
+          title={editable ? undefined : 'Read-only in viewing mode'}
+          aria-disabled={!editable}
+        >
+          Review Today’s Planning
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/app/(app)/planning/next/actions.ts
+++ b/app/(app)/planning/next/actions.ts
@@ -1,0 +1,21 @@
+'use server';
+
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { assertOwner } from '@/lib/profile';
+import { savePlan } from '@/lib/planning-store';
+import type { PlanBlockInput } from '@/types/plan';
+
+function tomorrowISO() {
+  const now = new Date();
+  now.setDate(now.getDate() + 1);
+  return now.toISOString().slice(0, 10);
+}
+
+export async function saveNextDayPlan(blocks: PlanBlockInput[]) {
+  const session = await auth();
+  const me = await ensureUser(session);
+  await assertOwner(me.id, me.id);
+  const date = tomorrowISO();
+  return savePlan(String(me.id), date, blocks);
+}

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -1,0 +1,20 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getPlan } from '@/lib/planning-store';
+import PlanningEditor from './planner';
+
+function tomorrowISO() {
+  const now = new Date();
+  now.setDate(now.getDate() + 1);
+  return now.toISOString().slice(0, 10);
+}
+
+export default async function PlanningNextPage() {
+  const session = await auth();
+  const me = await ensureUser(session);
+  const date = tomorrowISO();
+  const { blocks } = await getPlan(String(me.id), date);
+  return (
+    <PlanningEditor userId={String(me.id)} initialBlocks={blocks} date={date} />
+  );
+}

--- a/app/(app)/planning/next/planner.tsx
+++ b/app/(app)/planning/next/planner.tsx
@@ -1,0 +1,439 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useViewContext } from '@/lib/view-context';
+import { hrefFor } from '@/lib/navigation';
+import { saveNextDayPlan } from './actions';
+import type { PlanBlock } from '@/types/plan';
+
+const COLORS = [
+  '#f87171',
+  '#f97316',
+  '#4ade80',
+  '#60a5fa',
+  '#a78bfa',
+  '#f472b6',
+  '#94a3b8',
+  '#facc15',
+  '#ec4899',
+  '#14b8a6',
+];
+
+const PX_PER_MIN = 2;
+const SNAP = 15; // minutes
+
+interface BlockState {
+  id: string;
+  start: Date;
+  end: Date;
+  title: string;
+  description: string;
+  color: string;
+  isNew?: boolean;
+}
+
+function minutesOf(date: Date) {
+  return date.getHours() * 60 + date.getMinutes();
+}
+
+function dateFromMinutes(base: Date, mins: number) {
+  const d = new Date(base);
+  d.setHours(0, 0, 0, 0);
+  d.setMinutes(mins);
+  return d;
+}
+
+export default function PlanningEditor({
+  userId,
+  initialBlocks,
+  date,
+}: {
+  userId: string;
+  initialBlocks: PlanBlock[];
+  date: string;
+}) {
+  const router = useRouter();
+  const ctx = useViewContext();
+  const { editable } = ctx;
+  const dayStart = new Date(`${date}T00:00:00`);
+  const [blocks, setBlocks] = useState<BlockState[]>(
+    initialBlocks.map((b) => ({
+      id: b.id,
+      start: new Date(b.start),
+      end: new Date(b.end),
+      title: b.title,
+      description: b.description,
+      color: b.color || COLORS[3],
+    })),
+  );
+  const [selected, setSelected] = useState<string | null>(null);
+  const [snapshots, setSnapshots] = useState<Record<string, BlockState>>({});
+
+  const sorted = [...blocks].sort(
+    (a, b) => a.start.getTime() - b.start.getTime(),
+  );
+
+  useEffect(() => {
+    if (selected) {
+      const blk = blocks.find((b) => b.id === selected);
+      if (blk) setSnapshots((s) => ({ ...s, [selected]: { ...blk } }));
+    }
+  }, [selected, blocks]);
+
+  function addBlock() {
+    if (!editable) return;
+    const duration = 60;
+    const taken: boolean[] = Array(24 * 60).fill(false);
+    blocks.forEach((b) => {
+      const s = minutesOf(b.start);
+      const e = minutesOf(b.end);
+      for (let i = s; i < e; i++) taken[i] = true;
+    });
+    let startMin = 0;
+    for (let t = 0; t <= 24 * 60 - duration; t += SNAP) {
+      let free = true;
+      for (let i = t; i < t + duration; i++) {
+        if (taken[i]) {
+          free = false;
+          break;
+        }
+      }
+      if (free) {
+        startMin = t;
+        break;
+      }
+    }
+    if (startMin + duration > 24 * 60) {
+      alert('No 1-hour slot available.');
+      return;
+    }
+    const id = `tmp-${crypto.randomUUID()}`;
+    const blk: BlockState = {
+      id,
+      start: dateFromMinutes(dayStart, startMin),
+      end: dateFromMinutes(dayStart, startMin + duration),
+      title: '',
+      description: '',
+      color: COLORS[3],
+      isNew: true,
+    };
+    setBlocks((b) => [...b, blk]);
+    setSelected(id);
+  }
+
+  function updateBlock(id: string, partial: Partial<BlockState>) {
+    setBlocks((bs) => bs.map((b) => (b.id === id ? { ...b, ...partial } : b)));
+  }
+
+  function handleDrag(id: string, deltaMin: number) {
+    setBlocks((bs) =>
+      bs.map((b) => {
+        if (b.id !== id) return b;
+        const dur = minutesOf(b.end) - minutesOf(b.start);
+        let newStart = minutesOf(b.start) + deltaMin;
+        newStart = Math.max(0, Math.min(24 * 60 - dur, newStart));
+        const s = dateFromMinutes(dayStart, newStart);
+        const e = dateFromMinutes(dayStart, newStart + dur);
+        return { ...b, start: s, end: e };
+      }),
+    );
+  }
+
+  function handleResize(id: string, deltaStart: number, deltaEnd: number) {
+    setBlocks((bs) =>
+      bs.map((b) => {
+        if (b.id !== id) return b;
+        let sMin = minutesOf(b.start) + deltaStart;
+        let eMin = minutesOf(b.end) + deltaEnd;
+        if (eMin - sMin < SNAP) {
+          if (deltaStart !== 0) sMin = eMin - SNAP;
+          else eMin = sMin + SNAP;
+        }
+        sMin = Math.max(0, sMin);
+        eMin = Math.min(24 * 60, eMin);
+        const s = dateFromMinutes(dayStart, sMin);
+        const e = dateFromMinutes(dayStart, eMin);
+        return { ...b, start: s, end: e };
+      }),
+    );
+  }
+
+  function startDrag(e: React.MouseEvent, id: string) {
+    if (!editable) return;
+    e.preventDefault();
+    const startY = e.clientY;
+    const startMin = minutesOf(blocks.find((b) => b.id === id)!.start);
+    function onMove(ev: MouseEvent) {
+      const dy = ev.clientY - startY;
+      const deltaMin = Math.round(dy / (PX_PER_MIN * SNAP)) * SNAP;
+      handleDrag(id, deltaMin);
+    }
+    function onUp() {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    }
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }
+
+  function startResize(
+    e: React.MouseEvent,
+    id: string,
+    edge: 'top' | 'bottom',
+  ) {
+    if (!editable) return;
+    e.preventDefault();
+    const startY = e.clientY;
+    function onMove(ev: MouseEvent) {
+      const dy = ev.clientY - startY;
+      const deltaMin = Math.round(dy / (PX_PER_MIN * SNAP)) * SNAP;
+      if (edge === 'top') handleResize(id, deltaMin, 0);
+      else handleResize(id, 0, deltaMin);
+    }
+    function onUp() {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    }
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }
+
+  async function save() {
+    if (!editable) return;
+    const payload = blocks.map((b) => ({
+      id: b.isNew ? undefined : b.id,
+      start: b.start.toISOString(),
+      end: b.end.toISOString(),
+      title: b.title,
+      description: b.description,
+      color: b.color,
+    }));
+    await saveNextDayPlan(payload);
+    alert('Saved');
+    router.push(hrefFor('/planning', ctx));
+  }
+
+  function closePanel() {
+    if (!selected) return;
+    const snap = snapshots[selected];
+    if (snap && blocks.find((b) => b.id === selected)?.isNew) {
+      setBlocks((bs) => bs.filter((b) => b.id !== selected));
+    } else if (snap) {
+      setBlocks((bs) => bs.map((b) => (b.id === selected ? snap : b)));
+    }
+    setSelected(null);
+  }
+
+  const selectedBlock = blocks.find((b) => b.id === selected);
+
+  return (
+    <div className="flex h-screen">
+      <div
+        className="relative w-1/2 border-r"
+        id={`p1an-timecol-${userId}`}
+        onClick={() => setSelected(null)}
+      >
+        <div className="sticky top-0 z-10 flex justify-end bg-white p-2">
+          <button
+            id={`p1an-add-top-${userId}`}
+            disabled={!editable}
+            title={!editable ? 'Read-only in viewing mode' : ''}
+            onClick={addBlock}
+            className="rounded border px-2 py-1 disabled:opacity-50"
+          >
+            + Add timeslot
+          </button>
+        </div>
+        <div className="relative" style={{ height: PX_PER_MIN * 60 * 24 }}>
+          {Array.from({ length: 24 }).map((_, h) => (
+            <div
+              key={h}
+              id={`p1an-hour-${h}-${userId}`}
+              className="absolute w-full border-t border-gray-200 text-xs text-gray-500"
+              style={{ top: h * 60 * PX_PER_MIN }}
+            >
+              <span className="-mt-2 block w-12">
+                {String(h).padStart(2, '0')}:00
+              </span>
+            </div>
+          ))}
+          {sorted.map((b, idx) => {
+            const top = minutesOf(b.start) * PX_PER_MIN;
+            const height = (minutesOf(b.end) - minutesOf(b.start)) * PX_PER_MIN;
+            return (
+              <div
+                key={b.id}
+                id={`p1an-blk-${b.id}-${userId}`}
+                data-selected={selected === b.id ? 'true' : undefined}
+                className="absolute left-1 right-1 cursor-pointer rounded text-sm text-white"
+                style={{
+                  top,
+                  height,
+                  backgroundColor: b.color,
+                  zIndex: sorted.length - idx,
+                }}
+                onMouseDown={(e) => startDrag(e, b.id)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setSelected(b.id);
+                }}
+              >
+                <div
+                  className="absolute left-0 right-0 top-0 h-2 cursor-n-resize"
+                  onMouseDown={(e) => startResize(e, b.id, 'top')}
+                />
+                <div className="h-full w-full overflow-hidden p-1">
+                  {b.title}
+                </div>
+                <div
+                  className="absolute bottom-0 left-0 right-0 h-2 cursor-s-resize"
+                  onMouseDown={(e) => startResize(e, b.id, 'bottom')}
+                />
+              </div>
+            );
+          })}
+          <button
+            id={`p1an-add-fab-${userId}`}
+            disabled={!editable}
+            title={!editable ? 'Read-only in viewing mode' : ''}
+            onClick={addBlock}
+            className="absolute bottom-2 right-2 h-10 w-10 rounded-full bg-orange-500 text-white disabled:opacity-50"
+          >
+            +
+          </button>
+        </div>
+      </div>
+      <div className="relative w-1/2 p-4">
+        {selectedBlock && (
+          <div
+            id={`p1an-meta-${selectedBlock.id}-${userId}`}
+            className="space-y-4"
+          >
+            {!editable && (
+              <div className="text-xs text-gray-500">
+                Read-only (viewing mode)
+              </div>
+            )}
+            <div>
+              <label
+                className="block text-sm font-medium"
+                htmlFor={`p1an-meta-ttl-${selectedBlock.id}-${userId}`}
+              >
+                Activity
+              </label>
+              <input
+                id={`p1an-meta-ttl-${selectedBlock.id}-${userId}`}
+                type="text"
+                maxLength={60}
+                value={selectedBlock.title}
+                onChange={(e) =>
+                  updateBlock(selectedBlock.id, { title: e.target.value })
+                }
+                disabled={!editable}
+                className="w-full rounded border p-1"
+              />
+            </div>
+            <div>
+              <label
+                className="block text-sm font-medium"
+                htmlFor={`p1an-meta-dsc-${selectedBlock.id}-${userId}`}
+              >
+                Description
+              </label>
+              <textarea
+                id={`p1an-meta-dsc-${selectedBlock.id}-${userId}`}
+                maxLength={500}
+                value={selectedBlock.description}
+                onChange={(e) =>
+                  updateBlock(selectedBlock.id, { description: e.target.value })
+                }
+                disabled={!editable}
+                className="w-full rounded border p-1"
+                rows={6}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium">Color</label>
+              <div
+                id={`p1an-meta-col-${selectedBlock.id}-${userId}`}
+                className="flex flex-wrap gap-2"
+              >
+                {COLORS.map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    disabled={!editable}
+                    onClick={() => updateBlock(selectedBlock.id, { color: c })}
+                    className={`h-6 w-6 rounded-full border ${selectedBlock.color === c ? 'ring-2 ring-black' : ''}`}
+                    style={{ backgroundColor: c }}
+                  />
+                ))}
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm font-medium">Time</label>
+              <div
+                className="flex gap-2"
+                id={`p1an-meta-col-${selectedBlock.id}-${userId}`}
+              >
+                <input
+                  id={`p1an-meta-tms-${selectedBlock.id}-${userId}`}
+                  type="time"
+                  step={900}
+                  value={selectedBlock.start.toISOString().slice(11, 16)}
+                  onChange={(e) => {
+                    const [h, m] = e.target.value.split(':').map(Number);
+                    const start = new Date(selectedBlock.start);
+                    start.setHours(h, m, 0, 0);
+                    if (start >= selectedBlock.end)
+                      start.setTime(selectedBlock.end.getTime() - SNAP * 60000);
+                    updateBlock(selectedBlock.id, { start });
+                  }}
+                  disabled={!editable}
+                  className="rounded border p-1"
+                />
+                <span>→</span>
+                <input
+                  id={`p1an-meta-tme-${selectedBlock.id}-${userId}`}
+                  type="time"
+                  step={900}
+                  value={selectedBlock.end.toISOString().slice(11, 16)}
+                  onChange={(e) => {
+                    const [h, m] = e.target.value.split(':').map(Number);
+                    const end = new Date(selectedBlock.end);
+                    end.setHours(h, m, 0, 0);
+                    if (end <= selectedBlock.start)
+                      end.setTime(selectedBlock.start.getTime() + SNAP * 60000);
+                    updateBlock(selectedBlock.id, { end });
+                  }}
+                  disabled={!editable}
+                  className="rounded border p-1"
+                />
+              </div>
+            </div>
+            <div className="flex justify-end gap-2 pt-4">
+              <button
+                id={`p1an-meta-close-${userId}`}
+                type="button"
+                onClick={closePanel}
+                className="rounded border px-3 py-1"
+              >
+                X
+              </button>
+              <button
+                id={`p1an-meta-save-${userId}`}
+                type="button"
+                onClick={save}
+                disabled={!editable}
+                className="rounded bg-orange-500 px-3 py-1 text-white disabled:opacity-50"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/planning/page.tsx
+++ b/app/(app)/planning/page.tsx
@@ -1,9 +1,7 @@
+import PlanningLanding from './landing';
+
 export function PlanningHome() {
-  return (
-    <section>
-      <h1 className="text-2xl font-bold">Planning</h1>
-    </section>
-  );
+  return <PlanningLanding />;
 }
 
 export default function PlanningPage() {

--- a/app/(view)/view/[viewId]/planning/next/page.tsx
+++ b/app/(view)/view/[viewId]/planning/next/page.tsx
@@ -1,0 +1,29 @@
+import { getUserByViewId } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { getPlan } from '@/lib/planning-store';
+import PlanningEditor from '@/app/(app)/planning/next/planner';
+
+function tomorrowISO() {
+  const now = new Date();
+  now.setDate(now.getDate() + 1);
+  return now.toISOString().slice(0, 10);
+}
+
+export default async function ViewPlanningNextPage({
+  params,
+}: {
+  params: Promise<{ viewId: string }>;
+}) {
+  const { viewId } = await params;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const date = tomorrowISO();
+  const { blocks } = await getPlan(String(user.id), date);
+  return (
+    <PlanningEditor
+      userId={String(user.id)}
+      initialBlocks={blocks}
+      date={date}
+    />
+  );
+}

--- a/drizzle/0007_planning.sql
+++ b/drizzle/0007_planning.sql
@@ -1,0 +1,20 @@
+CREATE TABLE plans (
+  id serial PRIMARY KEY,
+  user_id integer NOT NULL REFERENCES users(id),
+  date date NOT NULL,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now()
+);
+CREATE UNIQUE INDEX plans_user_date_idx ON plans (user_id, date);
+
+CREATE TABLE plan_blocks (
+  id serial PRIMARY KEY,
+  plan_id integer NOT NULL REFERENCES plans(id) ON DELETE CASCADE,
+  start timestamp NOT NULL,
+  "end" timestamp NOT NULL,
+  title varchar(60),
+  description text,
+  color varchar(10),
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now()
+);

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -5,6 +5,7 @@ import {
   varchar,
   timestamp,
   integer,
+  date,
   pgEnum,
   uniqueIndex,
 } from 'drizzle-orm/pg-core';
@@ -108,4 +109,29 @@ export const notifications = pgTable('notifications', {
   type: notificationTypeEnum('type').notNull(),
   createdAt: timestamp('created_at').defaultNow(),
   readAt: timestamp('read_at'),
+});
+export const plans = pgTable(
+  'plans',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id').references(() => users.id).notNull(),
+    date: date('date').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+    updatedAt: timestamp('updated_at').defaultNow(),
+  },
+  (table) => ({
+    userDateIdx: uniqueIndex('plans_user_date_idx').on(table.userId, table.date),
+  }),
+);
+
+export const planBlocks = pgTable('plan_blocks', {
+  id: serial('id').primaryKey(),
+  planId: integer('plan_id').references(() => plans.id).notNull(),
+  start: timestamp('start').notNull(),
+  end: timestamp('end').notNull(),
+  title: varchar('title', { length: 60 }),
+  description: text('description'),
+  color: varchar('color', { length: 10 }),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
 });

--- a/lib/planning-store.ts
+++ b/lib/planning-store.ts
@@ -1,0 +1,109 @@
+import { db } from './db';
+import { plans, planBlocks } from './db/schema';
+import { and, eq, inArray } from 'drizzle-orm';
+import type { Plan, PlanBlock, PlanBlockInput } from '@/types/plan';
+
+function toPlan(row: typeof plans.$inferSelect): Plan {
+  return {
+    id: String(row.id),
+    userId: String(row.userId),
+    date: row.date ?? '',
+    createdAt: row.createdAt?.toISOString() ?? '',
+    updatedAt: row.updatedAt?.toISOString() ?? '',
+  };
+}
+
+function toBlock(row: typeof planBlocks.$inferSelect): PlanBlock {
+  return {
+    id: String(row.id),
+    planId: String(row.planId),
+    start: row.start?.toISOString() ?? '',
+    end: row.end?.toISOString() ?? '',
+    title: row.title ?? '',
+    description: row.description ?? '',
+    color: row.color ?? '#60a5fa',
+    createdAt: row.createdAt?.toISOString() ?? '',
+    updatedAt: row.updatedAt?.toISOString() ?? '',
+  };
+}
+
+export async function getPlan(
+  userId: string,
+  date: string,
+): Promise<{ plan: Plan | null; blocks: PlanBlock[] }> {
+  const [planRow] = await db
+    .select()
+    .from(plans)
+    .where(and(eq(plans.userId, Number(userId)), eq(plans.date, date)));
+  if (!planRow) return { plan: null, blocks: [] };
+  const blockRows = await db
+    .select()
+    .from(planBlocks)
+    .where(eq(planBlocks.planId, planRow.id))
+    .orderBy(planBlocks.start);
+  return { plan: toPlan(planRow), blocks: blockRows.map(toBlock) };
+}
+
+export async function savePlan(
+  userId: string,
+  date: string,
+  items: PlanBlockInput[],
+): Promise<PlanBlock[]> {
+  let planRow = (
+    await db
+      .select()
+      .from(plans)
+      .where(and(eq(plans.userId, Number(userId)), eq(plans.date, date)))
+  )[0];
+  if (!planRow) {
+    const [p] = await db
+      .insert(plans)
+      .values({ userId: Number(userId), date })
+      .returning();
+    planRow = p;
+  }
+  const existing = await db
+    .select()
+    .from(planBlocks)
+    .where(eq(planBlocks.planId, planRow.id));
+  const existingIds = new Set(existing.map((b) => String(b.id)));
+  const inputIds = new Set(items.filter((b) => b.id).map((b) => String(b.id)));
+  // upsert
+  for (const item of items) {
+    if (item.id && existingIds.has(String(item.id))) {
+      await db
+        .update(planBlocks)
+        .set({
+          start: new Date(item.start),
+          end: new Date(item.end),
+          title: item.title,
+          description: item.description,
+          color: item.color,
+          updatedAt: new Date(),
+        })
+        .where(eq(planBlocks.id, Number(item.id)));
+    } else {
+      await db.insert(planBlocks).values({
+        planId: planRow.id,
+        start: new Date(item.start),
+        end: new Date(item.end),
+        title: item.title,
+        description: item.description,
+        color: item.color,
+      });
+    }
+  }
+  // delete removed
+  const toDelete = [...existingIds].filter((id) => !inputIds.has(id));
+  if (toDelete.length) {
+    await db
+      .delete(planBlocks)
+      .where(inArray(planBlocks.id, toDelete.map(Number)));
+  }
+  const result = await db
+    .select()
+    .from(planBlocks)
+    .where(eq(planBlocks.planId, planRow.id))
+    .orderBy(planBlocks.start);
+  return result.map(toBlock);
+}

--- a/tests/planning.spec.ts
+++ b/tests/planning.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+async function signup(page) {
+  const handle = `user${Date.now()}`;
+  const email = `${handle}@example.com`;
+  const password = 'pass1234';
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Tester');
+  await page.fill('input[placeholder="Handle"]', handle);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+}
+
+test('planning landing and add block', async ({ page }) => {
+  await signup(page);
+  await page.goto('/planning');
+  await expect(page.locator('[id^="p1an-btn-next"]')).toBeVisible();
+  await expect(page.locator('[id^="p1an-btn-live"]')).toBeVisible();
+  await expect(page.locator('[id^="p1an-btn-review"]')).toBeVisible();
+  await page.click('[id^="p1an-btn-next"]');
+  await expect(page.locator('[id^="p1an-timecol"]')).toBeVisible();
+  await page.click('[id^="p1an-add-top"]');
+  const block = page.locator('[id^="p1an-blk-"]').first();
+  await expect(block).toBeVisible();
+});

--- a/types/plan.ts
+++ b/types/plan.ts
@@ -1,0 +1,26 @@
+export interface Plan {
+  id: string;
+  userId: string;
+  date: string; // YYYY-MM-DD
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PlanBlock {
+  id: string;
+  planId: string;
+  start: string; // ISO datetime
+  end: string; // ISO datetime
+  title: string;
+  description: string;
+  color: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type PlanBlockInput = Omit<
+  PlanBlock,
+  'id' | 'planId' | 'createdAt' | 'updatedAt'
+> & {
+  id?: string;
+};


### PR DESCRIPTION
## Summary
- add planning landing with three navigation buttons and live indicator
- introduce next-day planning editor with draggable time blocks and metadata panel
- add Plan and PlanBlock schema and storage utilities

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a338be512c832aa18d1cdf74dc9a5d