### PR TITLE
feat: add historical profile snapshots

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -70,3 +70,4 @@
 - 2025-09-29: Added reset-to-current-time option (Dutch timezone) and auto-close behavior when applying overrides.
 - 2025-09-30: Added slide-out calendar panel on home screen with past 30 days and upcoming week view.
 - 2025-09-30: Enabled month navigation in slide-out calendar to jump one month backward or forward.
+- 2025-09-30: Introduced daily profile snapshots with historical viewing mode and calendar links to past profiles.

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { ensureUser } from '@/lib/users';
 import { buildViewContext } from '@/lib/profile';
 import { ViewContextProvider } from '@/lib/view-context';
 import { AppNav } from '@/components/app-nav';
+import { SnapshotScheduler } from '@/components/snapshot/scheduler';
 
 export default async function AppLayout({
   children,
@@ -30,6 +31,7 @@ export default async function AppLayout({
     <html lang="en">
       <body>
         <ViewContextProvider value={ctx}>
+          <SnapshotScheduler />
           <AppNav />
           <main className="p-4">
             <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId}`}>{children}</div>

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,5 +1,11 @@
 import { CakeHome } from '@/components/cake/cake-home';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { listSnapshotDates } from '@/lib/profile-snapshots';
 
-export default function DashboardPage() {
-  return <CakeHome />;
+export default async function DashboardPage() {
+  const session = await auth();
+  const me = await ensureUser(session);
+  const dates = await listSnapshotDates(me.id);
+  return <CakeHome snapshotDates={dates} />;
 }

--- a/app/(app)/snapshot/actions.ts
+++ b/app/(app)/snapshot/actions.ts
@@ -1,0 +1,12 @@
+'use server';
+
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { createProfileSnapshot } from '@/lib/profile-snapshots';
+
+export async function snapshotProfileAction(date: string) {
+  const session = await auth();
+  const me = await ensureUser(session);
+  const d = new Date(date);
+  await createProfileSnapshot(me.id, d);
+}

--- a/app/(view)/view/[viewId]/history/[date]/layout.tsx
+++ b/app/(view)/view/[viewId]/history/[date]/layout.tsx
@@ -1,0 +1,46 @@
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { getUserByViewId } from '@/lib/users';
+import { buildViewContext, canViewProfile } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { AppNav } from '@/components/app-nav';
+import { ViewerBar } from '@/components/viewer-bar';
+
+export default async function HistoryLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ viewId: string; date: string }>;
+}) {
+  const { viewId, date } = await params;
+  const session = await auth();
+  const viewerId = session?.user?.id ? Number(session.user.id) : null;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const allowed = await canViewProfile({
+    viewerId,
+    targetUser: { id: owner.id, accountVisibility: owner.accountVisibility as any },
+  });
+  if (!allowed) notFound();
+  const ctx = buildViewContext({
+    ownerId: owner.id,
+    viewerId,
+    mode: 'history',
+    viewId,
+    historyDate: date,
+  });
+  return (
+    <html lang="en">
+      <body>
+        <ViewContextProvider value={ctx}>
+          <AppNav />
+          <main className="p-4">
+            <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId || 0}`}>{children}</div>
+          </main>
+          <ViewerBar />
+        </ViewContextProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/(view)/view/[viewId]/history/[date]/page.tsx
+++ b/app/(view)/view/[viewId]/history/[date]/page.tsx
@@ -1,0 +1,25 @@
+import { notFound } from 'next/navigation';
+import { getUserByViewId } from '@/lib/users';
+import { getProfileSnapshot, listSnapshotDates } from '@/lib/profile-snapshots';
+import { CakeHome } from '@/components/cake/cake-home';
+
+export default async function HistoryPage({
+  params,
+}: {
+  params: Promise<{ viewId: string; date: string }>;
+}) {
+  const { viewId, date } = await params;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const snapshot = await getProfileSnapshot(user.id, new Date(date));
+  if (!snapshot) notFound();
+  const dates = await listSnapshotDates(user.id);
+  return (
+    <section id={`v13w-hist-${user.id}-${date}`}>
+      <CakeHome snapshotDates={dates} />
+      <pre className="mt-4 overflow-auto text-xs">
+        {JSON.stringify(snapshot, null, 2)}
+      </pre>
+    </section>
+  );
+}

--- a/app/(view)/view/[viewId]/page.tsx
+++ b/app/(view)/view/[viewId]/page.tsx
@@ -1,6 +1,7 @@
 import { getUserByViewId } from '@/lib/users';
 import { notFound } from 'next/navigation';
 import { CakeHome } from '@/components/cake/cake-home';
+import { listSnapshotDates } from '@/lib/profile-snapshots';
 
 export default async function ViewCakePage({
   params,
@@ -10,9 +11,10 @@ export default async function ViewCakePage({
   const { viewId } = await params;
   const user = await getUserByViewId(viewId);
   if (!user) notFound();
+  const dates = await listSnapshotDates(user.id);
   return (
     <section id={`v13w-cake-${user.id}`}>
-      <CakeHome />
+      <CakeHome snapshotDates={dates} />
     </section>
   );
 }

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -19,9 +19,9 @@ export function AppNav() {
   const ctx = useViewContext();
   const pathname = usePathname();
   const sections: Section[] =
-    ctx.mode === 'viewer'
-      ? ['cake', 'planning', 'flavors', 'ingredients', 'review', 'people']
-      : ['cake', 'planning', 'flavors', 'ingredients', 'review', 'people', 'visibility'];
+    ctx.mode === 'owner'
+      ? ['cake', 'planning', 'flavors', 'ingredients', 'review', 'people', 'visibility']
+      : ['cake', 'planning', 'flavors', 'ingredients', 'review', 'people'];
 
   return (
     <nav className="flex items-center justify-between border-b p-4">

--- a/components/cake/cake-home.tsx
+++ b/components/cake/cake-home.tsx
@@ -1,11 +1,15 @@
 import { SideCalendar } from '@/components/calendar/side-calendar';
 import { CakeNavigation } from './cake-navigation';
 
-export function CakeHome() {
+export function CakeHome({
+  snapshotDates = [],
+}: {
+  snapshotDates?: string[];
+}) {
   return (
     <section className="w-full">
       <h1 className="sr-only">Cake</h1>
-      <SideCalendar />
+      <SideCalendar snapshotDates={snapshotDates} />
       <CakeNavigation />
     </section>
   );

--- a/components/calendar/side-calendar.tsx
+++ b/components/calendar/side-calendar.tsx
@@ -1,11 +1,19 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
+import Link from 'next/link';
 import { cn } from '@/lib/utils';
+import { useViewContext } from '@/lib/view-context';
 
-export function SideCalendar() {
+export function SideCalendar({
+  snapshotDates = [],
+}: {
+  snapshotDates?: string[];
+}) {
   const [open, setOpen] = useState(false);
   const [monthOffset, setMonthOffset] = useState(0);
+  const ctx = useViewContext();
+  const snapshotSet = useMemo(() => new Set(snapshotDates), [snapshotDates]);
 
   const today = new Date();
   const base = new Date(today);
@@ -71,16 +79,29 @@ export function SideCalendar() {
             ))}
             {days.map((date) => {
               const isToday = date.toDateString() === today.toDateString();
-              return (
+              const iso = date.toISOString().slice(0, 10);
+              const hasSnapshot = snapshotSet.has(iso);
+              const day = (
                 <div
-                  key={date.toISOString()}
                   className={cn(
                     'p-1 rounded',
                     isToday && 'bg-orange-500 text-white font-bold',
+                    hasSnapshot && 'underline cursor-pointer',
                   )}
                 >
                   {date.getDate()}
                 </div>
+              );
+              return hasSnapshot ? (
+                <Link
+                  key={iso}
+                  href={`/view/${ctx.viewId}/history/${iso}`}
+                  aria-label={`View snapshot for ${iso}`}
+                >
+                  {day}
+                </Link>
+              ) : (
+                <div key={iso}>{day}</div>
               );
             })}
           </div>

--- a/components/snapshot/scheduler.tsx
+++ b/components/snapshot/scheduler.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { snapshotProfileAction } from '@/app/(app)/snapshot/actions';
+
+export function SnapshotScheduler() {
+  const lastDate = useRef<string>(new Date().toDateString());
+
+  useEffect(() => {
+    const check = () => {
+      const now = new Date();
+      const current = now.toDateString();
+      if (current !== lastDate.current) {
+        const y = new Date(now);
+        y.setDate(now.getDate() - 1);
+        snapshotProfileAction(y.toISOString().slice(0, 10));
+        lastDate.current = current;
+      }
+    };
+    const id = setInterval(check, 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  return null;
+}

--- a/components/viewer-bar.tsx
+++ b/components/viewer-bar.tsx
@@ -13,11 +13,13 @@ export function ViewerBar() {
       className="fixed bottom-4 left-4 z-40 rounded-md bg-black/30 px-3 py-2 text-sm text-white backdrop-blur-sm shadow-sm dark:bg-white/40 dark:text-black"
     >
       <span className="flex items-center gap-2">
-        Viewing (live)
+        {ctx.mode === 'history' ? 'Historical viewing mode' : 'Viewing (live)'}
         <span
           id={`v13wbar-live-${ctx.ownerId}-${ctx.viewerId || 0}`}
-          aria-label="live"
-          className="h-2 w-2 rounded-full bg-green-500"
+          aria-label={ctx.mode === 'history' ? 'historical' : 'live'}
+          className={`h-2 w-2 rounded-full ${
+            ctx.mode === 'history' ? 'bg-blue-500' : 'bg-green-500'
+          }`}
         />
         &bull;
         <button

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -8,6 +8,7 @@ import {
   integer,
   pgEnum,
   uniqueIndex,
+  jsonb,
 } from 'drizzle-orm/pg-core';
 
 export const accountVisibilityEnum = pgEnum('account_visibility', [
@@ -139,3 +140,20 @@ export const planBlocks = pgTable('plan_blocks', {
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),
 });
+
+export const profileSnapshots = pgTable(
+  'profile_snapshots',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id').references(() => users.id).notNull(),
+    snapshotDate: date('snapshot_date').notNull(),
+    data: jsonb('data').$type<any>().notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserDate: uniqueIndex('profile_snapshots_user_date_unique').on(
+      table.userId,
+      table.snapshotDate,
+    ),
+  }),
+);

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -21,11 +21,11 @@ export function hrefFor(
 ): string {
   if (sectionOrPath.startsWith('/')) {
     // raw path case
-    return ctx.mode === 'viewer'
+    return ctx.mode !== 'owner'
       ? `/view/${ctx.viewId}${sectionOrPath === '/' ? '' : sectionOrPath}`
       : sectionOrPath;
   }
-  if (ctx.mode === 'viewer') {
+  if (ctx.mode !== 'owner') {
     const base = `/view/${ctx.viewId}`;
     switch (sectionOrPath) {
       case 'cake':

--- a/lib/profile-snapshots.ts
+++ b/lib/profile-snapshots.ts
@@ -1,0 +1,84 @@
+import { db } from './db';
+import { users, flavors, subflavors, profileSnapshots } from './db/schema';
+import { eq, and } from 'drizzle-orm';
+
+export interface ProfileSnapshotData {
+  user: {
+    id: number;
+    handle: string;
+    displayName: string | null;
+    avatarUrl: string | null;
+    accountVisibility: string;
+    viewId: string;
+  };
+  flavors: any[];
+  subflavors: any[];
+}
+
+export async function createProfileSnapshot(userId: number, date: Date) {
+  const [user] = await db
+    .select({
+      id: users.id,
+      handle: users.handle,
+      displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
+      accountVisibility: users.accountVisibility,
+      viewId: users.viewId,
+    })
+    .from(users)
+    .where(eq(users.id, userId));
+  if (!user) return;
+
+  const flavorRows = await db
+    .select()
+    .from(flavors)
+    .where(eq(flavors.userId, userId));
+  const subRows = await db
+    .select()
+    .from(subflavors)
+    .where(eq(subflavors.userId, userId));
+
+  const data: ProfileSnapshotData = {
+    user,
+    flavors: flavorRows,
+    subflavors: subRows,
+  };
+
+  const iso = date.toISOString().slice(0, 10);
+  await db
+    .insert(profileSnapshots)
+    .values({
+      userId,
+      snapshotDate: iso,
+      data: data as any,
+    })
+    .onConflictDoNothing({
+      target: [profileSnapshots.userId, profileSnapshots.snapshotDate],
+    });
+}
+
+export async function getProfileSnapshot(
+  userId: number,
+  date: Date,
+): Promise<ProfileSnapshotData | null> {
+  const iso = date.toISOString().slice(0, 10);
+  const [row] = await db
+    .select({ data: profileSnapshots.data })
+    .from(profileSnapshots)
+    .where(
+      and(
+        eq(profileSnapshots.userId, userId),
+        eq(profileSnapshots.snapshotDate, iso),
+      ),
+    );
+  return (row?.data as ProfileSnapshotData) ?? null;
+}
+
+export async function listSnapshotDates(userId: number): Promise<string[]> {
+  const rows = await db
+    .select({ date: profileSnapshots.snapshotDate })
+    .from(profileSnapshots)
+    .where(eq(profileSnapshots.userId, userId))
+    .orderBy(profileSnapshots.snapshotDate);
+  return rows.map((r) => r.date);
+}

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -7,8 +7,9 @@ export interface ViewContext {
   ownerId: number;
   viewerId: number | null;
   viewId?: string;
-  mode: 'owner' | 'viewer';
+  mode: 'owner' | 'viewer' | 'history';
   editable: boolean;
+  historyDate?: string;
 }
 
 export function buildViewContext({
@@ -16,13 +17,22 @@ export function buildViewContext({
   viewerId,
   mode,
   viewId,
+  historyDate,
 }: {
   ownerId: number;
   viewerId: number | null;
-  mode: 'owner' | 'viewer';
+  mode: 'owner' | 'viewer' | 'history';
   viewId?: string;
+  historyDate?: string;
 }): ViewContext {
-  return { ownerId, viewerId, viewId, mode, editable: mode === 'owner' };
+  return {
+    ownerId,
+    viewerId,
+    viewId,
+    mode,
+    editable: mode === 'owner',
+    historyDate,
+  };
 }
 
 export async function canViewProfile({

--- a/lib/view-context.tsx
+++ b/lib/view-context.tsx
@@ -8,6 +8,7 @@ const Ctx = createContext<ViewContext>({
   viewId: undefined,
   mode: 'owner',
   editable: true,
+  historyDate: undefined,
 });
 
 export function ViewContextProvider({


### PR DESCRIPTION
## Summary
- snapshot user profile nightly and store in new `profile_snapshots` table
- show calendar links for snapshot days and add historical viewing mode UI
- provide scheduler to auto-create snapshots and viewer route for past profiles

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Please sign in)*

------
https://chatgpt.com/codex/tasks/task_e_68a381a7d7b0832a8276d6a69fecb9cb