### PR TITLE
fix: allow viewing next-day planning read-only

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -59,3 +59,4 @@
 - 2025-09-27: Prevented planner glitches by clamping blocks to 23:59 and restricting cross-day jumps to block moves.
 - 2025-09-27: Awaited planner search params to remove runtime warnings when loading the next-day page.
 - 2025-09-27: Dropped dragging when the cursor leaves the timeline, preventing disappearing planner blocks.
+- 2025-09-27: Enabled viewing next-day planning in read-only mode via view routes and added test coverage.

--- a/app/(app)/planning/client.tsx
+++ b/app/(app)/planning/client.tsx
@@ -6,8 +6,14 @@ import { Button } from '@/components/ui/button';
 
 export default function PlanningLanding({ userId }: { userId: string }) {
   const router = useRouter();
-  const { editable } = useViewContext();
+  const { editable, viewId } = useViewContext();
   const tooltip = editable ? undefined : 'Read-only in viewing mode.';
+
+  function handleNext() {
+    if (editable) router.push('/planning/next');
+    else if (viewId) router.push(`/view/${viewId}/planning/next`);
+  }
+
   return (
     <section
       id={`p1an-landing-${userId}`}
@@ -15,9 +21,8 @@ export default function PlanningLanding({ userId }: { userId: string }) {
     >
       <Button
         id={`p1an-btn-next-${userId}`}
-        disabled={!editable}
         title={tooltip}
-        onClick={() => editable && router.push('/planning/next')}
+        onClick={handleNext}
       >
         Planning for Next Day
       </Button>

--- a/tests/view-planning.spec.ts
+++ b/tests/view-planning.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+
+// viewer should be able to view next-day plan but not edit
+// reuse password for simplicity
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+test('viewer can read next-day plan without editing', async ({ page }) => {
+  const handleA = unique('owner');
+  const emailA = `${handleA}@example.com`;
+
+  // sign up owner and create a plan block
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', handleA);
+  await page.fill('input[placeholder="Email"]', emailA);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  await page.goto('/planning');
+  await page.click('[id^="p1an-btn-next-"]');
+  await page.click('[id^="p1an-add-top-"]');
+  await page.fill('input[id^="p1an-meta-ttl-"]', 'Task');
+  await page.click('button[id^="p1an-meta-save-"]');
+
+  // fetch view link for owner
+  await page.goto(`/u/${handleA}`);
+  const viewHref = await page.getAttribute('[id^="pr0ovr-view-"]', 'href');
+
+  // sign out
+  await page.click('text=Sign out');
+
+  // sign up viewer
+  const handleB = unique('viewer');
+  const emailB = `${handleB}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Viewer');
+  await page.fill('input[placeholder="Handle"]', handleB);
+  await page.fill('input[placeholder="Email"]', emailB);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  // navigate to owner's planning via view link
+  await page.goto(`${viewHref}/planning`);
+  await page.click('[id^="p1an-btn-next-"]');
+
+  // verify block is visible and metadata is read-only
+  await expect(page.locator('[id^="p1an-blk-"]')).toHaveCount(1);
+  await page.click('[id^="p1an-blk-"]');
+  await expect(page.locator('[id^="p1an-meta-"]')).toBeVisible();
+  await expect(page.locator('button[id^="p1an-meta-save-"]')).toBeDisabled();
+  await expect(page.locator('input[id^="p1an-meta-ttl-"]')).toBeDisabled();
+});


### PR DESCRIPTION
## Summary
- enable navigation to next-day planning in view mode while keeping it read-only
- cover read-only view of next-day plan with Playwright test

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a35a466f50832a9eff36bcaaace98a