### PR TITLE
fix: align planner times and add block deletion

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -55,3 +55,4 @@
 - 2025-09-25: Added Planning landing with mode buttons and next-day planner editor with draggable time blocks, metadata panel, persistence, and read-only viewer mode.
 - 2025-09-25: Enabled block edge resizing with 15-minute snap, kept next-day planner open on save, and tightened timeline to show all hours with side labels.
 - 2025-09-26: Improved next-day planner with cursor feedback near block edges, persistent metadata panel on click, and hourly time column from 00:00 to 24:00.
+- 2025-09-27: Fixed timezone display mismatch in planner, enabled cross-day block navigation via drag, and added delete control in block metadata.

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -4,13 +4,22 @@ import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
 import EditorClient from './client';
 
-export default async function PlanningNextPage() {
+export default async function PlanningNextPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ date?: string }>;
+}) {
   const session = await auth();
   if (!session) notFound();
   const me = await ensureUser(session);
+  const { date: rawDate } = await searchParams;
   const now = new Date();
-  const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
-  const date = tomorrow.toISOString().slice(0, 10);
+  const tomorrow = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() + 1,
+  );
+  const date = rawDate || tomorrow.toISOString().slice(0, 10);
   const plan = await getPlan(String(me.id), date);
   return (
     <EditorClient userId={String(me.id)} date={date} initialPlan={plan} />

--- a/app/(view)/view/[viewId]/planning/next/page.tsx
+++ b/app/(view)/view/[viewId]/planning/next/page.tsx
@@ -5,15 +5,22 @@ import EditorClient from '@/app/(app)/planning/next/client';
 
 export default async function ViewPlanningNextPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ viewId: string }>;
+  searchParams: Promise<{ date?: string }>;
 }) {
   const { viewId } = await params;
+  const { date: rawDate } = await searchParams;
   const user = await getUserByViewId(viewId);
   if (!user) notFound();
   const now = new Date();
-  const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
-  const date = tomorrow.toISOString().slice(0, 10);
+  const tomorrow = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() + 1,
+  );
+  const date = rawDate || tomorrow.toISOString().slice(0, 10);
   const plan = await getPlan(String(user.id), date);
   return (
     <section id={`v13w-plan-${user.id}`}>


### PR DESCRIPTION
## Summary
- show local times in planner metadata and allow cross-day drag navigation
- load planning pages by ?date parameter
- allow deleting blocks from metadata panel

## Testing
- `pnpm format` *(fails: Command "format" not found)*
- `pnpm lint`
- `pnpm type-check` *(fails: Command "type-check" not found)*
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a34b2ec3ac832aa6dabf0d8c11ce04