### PR TITLE
feat: persist time-machine override and show site time

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -77,3 +77,6 @@
 - 2025-10-02: Relocated general day vibe action to planner toolbar, removed add timeslot in review, and ensured modal blurs background.
 - 2025-10-02: Highlighted general day vibe button and raised vibe modal above planner blocks.
 - 2025-10-03: Restricted new planning blocks to selected time range and ensured timeline hour labels are fully visible.
+- 2025-10-05: Separated next-day and live planning dates so next-day always targets tomorrow while live and review load today's plan.
+- 2025-10-05: Auto-reload planning pages when system date changes to keep next-day and live planning in sync.
+- 2025-10-05: Persisted time-machine overrides via cookie and displayed current site time in the app header for easier testing.

--- a/app/(app)/planning/live/page.tsx
+++ b/app/(app)/planning/live/page.tsx
@@ -2,19 +2,17 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
+import { getSiteDate } from '@/lib/site-date';
 import EditorClient from '../next/client';
 
-export default async function PlanningLivePage({
-  searchParams,
-}: {
-  searchParams: Promise<{ date?: string }>;
-}) {
+export const revalidate = 0;
+
+export default async function PlanningLivePage() {
   const session = await auth();
   if (!session) notFound();
   const me = await ensureUser(session);
-  const now = new Date();
-  const { date: raw } = await searchParams;
-  const date = raw ?? now.toISOString().slice(0, 10);
+  const now = await getSiteDate();
+  const date = now.toISOString().slice(0, 10);
   const plan = await getPlan(String(me.id), date);
   return (
     <EditorClient userId={String(me.id)} date={date} initialPlan={plan} live />

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -125,6 +125,24 @@ export default function EditorClient({
     if (nowMinute > endMinute) setEndMinute(MAX_MINUTES);
   }, [live, nowMinute, startMinute, endMinute]);
 
+  // Reload the planner when the system date rolls over so each mode
+  // always operates on the correct day. This lets testers advance time
+  // and have live/next-day logic adjust automatically.
+  useEffect(() => {
+    const checkRollover = () => {
+      const now = new Date();
+      const expected = live
+        ? now.toISOString().slice(0, 10)
+        : new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1)
+            .toISOString()
+            .slice(0, 10);
+      if (expected !== date) window.location.reload();
+    };
+    const id = setInterval(checkRollover, 60_000);
+    checkRollover();
+    return () => clearInterval(id);
+  }, [date, live]);
+
   useEffect(() => {
     try {
       window.localStorage.setItem(reviewKey, JSON.stringify(reviews));

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -2,25 +2,22 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
+import { getSiteDate } from '@/lib/site-date';
 import EditorClient from './client';
 
-export default async function PlanningNextPage({
-  searchParams,
-}: {
-  // Next.js dynamic APIs like `searchParams` are async and must be awaited
-  searchParams: Promise<{ date?: string }>;
-}) {
+export const revalidate = 0;
+
+export default async function PlanningNextPage() {
   const session = await auth();
   if (!session) notFound();
   const me = await ensureUser(session);
-  const now = new Date();
+  const now = await getSiteDate();
   const tomorrow = new Date(
     now.getFullYear(),
     now.getMonth(),
     now.getDate() + 1,
   );
-  const { date: raw } = await searchParams;
-  const date = raw ?? tomorrow.toISOString().slice(0, 10);
+  const date = tomorrow.toISOString().slice(0, 10);
   const plan = await getPlan(String(me.id), date);
   return <EditorClient userId={String(me.id)} date={date} initialPlan={plan} />;
 }

--- a/app/(app)/planning/review/page.tsx
+++ b/app/(app)/planning/review/page.tsx
@@ -2,19 +2,17 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
+import { getSiteDate } from '@/lib/site-date';
 import EditorClient from '../next/client';
 
-export default async function PlanningReviewPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ date?: string }>;
-}) {
+export const revalidate = 0;
+
+export default async function PlanningReviewPage() {
   const session = await auth();
   if (!session) notFound();
   const me = await ensureUser(session);
-  const now = new Date();
-  const { date: raw } = await searchParams;
-  const date = raw ?? now.toISOString().slice(0, 10);
+  const now = await getSiteDate();
+  const date = now.toISOString().slice(0, 10);
   const plan = await getPlan(String(me.id), date);
   return (
     <EditorClient

--- a/app/(view)/view/[viewId]/planning/live/page.tsx
+++ b/app/(view)/view/[viewId]/planning/live/page.tsx
@@ -1,21 +1,21 @@
 import { getUserByViewId } from '@/lib/users';
 import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
+import { getSiteDate } from '@/lib/site-date';
 import EditorClient from '@/app/(app)/planning/next/client';
+
+export const revalidate = 0;
 
 export default async function ViewPlanningLivePage({
   params,
-  searchParams,
 }: {
   params: Promise<{ viewId: string }>;
-  searchParams: Promise<{ date?: string }>;
 }) {
   const { viewId } = await params;
   const user = await getUserByViewId(viewId);
   if (!user) notFound();
-  const now = new Date();
-  const { date: raw } = await searchParams;
-  const date = raw ?? now.toISOString().slice(0, 10);
+  const now = await getSiteDate();
+  const date = now.toISOString().slice(0, 10);
   const plan = await getPlan(String(user.id), date);
   return (
     <section id={`v13w-plan-${user.id}`}>

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -1,9 +1,11 @@
 'use client';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor, type Section } from '@/lib/navigation';
 import { Button } from '@/components/ui/button';
+import { useApplySiteDate } from '@/lib/use-site-date';
 
 const labels: Record<Section, string> = {
   cake: 'Cake',
@@ -16,8 +18,21 @@ const labels: Record<Section, string> = {
 };
 
 export function AppNav() {
+  useApplySiteDate();
   const ctx = useViewContext();
   const pathname = usePathname();
+  const [now, setNow] = useState(() => {
+    const match = document.cookie.match(/(?:^|; )site-date=(\d+)/);
+    if (match) {
+      const t = Number(match[1]);
+      if (!Number.isNaN(t)) return new Date(t);
+    }
+    return new Date();
+  });
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
   const sections: Section[] =
     ctx.mode === 'viewer'
       ? ['cake', 'planning', 'flavors', 'ingredients', 'review', 'people']
@@ -38,9 +53,12 @@ export function AppNav() {
           );
         })}
       </ul>
-      <form action="/api/auth/signout" method="post">
-        <Button type="submit">Sign out</Button>
-      </form>
+      <div className="flex items-center gap-4">
+        <span className="text-sm">{now.toLocaleString()}</span>
+        <form action="/api/auth/signout" method="post">
+          <Button type="submit">Sign out</Button>
+        </form>
+      </div>
     </nav>
   );
 }

--- a/lib/site-date.ts
+++ b/lib/site-date.ts
@@ -1,0 +1,17 @@
+import { cookies } from 'next/headers';
+
+/**
+ * Returns the current site date, respecting any override stored in the
+ * `site-date` cookie. Falls back to the real system time when no override is
+ * present.
+ */
+export async function getSiteDate(): Promise<Date> {
+  const cookie = (await cookies()).get('site-date');
+  if (cookie) {
+    const t = Number(cookie.value);
+    if (!Number.isNaN(t)) {
+      return new Date(t);
+    }
+  }
+  return new Date();
+}

--- a/lib/use-site-date.ts
+++ b/lib/use-site-date.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Applies a Date override on the client based on the `site-date` cookie.
+ * This keeps the client-side clock in sync with server-side calculations.
+ */
+export function useApplySiteDate() {
+  useEffect(() => {
+    const match = document.cookie.match(/(?:^|; )site-date=(\d+)/);
+    if (match) {
+      const t = Number(match[1]);
+      if (!Number.isNaN(t)) {
+        const g = globalThis as any;
+        const RealDate = g.__realDate || Date;
+        g.__realDate = RealDate;
+        class MockDate extends RealDate {
+          constructor(...args: any[]) {
+            if (args.length === 0) {
+              super(t);
+            } else {
+              // @ts-ignore
+              super(...args);
+            }
+          }
+          static now() {
+            return t;
+          }
+        }
+        g.Date = MockDate as unknown as DateConstructor;
+      }
+    }
+  }, []);
+}


### PR DESCRIPTION
## Summary
- remember time-machine override in a cookie and sync it on server and client
- show the current site date/time in the top nav for debugging
- load planner pages using the overridden date when present

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a436af7f24832aab4ffac3736cfd6b