### PR TITLE
feat: add hidden time machine

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -66,3 +66,4 @@
 - 2025-09-27: Placed new timeslots within custom range, falling back to 30-minute or random 1-hour blocks when space is limited.
 - 2025-09-28: Introduced live planning view with real-time indicator, automatic block metadata selection, and viewer support.
 - 2025-09-28: Stored live planning adjustments locally without altering next-day plans.
+- 2025-09-29: Added hidden TimeMachine overlay triggered by clicking the "c" in "Piece" five times to override site date/time for testing.

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -7,6 +7,7 @@ import { Cake3D } from './cake-3d';
 import { SettingsButton } from './settings-button';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor, type Section } from '@/lib/navigation';
+import TimeMachine from '@/components/dev/time-machine';
 
 export function CakeNavigation() {
   const router = useRouter();
@@ -18,6 +19,9 @@ export function CakeNavigation() {
   const ctx = useViewContext();
   const userId = String(ctx.ownerId);
   const clearTimer = useRef<NodeJS.Timeout | null>(null);
+  const secretTimer = useRef<NodeJS.Timeout | null>(null);
+  const secretClicks = useRef(0);
+  const [timeMachineOpen, setTimeMachineOpen] = useState(false);
 
   useEffect(() => {
     const computeOffset = () => {
@@ -95,7 +99,24 @@ export function CakeNavigation() {
             fontSize: 'clamp(22px,2.4vw,32px)',
           }}
         >
-          A Piece Of Cake
+          A Pie
+          <span
+            onClick={() => {
+              secretClicks.current += 1;
+              if (secretClicks.current >= 5) {
+                setTimeMachineOpen(true);
+                secretClicks.current = 0;
+              }
+              if (secretTimer.current) clearTimeout(secretTimer.current);
+              secretTimer.current = setTimeout(() => {
+                secretClicks.current = 0;
+              }, 1000);
+            }}
+            className="cursor-default select-none"
+          >
+            c
+          </span>
+          e Of Cake
         </h1>
       </div>
       <div
@@ -133,9 +154,7 @@ export function CakeNavigation() {
                 id={`n4vbox-${slice.slug}-${userId}`}
                 data-popped={popped ? true : undefined}
                 aria-label={slice.label}
-                onClick={() =>
-                  router.push(hrefFor(slice.slug as Section, ctx))
-                }
+                onClick={() => router.push(hrefFor(slice.slug as Section, ctx))}
                 onMouseEnter={() => handleEnter(slice.slug)}
                 onMouseLeave={handleLeave}
                 onFocus={() => handleEnter(slice.slug)}
@@ -163,6 +182,10 @@ export function CakeNavigation() {
       <p className="sr-only" aria-live="polite">
         {hoveredLabel}
       </p>
+      <TimeMachine
+        open={timeMachineOpen}
+        onClose={() => setTimeMachineOpen(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add hidden TimeMachine overlay triggered by clicking the 'c' in 'Piece' 5 times
- allow overriding site date/time for testing and restore to system clock

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68a37734bdf0832ab03a8ffba5b369fe