### PR TITLE
Add live planning view with real-time timeline indicator

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -64,3 +64,4 @@
 - 2025-09-27: Removed planning metadata save button and enabled automatic persistence on edit with updated tests.
 - 2025-09-27: Added adjustable planner range with default 05:00–22:00 view, earlier/later loading, and custom time inputs to resize the timeline.
 - 2025-09-27: Placed new timeslots within custom range, falling back to 30-minute or random 1-hour blocks when space is limited.
+- 2025-09-28: Introduced live planning view with real-time indicator, automatic block metadata selection, and viewer support.

--- a/app/(app)/planning/client.tsx
+++ b/app/(app)/planning/client.tsx
@@ -14,6 +14,11 @@ export default function PlanningLanding({ userId }: { userId: string }) {
     else if (viewId) router.push(`/view/${viewId}/planning/next`);
   }
 
+  function handleLive() {
+    if (editable) router.push('/planning/live');
+    else if (viewId) router.push(`/view/${viewId}/planning/live`);
+  }
+
   return (
     <section
       id={`p1an-landing-${userId}`}
@@ -32,8 +37,8 @@ export default function PlanningLanding({ userId }: { userId: string }) {
         </span>
         <Button
           id={`p1an-btn-live-${userId}`}
-          disabled={!editable}
           title={tooltip}
+          onClick={handleLive}
         >
           Live Planning
         </Button>

--- a/app/(app)/planning/live/page.tsx
+++ b/app/(app)/planning/live/page.tsx
@@ -1,0 +1,22 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { getPlan } from '@/lib/plans-store';
+import EditorClient from '../next/client';
+
+export default async function PlanningLivePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ date?: string }>;
+}) {
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const now = new Date();
+  const { date: raw } = await searchParams;
+  const date = raw ?? now.toISOString().slice(0, 10);
+  const plan = await getPlan(String(me.id), date);
+  return (
+    <EditorClient userId={String(me.id)} date={date} initialPlan={plan} live />
+  );
+}

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -31,9 +31,15 @@ interface Props {
   userId: string;
   date: string; // YYYY-MM-DD
   initialPlan: Plan | null;
+  live?: boolean;
 }
 
-export default function EditorClient({ userId, date, initialPlan }: Props) {
+export default function EditorClient({
+  userId,
+  date,
+  initialPlan,
+  live = false,
+}: Props) {
   const { editable } = useViewContext();
   const [blocks, setBlocks] = useState<PlanBlock[]>(initialPlan?.blocks ?? []);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -51,6 +57,29 @@ export default function EditorClient({ userId, date, initialPlan }: Props) {
   const PIXELS_PER_MINUTE = TIMELINE_HEIGHT / visibleMinutes;
   const startHour = Math.floor(startMinute / 60);
   const endHour = Math.ceil(endMinute / 60);
+
+  const [nowMinute, setNowMinute] = useState(() => {
+    if (!live) return 0;
+    const d = new Date();
+    return d.getHours() * 60 + d.getMinutes();
+  });
+
+  useEffect(() => {
+    if (!live) return;
+    const tick = () => {
+      const d = new Date();
+      setNowMinute(d.getHours() * 60 + d.getMinutes());
+    };
+    tick();
+    const id = setInterval(tick, 60_000);
+    return () => clearInterval(id);
+  }, [live]);
+
+  useEffect(() => {
+    if (!live) return;
+    if (nowMinute < startMinute) setStartMinute(0);
+    if (nowMinute > endMinute) setEndMinute(MAX_MINUTES);
+  }, [live, nowMinute, startMinute, endMinute]);
 
   const minutesFromIso = useCallback(
     (iso: string) => {
@@ -350,6 +379,40 @@ export default function EditorClient({ userId, date, initialPlan }: Props) {
     return depthMap;
   }, [sortedBlocks, minutesFromIso]);
 
+  const liveBlocks = useMemo(() => {
+    if (!live) return [] as PlanBlock[];
+    return blocks.filter((b) => {
+      const s = minutesFromIso(b.start);
+      const e = minutesFromIso(b.end);
+      return s <= nowMinute && nowMinute < e;
+    });
+  }, [blocks, minutesFromIso, nowMinute, live]);
+
+  const currentBlock = useMemo(() => {
+    if (!liveBlocks.length) return null;
+    return liveBlocks.reduce(
+      (latest, b) =>
+        minutesFromIso(b.start) > minutesFromIso(latest.start) ? b : latest,
+      liveBlocks[0],
+    );
+  }, [liveBlocks, minutesFromIso]);
+
+  useEffect(() => {
+    if (!live) return;
+    if (currentBlock) setSelectedId(currentBlock.id);
+    else setSelectedId(null);
+  }, [live, currentBlock]);
+
+  const lineColor = useMemo(() => {
+    if (!live) return '#FF0000';
+    const overRed = blocks.some((b) => {
+      const s = minutesFromIso(b.start);
+      const e = minutesFromIso(b.end);
+      return s <= nowMinute && nowMinute < e && b.color === '#F87171';
+    });
+    return overRed ? '#0000FF' : '#FF0000';
+  }, [blocks, minutesFromIso, nowMinute, live]);
+
   return (
     <div className="flex h-full">
       <div
@@ -554,6 +617,22 @@ export default function EditorClient({ userId, date, initialPlan }: Props) {
                 </div>
               );
             })}
+            {live && nowMinute >= startMinute && nowMinute <= endMinute && (
+              <div
+                id={`p1an-now-${userId}`}
+                className="pointer-events-none absolute left-0 right-0 border-t-2 border-dotted"
+                style={{
+                  top: (nowMinute - startMinute) * PIXELS_PER_MINUTE,
+                  borderColor: lineColor,
+                  zIndex: 999999,
+                }}
+              >
+                <div
+                  className="absolute -left-2 -top-1 h-2 w-2 rounded-full"
+                  style={{ background: lineColor }}
+                />
+              </div>
+            )}
           </div>
         </div>
         {editable ? (

--- a/app/(view)/view/[viewId]/planning/live/page.tsx
+++ b/app/(view)/view/[viewId]/planning/live/page.tsx
@@ -1,0 +1,30 @@
+import { getUserByViewId } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { getPlan } from '@/lib/plans-store';
+import EditorClient from '@/app/(app)/planning/next/client';
+
+export default async function ViewPlanningLivePage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams: Promise<{ date?: string }>;
+}) {
+  const { viewId } = await params;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const now = new Date();
+  const { date: raw } = await searchParams;
+  const date = raw ?? now.toISOString().slice(0, 10);
+  const plan = await getPlan(String(user.id), date);
+  return (
+    <section id={`v13w-plan-${user.id}`}>
+      <EditorClient
+        userId={String(user.id)}
+        date={date}
+        initialPlan={plan}
+        live
+      />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- enable Live Planning navigation with dedicated routes
- add real-time "now" indicator with color swap on red blocks and auto-selected current block
- expose live planning in view mode

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a370e996dc832a969b3cf096be4106