### PR TITLE
Add live planning view with real-time timeline indicator

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -64,3 +64,5 @@
 - 2025-09-27: Removed planning metadata save button and enabled automatic persistence on edit with updated tests.
 - 2025-09-27: Added adjustable planner range with default 05:00–22:00 view, earlier/later loading, and custom time inputs to resize the timeline.
 - 2025-09-27: Placed new timeslots within custom range, falling back to 30-minute or random 1-hour blocks when space is limited.
+- 2025-09-28: Introduced live planning view with real-time indicator, automatic block metadata selection, and viewer support.
+- 2025-09-28: Stored live planning adjustments locally without altering next-day plans.

--- a/app/(app)/planning/client.tsx
+++ b/app/(app)/planning/client.tsx
@@ -14,6 +14,11 @@ export default function PlanningLanding({ userId }: { userId: string }) {
     else if (viewId) router.push(`/view/${viewId}/planning/next`);
   }
 
+  function handleLive() {
+    if (editable) router.push('/planning/live');
+    else if (viewId) router.push(`/view/${viewId}/planning/live`);
+  }
+
   return (
     <section
       id={`p1an-landing-${userId}`}
@@ -32,8 +37,8 @@ export default function PlanningLanding({ userId }: { userId: string }) {
         </span>
         <Button
           id={`p1an-btn-live-${userId}`}
-          disabled={!editable}
           title={tooltip}
+          onClick={handleLive}
         >
           Live Planning
         </Button>

--- a/app/(app)/planning/live/page.tsx
+++ b/app/(app)/planning/live/page.tsx
@@ -1,0 +1,22 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { getPlan } from '@/lib/plans-store';
+import EditorClient from '../next/client';
+
+export default async function PlanningLivePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ date?: string }>;
+}) {
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const now = new Date();
+  const { date: raw } = await searchParams;
+  const date = raw ?? now.toISOString().slice(0, 10);
+  const plan = await getPlan(String(me.id), date);
+  return (
+    <EditorClient userId={String(me.id)} date={date} initialPlan={plan} live />
+  );
+}

--- a/app/(view)/view/[viewId]/planning/live/page.tsx
+++ b/app/(view)/view/[viewId]/planning/live/page.tsx
@@ -1,0 +1,30 @@
+import { getUserByViewId } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { getPlan } from '@/lib/plans-store';
+import EditorClient from '@/app/(app)/planning/next/client';
+
+export default async function ViewPlanningLivePage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams: Promise<{ date?: string }>;
+}) {
+  const { viewId } = await params;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const now = new Date();
+  const { date: raw } = await searchParams;
+  const date = raw ?? now.toISOString().slice(0, 10);
+  const plan = await getPlan(String(user.id), date);
+  return (
+    <section id={`v13w-plan-${user.id}`}>
+      <EditorClient
+        userId={String(user.id)}
+        date={date}
+        initialPlan={plan}
+        live
+      />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- enable Live Planning navigation with dedicated routes
- add real-time "now" indicator with color swap on red blocks and auto-selected current block
- expose live planning in view mode
- persist live planning adjustments locally without affecting next-day plans

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a370e996dc832a969b3cf096be4106