### PR TITLE
Improve next-day planner interactions

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -54,3 +54,4 @@
 - 2025-09-24: Awaited subflavor route params and added view-mode subflavor path so profile viewers can browse without editing.
 - 2025-09-25: Added Planning landing with mode buttons and next-day planner editor with draggable time blocks, metadata panel, persistence, and read-only viewer mode.
 - 2025-09-25: Enabled block edge resizing with 15-minute snap, kept next-day planner open on save, and tightened timeline to show all hours with side labels.
+- 2025-09-26: Improved next-day planner with cursor feedback near block edges, persistent metadata panel on click, and hourly time column from 00:00 to 24:00.


### PR DESCRIPTION
## Summary
- show hourly labels along a dedicated left column from 00:00–24:00
- persist metadata panel on click and ignore drags; close on outside click
- change cursor to resize when near block edges

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a34289730c832a9e052ecc9161a560