### PR TITLE
feat: add review planning view

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -71,5 +71,8 @@
 - 2025-09-30: Added slide-out calendar panel on home screen with past 30 days and upcoming week view.
 - 2025-09-30: Enabled month navigation in slide-out calendar to jump one month backward or forward.
 - 2025-08-18: Implemented profile snapshot system with historical viewing mode and calendar access.
- - 2025-08-18: Implemented profile snapshot system with historical viewing mode and calendar access.
- - 2025-10-01: Added visual historical profile pages with snapshot-based flavors and subflavors navigation.
+- 2025-08-18: Implemented profile snapshot system with historical viewing mode and calendar access.
+- 2025-10-01: Added visual historical profile pages with snapshot-based flavors and subflavors navigation.
+- 2025-10-02: Added review planning view with per-block good/bad feedback and general day vibe modal.
+- 2025-10-02: Relocated general day vibe action to planner toolbar, removed add timeslot in review, and ensured modal blurs background.
+- 2025-10-02: Highlighted general day vibe button and raised vibe modal above planner blocks.

--- a/app/(app)/planning/client.tsx
+++ b/app/(app)/planning/client.tsx
@@ -19,6 +19,11 @@ export default function PlanningLanding({ userId }: { userId: string }) {
     else if (viewId) router.push(`/view/${viewId}/planning/live`);
   }
 
+  function handleReview() {
+    if (editable) router.push('/planning/review');
+    else if (viewId) router.push(`/view/${viewId}/planning/review`);
+  }
+
   return (
     <section
       id={`p1an-landing-${userId}`}
@@ -47,6 +52,7 @@ export default function PlanningLanding({ userId }: { userId: string }) {
         id={`p1an-btn-review-${userId}`}
         disabled={!editable}
         title={tooltip}
+        onClick={handleReview}
       >
         Review Today’s Planning
       </Button>

--- a/app/(app)/planning/review/page.tsx
+++ b/app/(app)/planning/review/page.tsx
@@ -1,0 +1,28 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { getPlan } from '@/lib/plans-store';
+import EditorClient from '../next/client';
+
+export default async function PlanningReviewPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ date?: string }>;
+}) {
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const now = new Date();
+  const { date: raw } = await searchParams;
+  const date = raw ?? now.toISOString().slice(0, 10);
+  const plan = await getPlan(String(me.id), date);
+  return (
+    <EditorClient
+      userId={String(me.id)}
+      date={date}
+      initialPlan={plan}
+      live
+      review
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add review planning page with block feedback and general day vibe modal
- support review mode in planner client with read-only blocks and auto-saved notes
- move and emphasize general day vibe action in toolbar, remove add timeslot in review, and ensure modal overlays above blocks

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a4294950a4832a853ea76f9738834c