### PR TITLE
fix: decouple next-day and live planning dates

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -77,3 +77,4 @@
 - 2025-10-02: Relocated general day vibe action to planner toolbar, removed add timeslot in review, and ensured modal blurs background.
 - 2025-10-02: Highlighted general day vibe button and raised vibe modal above planner blocks.
 - 2025-10-03: Restricted new planning blocks to selected time range and ensured timeline hour labels are fully visible.
+- 2025-10-05: Separated next-day and live planning dates so next-day always targets tomorrow while live and review load today's plan.

--- a/app/(app)/planning/live/page.tsx
+++ b/app/(app)/planning/live/page.tsx
@@ -4,17 +4,12 @@ import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
 import EditorClient from '../next/client';
 
-export default async function PlanningLivePage({
-  searchParams,
-}: {
-  searchParams: Promise<{ date?: string }>;
-}) {
+export default async function PlanningLivePage() {
   const session = await auth();
   if (!session) notFound();
   const me = await ensureUser(session);
   const now = new Date();
-  const { date: raw } = await searchParams;
-  const date = raw ?? now.toISOString().slice(0, 10);
+  const date = now.toISOString().slice(0, 10);
   const plan = await getPlan(String(me.id), date);
   return (
     <EditorClient userId={String(me.id)} date={date} initialPlan={plan} live />

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -4,12 +4,7 @@ import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
 import EditorClient from './client';
 
-export default async function PlanningNextPage({
-  searchParams,
-}: {
-  // Next.js dynamic APIs like `searchParams` are async and must be awaited
-  searchParams: Promise<{ date?: string }>;
-}) {
+export default async function PlanningNextPage() {
   const session = await auth();
   if (!session) notFound();
   const me = await ensureUser(session);
@@ -19,8 +14,7 @@ export default async function PlanningNextPage({
     now.getMonth(),
     now.getDate() + 1,
   );
-  const { date: raw } = await searchParams;
-  const date = raw ?? tomorrow.toISOString().slice(0, 10);
+  const date = tomorrow.toISOString().slice(0, 10);
   const plan = await getPlan(String(me.id), date);
   return <EditorClient userId={String(me.id)} date={date} initialPlan={plan} />;
 }

--- a/app/(app)/planning/review/page.tsx
+++ b/app/(app)/planning/review/page.tsx
@@ -4,17 +4,12 @@ import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
 import EditorClient from '../next/client';
 
-export default async function PlanningReviewPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ date?: string }>;
-}) {
+export default async function PlanningReviewPage() {
   const session = await auth();
   if (!session) notFound();
   const me = await ensureUser(session);
   const now = new Date();
-  const { date: raw } = await searchParams;
-  const date = raw ?? now.toISOString().slice(0, 10);
+  const date = now.toISOString().slice(0, 10);
   const plan = await getPlan(String(me.id), date);
   return (
     <EditorClient

--- a/app/(view)/view/[viewId]/planning/live/page.tsx
+++ b/app/(view)/view/[viewId]/planning/live/page.tsx
@@ -5,17 +5,14 @@ import EditorClient from '@/app/(app)/planning/next/client';
 
 export default async function ViewPlanningLivePage({
   params,
-  searchParams,
 }: {
   params: Promise<{ viewId: string }>;
-  searchParams: Promise<{ date?: string }>;
 }) {
   const { viewId } = await params;
   const user = await getUserByViewId(viewId);
   if (!user) notFound();
   const now = new Date();
-  const { date: raw } = await searchParams;
-  const date = raw ?? now.toISOString().slice(0, 10);
+  const date = now.toISOString().slice(0, 10);
   const plan = await getPlan(String(user.id), date);
   return (
     <section id={`v13w-plan-${user.id}`}>


### PR DESCRIPTION
## Summary
- ensure Planning for Next Day always targets tomorrow's date
- load today's saved plan for live and review planning views
- clarify viewer live planning to use current day's plan

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a436af7f24832aab4ffac3736cfd6b