### PR TITLE
fix planner timezone mismatch and add block delete

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -55,3 +55,4 @@
 - 2025-09-25: Added Planning landing with mode buttons and next-day planner editor with draggable time blocks, metadata panel, persistence, and read-only viewer mode.
 - 2025-09-25: Enabled block edge resizing with 15-minute snap, kept next-day planner open on save, and tightened timeline to show all hours with side labels.
 - 2025-09-26: Improved next-day planner with cursor feedback near block edges, persistent metadata panel on click, and hourly time column from 00:00 to 24:00.
+- 2025-09-27: Aligned planner metadata times with timeline, added block deletion, and enabled cross-day navigation by dragging beyond timeline bounds.

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -4,15 +4,21 @@ import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
 import EditorClient from './client';
 
-export default async function PlanningNextPage() {
+export default async function PlanningNextPage({
+  searchParams,
+}: {
+  searchParams: { date?: string };
+}) {
   const session = await auth();
   if (!session) notFound();
   const me = await ensureUser(session);
   const now = new Date();
-  const tomorrow = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
-  const date = tomorrow.toISOString().slice(0, 10);
-  const plan = await getPlan(String(me.id), date);
-  return (
-    <EditorClient userId={String(me.id)} date={date} initialPlan={plan} />
+  const tomorrow = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate() + 1,
   );
+  const date = searchParams.date ?? tomorrow.toISOString().slice(0, 10);
+  const plan = await getPlan(String(me.id), date);
+  return <EditorClient userId={String(me.id)} date={date} initialPlan={plan} />;
 }


### PR DESCRIPTION
## Summary
- convert planner block times to local values so metadata matches timeline
- support dragging blocks past bounds to jump between days
- allow removing a block from the metadata panel

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a34b2ec3ac832aa6dabf0d8c11ce04