### PR TITLE
feat: add profile snapshot history

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -70,3 +70,4 @@
 - 2025-09-29: Added reset-to-current-time option (Dutch timezone) and auto-close behavior when applying overrides.
 - 2025-09-30: Added slide-out calendar panel on home screen with past 30 days and upcoming week view.
 - 2025-09-30: Enabled month navigation in slide-out calendar to jump one month backward or forward.
+- 2025-08-18: Implemented profile snapshot system with historical viewing mode and calendar access.

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,5 +1,9 @@
 import { CakeHome } from '@/components/cake/cake-home';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
 
-export default function DashboardPage() {
-  return <CakeHome />;
+export default async function DashboardPage() {
+  const session = await auth();
+  const me = await ensureUser(session!);
+  return <CakeHome ownerId={me.id} />;
 }

--- a/app/(view)/view/[viewId]/page.tsx
+++ b/app/(view)/view/[viewId]/page.tsx
@@ -12,7 +12,7 @@ export default async function ViewCakePage({
   if (!user) notFound();
   return (
     <section id={`v13w-cake-${user.id}`}>
-      <CakeHome />
+      <CakeHome ownerId={user.id} />
     </section>
   );
 }

--- a/app/history/[viewId]/[date]/layout.tsx
+++ b/app/history/[viewId]/[date]/layout.tsx
@@ -1,0 +1,46 @@
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { getUserByViewId } from '@/lib/users';
+import { buildViewContext, canViewProfile } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { AppNav } from '@/components/app-nav';
+import { ViewerBar } from '@/components/viewer-bar';
+
+export default async function HistoryViewLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ viewId: string; date: string }>;
+}) {
+  const { viewId, date } = await params;
+  const session = await auth();
+  const viewerId = session?.user?.id ? Number(session.user.id) : null;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const allowed = await canViewProfile({
+    viewerId,
+    targetUser: { id: owner.id, accountVisibility: owner.accountVisibility as any },
+  });
+  if (!allowed) notFound();
+  const ctx = buildViewContext({
+    ownerId: owner.id,
+    viewerId,
+    mode: 'historical',
+    viewId,
+    snapshotDate: date,
+  });
+  return (
+    <html lang="en">
+      <body>
+        <ViewContextProvider value={ctx}>
+          <AppNav />
+          <main className="p-4">
+            <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId || 0}`}>{children}</div>
+          </main>
+          <ViewerBar />
+        </ViewContextProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/history/[viewId]/[date]/page.tsx
+++ b/app/history/[viewId]/[date]/page.tsx
@@ -1,0 +1,16 @@
+import { getUserByViewId } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+
+export default async function ViewHistoryPage({
+  params,
+}: {
+  params: Promise<{ viewId: string; date: string }>;
+}) {
+  const { viewId, date } = await params;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const snapshot = await getProfileSnapshot(owner.id, date);
+  if (!snapshot) notFound();
+  return <pre className="whitespace-pre-wrap">{JSON.stringify(snapshot, null, 2)}</pre>;
+}

--- a/app/history/self/[date]/page.tsx
+++ b/app/history/self/[date]/page.tsx
@@ -1,0 +1,17 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+
+export default async function HistoryPage({
+  params,
+}: {
+  params: Promise<{ date: string }>;
+}) {
+  const { date } = await params;
+  const session = await auth();
+  const me = await ensureUser(session!);
+  const snapshot = await getProfileSnapshot(me.id, date);
+  if (!snapshot) notFound();
+  return <pre className="whitespace-pre-wrap">{JSON.stringify(snapshot, null, 2)}</pre>;
+}

--- a/components/cake/cake-home.tsx
+++ b/components/cake/cake-home.tsx
@@ -1,11 +1,13 @@
 import { SideCalendar } from '@/components/calendar/side-calendar';
 import { CakeNavigation } from './cake-navigation';
+import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
 
-export function CakeHome() {
+export async function CakeHome({ ownerId }: { ownerId: number }) {
+  const snapshotDates = await listProfileSnapshotDates(ownerId);
   return (
     <section className="w-full">
       <h1 className="sr-only">Cake</h1>
-      <SideCalendar />
+      <SideCalendar snapshotDates={snapshotDates} />
       <CakeNavigation />
     </section>
   );

--- a/components/calendar/side-calendar.tsx
+++ b/components/calendar/side-calendar.tsx
@@ -1,11 +1,15 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
+import { useViewContext } from '@/lib/view-context';
 
-export function SideCalendar() {
+export function SideCalendar({ snapshotDates }: { snapshotDates: string[] }) {
   const [open, setOpen] = useState(false);
   const [monthOffset, setMonthOffset] = useState(0);
+  const router = useRouter();
+  const ctx = useViewContext();
 
   const today = new Date();
   const base = new Date(today);
@@ -71,16 +75,30 @@ export function SideCalendar() {
             ))}
             {days.map((date) => {
               const isToday = date.toDateString() === today.toDateString();
+              const iso = date.toISOString().slice(0, 10);
+              const hasSnap = snapshotDates.includes(iso);
               return (
-                <div
+                <button
                   key={date.toISOString()}
+                  disabled={!hasSnap}
+                  onClick={() => {
+                    if (!hasSnap) return;
+                    const path =
+                      ctx.mode === 'owner'
+                        ? `/history/self/${iso}`
+                        : `/history/${ctx.viewId}/${iso}`;
+                    router.push(path);
+                  }}
                   className={cn(
                     'p-1 rounded',
+                    hasSnap
+                      ? 'cursor-pointer hover:bg-orange-100'
+                      : 'text-zinc-400 cursor-default',
                     isToday && 'bg-orange-500 text-white font-bold',
                   )}
                 >
                   {date.getDate()}
-                </div>
+                </button>
               );
             })}
           </div>

--- a/components/viewer-bar.tsx
+++ b/components/viewer-bar.tsx
@@ -5,6 +5,17 @@ import { useViewContext } from '@/lib/view-context';
 export function ViewerBar() {
   const router = useRouter();
   const ctx = useViewContext();
+  if (ctx.mode === 'owner') return null;
+  const label =
+    ctx.mode === 'historical'
+      ? `Snapshot ${ctx.snapshotDate}`
+      : 'Viewing (live)';
+  const exitPath =
+    ctx.mode === 'viewer'
+      ? '/'
+      : ctx.viewerId === ctx.ownerId
+        ? '/'
+        : `/view/${ctx.viewId}`;
   return (
     <div
       id={`v13wbar-${ctx.ownerId}-${ctx.viewerId || 0}`}
@@ -13,19 +24,25 @@ export function ViewerBar() {
       className="fixed bottom-4 left-4 z-40 rounded-md bg-black/30 px-3 py-2 text-sm text-white backdrop-blur-sm shadow-sm dark:bg-white/40 dark:text-black"
     >
       <span className="flex items-center gap-2">
-        Viewing (live)
-        <span
-          id={`v13wbar-live-${ctx.ownerId}-${ctx.viewerId || 0}`}
-          aria-label="live"
-          className="h-2 w-2 rounded-full bg-green-500"
-        />
+        {label}
+        {ctx.mode === 'viewer' && (
+          <span
+            id={`v13wbar-live-${ctx.ownerId}-${ctx.viewerId || 0}`}
+            aria-label="live"
+            className="h-2 w-2 rounded-full bg-green-500"
+          />
+        )}
         &bull;
         <button
           id={`v13wbar-exit-${ctx.ownerId}-${ctx.viewerId || 0}`}
           onClick={() => {
-            const prev = document.referrer;
-            if (prev && !prev.includes('/view/')) router.back();
-            else router.push('/');
+            if (ctx.mode === 'viewer') {
+              const prev = document.referrer;
+              if (prev && !prev.includes('/view/')) router.back();
+              else router.push('/');
+            } else {
+              router.push(exitPath);
+            }
           }}
           aria-label="Exit viewing and return to my account"
           className="underline"

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -8,6 +8,7 @@ import {
   integer,
   pgEnum,
   uniqueIndex,
+  jsonb,
 } from 'drizzle-orm/pg-core';
 
 export const accountVisibilityEnum = pgEnum('account_visibility', [
@@ -139,3 +140,20 @@ export const planBlocks = pgTable('plan_blocks', {
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),
 });
+
+export const profileSnapshots = pgTable(
+  'profile_snapshots',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id').references(() => users.id).notNull(),
+    snapshotDate: date('snapshot_date').notNull(),
+    data: jsonb('data').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserDate: uniqueIndex('profile_snapshots_user_date_unique').on(
+      table.userId,
+      table.snapshotDate,
+    ),
+  }),
+);

--- a/lib/profile-snapshots.ts
+++ b/lib/profile-snapshots.ts
@@ -1,0 +1,93 @@
+import { db } from './db';
+import {
+  profileSnapshots,
+  users,
+  flavors,
+  subflavors,
+} from './db/schema';
+import { eq, and, desc } from 'drizzle-orm';
+
+function toISODate(d: Date) {
+  return d.toISOString().slice(0, 10);
+}
+
+export async function createProfileSnapshot(
+  userId: number,
+  snapshotDate: string,
+) {
+  const [user] = await db
+    .select({
+      id: users.id,
+      handle: users.handle,
+      displayName: users.displayName,
+      avatarUrl: users.avatarUrl,
+      viewId: users.viewId,
+      accountVisibility: users.accountVisibility,
+    })
+    .from(users)
+    .where(eq(users.id, userId));
+  if (!user) return;
+  const flavorRows = await db
+    .select()
+    .from(flavors)
+    .where(eq(flavors.userId, userId));
+  const subflavorRows = await db
+    .select()
+    .from(subflavors)
+    .where(eq(subflavors.userId, userId));
+  await db
+    .insert(profileSnapshots)
+    .values({
+      userId,
+      snapshotDate,
+      data: { user, flavors: flavorRows, subflavors: subflavorRows },
+    })
+    .onConflictDoNothing();
+}
+
+export async function ensureDailyProfileSnapshot(userId: number) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yIso = toISODate(yesterday);
+  const existing = await db
+    .select({ id: profileSnapshots.id })
+    .from(profileSnapshots)
+    .where(
+      and(
+        eq(profileSnapshots.userId, userId),
+        eq(profileSnapshots.snapshotDate, yIso),
+      ),
+    );
+  if (existing.length === 0) {
+    await createProfileSnapshot(userId, yIso);
+  }
+}
+
+export async function listProfileSnapshotDates(
+  userId: number,
+): Promise<string[]> {
+  const rows = await db
+    .select({ snapshotDate: profileSnapshots.snapshotDate })
+    .from(profileSnapshots)
+    .where(eq(profileSnapshots.userId, userId))
+    .orderBy(desc(profileSnapshots.snapshotDate));
+  return rows.map((r) => r.snapshotDate);
+}
+
+export async function getProfileSnapshot(
+  userId: number,
+  snapshotDate: string,
+) {
+  const [row] = await db
+    .select()
+    .from(profileSnapshots)
+    .where(
+      and(
+        eq(profileSnapshots.userId, userId),
+        eq(profileSnapshots.snapshotDate, snapshotDate),
+      ),
+    );
+  return row?.data as any;
+}

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -7,7 +7,8 @@ export interface ViewContext {
   ownerId: number;
   viewerId: number | null;
   viewId?: string;
-  mode: 'owner' | 'viewer';
+  mode: 'owner' | 'viewer' | 'historical';
+  snapshotDate?: string;
   editable: boolean;
 }
 
@@ -16,13 +17,22 @@ export function buildViewContext({
   viewerId,
   mode,
   viewId,
+  snapshotDate,
 }: {
   ownerId: number;
   viewerId: number | null;
-  mode: 'owner' | 'viewer';
+  mode: 'owner' | 'viewer' | 'historical';
   viewId?: string;
+  snapshotDate?: string;
 }): ViewContext {
-  return { ownerId, viewerId, viewId, mode, editable: mode === 'owner' };
+  return {
+    ownerId,
+    viewerId,
+    viewId,
+    mode,
+    snapshotDate,
+    editable: mode === 'owner',
+  };
 }
 
 export async function canViewProfile({

--- a/lib/view-context.tsx
+++ b/lib/view-context.tsx
@@ -7,6 +7,7 @@ const Ctx = createContext<ViewContext>({
   viewerId: null,
   viewId: undefined,
   mode: 'owner',
+  snapshotDate: undefined,
   editable: true,
 });
 


### PR DESCRIPTION
## Summary
- add `profile_snapshots` table and utilities to capture daily profile state
- surface snapshot days in the side calendar and open historical view pages
- support read-only historical mode with exit bar

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Please sign in)*


------
https://chatgpt.com/codex/tasks/task_e_68a381a7d7b0832a8276d6a69fecb9cb