### PR TITLE
feat: add hidden time machine

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -66,3 +66,5 @@
 - 2025-09-27: Placed new timeslots within custom range, falling back to 30-minute or random 1-hour blocks when space is limited.
 - 2025-09-28: Introduced live planning view with real-time indicator, automatic block metadata selection, and viewer support.
 - 2025-09-28: Stored live planning adjustments locally without altering next-day plans.
+- 2025-09-29: Added hidden TimeMachine overlay triggered by clicking the "c" in "Piece" five times to override site date/time for testing.
+- 2025-09-29: Added reset-to-current-time option (Dutch timezone) and auto-close behavior when applying overrides.

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -7,6 +7,7 @@ import { Cake3D } from './cake-3d';
 import { SettingsButton } from './settings-button';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor, type Section } from '@/lib/navigation';
+import TimeMachine from '@/components/dev/time-machine';
 
 export function CakeNavigation() {
   const router = useRouter();
@@ -18,6 +19,9 @@ export function CakeNavigation() {
   const ctx = useViewContext();
   const userId = String(ctx.ownerId);
   const clearTimer = useRef<NodeJS.Timeout | null>(null);
+  const secretTimer = useRef<NodeJS.Timeout | null>(null);
+  const secretClicks = useRef(0);
+  const [timeMachineOpen, setTimeMachineOpen] = useState(false);
 
   useEffect(() => {
     const computeOffset = () => {
@@ -95,7 +99,24 @@ export function CakeNavigation() {
             fontSize: 'clamp(22px,2.4vw,32px)',
           }}
         >
-          A Piece Of Cake
+          A Pie
+          <span
+            onClick={() => {
+              secretClicks.current += 1;
+              if (secretClicks.current >= 5) {
+                setTimeMachineOpen(true);
+                secretClicks.current = 0;
+              }
+              if (secretTimer.current) clearTimeout(secretTimer.current);
+              secretTimer.current = setTimeout(() => {
+                secretClicks.current = 0;
+              }, 1000);
+            }}
+            className="cursor-default select-none"
+          >
+            c
+          </span>
+          e Of Cake
         </h1>
       </div>
       <div
@@ -133,9 +154,7 @@ export function CakeNavigation() {
                 id={`n4vbox-${slice.slug}-${userId}`}
                 data-popped={popped ? true : undefined}
                 aria-label={slice.label}
-                onClick={() =>
-                  router.push(hrefFor(slice.slug as Section, ctx))
-                }
+                onClick={() => router.push(hrefFor(slice.slug as Section, ctx))}
                 onMouseEnter={() => handleEnter(slice.slug)}
                 onMouseLeave={handleLeave}
                 onFocus={() => handleEnter(slice.slug)}
@@ -163,6 +182,10 @@ export function CakeNavigation() {
       <p className="sr-only" aria-live="polite">
         {hoveredLabel}
       </p>
+      <TimeMachine
+        open={timeMachineOpen}
+        onClose={() => setTimeMachineOpen(false)}
+      />
     </div>
   );
 }

--- a/components/dev/time-machine.tsx
+++ b/components/dev/time-machine.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useRef, useState } from 'react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function TimeMachine({ open, onClose }: Props) {
+  const [stage, setStage] = useState<'code' | 'time'>('code');
+  const [code, setCode] = useState('');
+  const [error, setError] = useState('');
+  const [date, setDate] = useState('');
+  const realDateRef = useRef<DateConstructor | null>(null);
+
+  if (!open) return null;
+
+  function handleVerify() {
+    if (code.trim() === 'hsug') {
+      setStage('time');
+      setCode('');
+      setError('');
+    } else {
+      setError('Incorrect code');
+    }
+  }
+
+  function applyOverride() {
+    if (!date) return;
+    const t = new Date(date).getTime();
+    if (!realDateRef.current) {
+      realDateRef.current = Date;
+    }
+    const RealDate = realDateRef.current;
+    class MockDate extends RealDate {
+      constructor(...args: any[]) {
+        if (args.length === 0) {
+          super(t);
+        } else {
+          // @ts-ignore -- spread args for Date constructor
+          super(...args);
+        }
+      }
+      static now() {
+        return t;
+      }
+    }
+    (globalThis as any).Date = MockDate as unknown as DateConstructor;
+    handleClose();
+  }
+
+  function resetOverride() {
+    if (realDateRef.current) {
+      (globalThis as any).Date = realDateRef.current;
+      realDateRef.current = null;
+    }
+  }
+
+  function resetToCurrentNl() {
+    const amsString = new Date().toLocaleString('en-US', {
+      timeZone: 'Europe/Amsterdam',
+      timeZoneName: 'short',
+    });
+    const [base, tz] = amsString.split(' GMT');
+    const offset = parseInt(tz, 10) * 60 * 60 * 1000;
+    const t = new Date(base).getTime() - offset;
+    if (!realDateRef.current) {
+      realDateRef.current = Date;
+    }
+    const RealDate = realDateRef.current;
+    class MockDate extends RealDate {
+      constructor(...args: any[]) {
+        if (args.length === 0) {
+          super(t);
+        } else {
+          // @ts-ignore -- spread args for Date constructor
+          super(...args);
+        }
+      }
+      static now() {
+        return t;
+      }
+    }
+    (globalThis as any).Date = MockDate as unknown as DateConstructor;
+    handleClose();
+  }
+
+  function handleClose() {
+    setStage('code');
+    setCode('');
+    setError('');
+    setDate('');
+    onClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[1000] grid place-items-center bg-black/50"
+      onClick={handleClose}
+    >
+      <div
+        className="relative w-[min(90%,320px)] rounded bg-[var(--surface)] p-4 text-[var(--text)] shadow"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={handleClose}
+          className="absolute right-2 top-2 rounded px-2 text-sm text-[var(--text)] hover:bg-[var(--surface)]/80"
+        >
+          ×
+        </button>
+        {stage === 'code' ? (
+          <div className="mt-2">
+            <p className="mb-2">Enter code</p>
+            <input
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              className="mb-2 w-full rounded border border-[var(--border)] bg-transparent p-2"
+              type="password"
+            />
+            {error && <p className="mb-2 text-sm text-red-500">{error}</p>}
+            <button
+              onClick={handleVerify}
+              className="rounded bg-[var(--accent)] px-3 py-1 text-white"
+            >
+              Submit
+            </button>
+          </div>
+        ) : (
+          <div className="mt-2">
+            <p className="mb-2">Set site date & time</p>
+            <input
+              type="datetime-local"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="mb-2 w-full rounded border border-[var(--border)] bg-transparent p-2"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={applyOverride}
+                className="rounded bg-[var(--accent)] px-3 py-1 text-white"
+              >
+                Apply
+              </button>
+              <button
+                onClick={resetToCurrentNl}
+                className="rounded border border-[var(--border)] px-3 py-1"
+              >
+                Reset to current time
+              </button>
+              <button
+                onClick={resetOverride}
+                className="rounded border border-[var(--border)] px-3 py-1"
+              >
+                Restore
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default TimeMachine;


### PR DESCRIPTION
## Summary
- add hidden TimeMachine overlay triggered by clicking the 'c' in 'Piece' 5 times
- allow overriding site date/time and restore to system clock
- add "reset to current time" shortcut using Dutch timezone and close overlay after applying

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68a37734bdf0832ab03a8ffba5b369fe