### PR TITLE
feat: auto-save planning metadata

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -61,3 +61,4 @@
 - 2025-09-27: Dropped dragging when the cursor leaves the timeline, preventing disappearing planner blocks.
 - 2025-09-27: Enabled viewing next-day planning in read-only mode via view routes and added test coverage.
 - 2025-09-27: Ensured nested planning blocks render above their containers and added regression test.
+- 2025-09-27: Removed planning metadata save button and enabled automatic persistence on edit with updated tests.

--- a/tests/planning.spec.ts
+++ b/tests/planning.spec.ts
@@ -53,8 +53,8 @@ test('next day planning flow', async ({ page }) => {
   );
   await page.mouse.up();
 
-  await page.click('button[id^="p1an-meta-save-"]');
-  await expect(page).toHaveURL('/planning/next');
+  await page.click('button[id^="p1an-meta-close-"]');
+  await page.waitForTimeout(1000);
   await expect(page.locator('[id^="p1an-meta-"]')).toHaveCount(0);
   await page.goto('/planning');
   await page.click('[id^="p1an-btn-next-"]');

--- a/tests/view-planning.spec.ts
+++ b/tests/view-planning.spec.ts
@@ -24,7 +24,8 @@ test('viewer can read next-day plan without editing', async ({ page }) => {
   await page.click('[id^="p1an-btn-next-"]');
   await page.click('[id^="p1an-add-top-"]');
   await page.fill('input[id^="p1an-meta-ttl-"]', 'Task');
-  await page.click('button[id^="p1an-meta-save-"]');
+  await page.click('button[id^="p1an-meta-close-"]');
+  await page.waitForTimeout(1000);
 
   // fetch view link for owner
   await page.goto(`/u/${handleA}`);
@@ -51,6 +52,6 @@ test('viewer can read next-day plan without editing', async ({ page }) => {
   await expect(page.locator('[id^="p1an-blk-"]')).toHaveCount(1);
   await page.click('[id^="p1an-blk-"]');
   await expect(page.locator('[id^="p1an-meta-"]')).toBeVisible();
-  await expect(page.locator('button[id^="p1an-meta-save-"]')).toBeDisabled();
+  await expect(page.locator('button[id^="p1an-meta-save-"]')).toHaveCount(0);
   await expect(page.locator('input[id^="p1an-meta-ttl-"]')).toBeDisabled();
 });


### PR DESCRIPTION
## Summary
- auto-save plan block edits and drop manual Save button
- adjust e2e tests for auto-save
- log change in UPDATE.md

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a362e650fc832a82582490d95abe4b