### PR TITLE
feat: adjustable planning timeline with custom range

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -62,3 +62,4 @@
 - 2025-09-27: Enabled viewing next-day planning in read-only mode via view routes and added test coverage.
 - 2025-09-27: Ensured nested planning blocks render above their containers and added regression test.
 - 2025-09-27: Removed planning metadata save button and enabled automatic persistence on edit with updated tests.
+- 2025-09-27: Added adjustable planner range with default 05:00–22:00 view, earlier/later loading, and custom time inputs to resize the timeline.


### PR DESCRIPTION
## Summary
- emphasize 05:00-22:00 by default and dynamically scale the planner timeline
- allow loading earlier/later hours or choosing a custom start/end range
- log new planner range feature in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a369886718832a9a2f21e30a91b6bd