### PR TITLE
fix: sync time override and remove extra html

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -77,3 +77,7 @@
 - 2025-10-02: Relocated general day vibe action to planner toolbar, removed add timeslot in review, and ensured modal blurs background.
 - 2025-10-02: Highlighted general day vibe button and raised vibe modal above planner blocks.
 - 2025-10-03: Restricted new planning blocks to selected time range and ensured timeline hour labels are fully visible.
+- 2025-10-05: Separated next-day and live planning dates so next-day always targets tomorrow while live and review load today's plan.
+- 2025-10-05: Auto-reload planning pages when system date changes to keep next-day and live planning in sync.
+- 2025-10-06: Persisted TimeMachine overrides across navigation and displayed current date/time in header for debugging.
+- 2025-10-06: Synced TimeMachine offset with server via cookie, removed nested HTML wrappers to fix hydration loops.

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -29,15 +29,11 @@ export default async function AppLayout({
   }
 
   return (
-    <html lang="en">
-      <body>
-        <ViewContextProvider value={ctx}>
-          <AppNav />
-          <main className="p-4">
-            <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId}`}>{children}</div>
-          </main>
-        </ViewContextProvider>
-      </body>
-    </html>
+    <ViewContextProvider value={ctx}>
+      <AppNav />
+      <main className="p-4">
+        <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId}`}>{children}</div>
+      </main>
+    </ViewContextProvider>
   );
 }

--- a/app/(app)/planning/live/page.tsx
+++ b/app/(app)/planning/live/page.tsx
@@ -4,17 +4,14 @@ import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
 import EditorClient from '../next/client';
 
-export default async function PlanningLivePage({
-  searchParams,
-}: {
-  searchParams: Promise<{ date?: string }>;
-}) {
+export const revalidate = 0;
+
+export default async function PlanningLivePage() {
   const session = await auth();
   if (!session) notFound();
   const me = await ensureUser(session);
   const now = new Date();
-  const { date: raw } = await searchParams;
-  const date = raw ?? now.toISOString().slice(0, 10);
+  const date = now.toISOString().slice(0, 10);
   const plan = await getPlan(String(me.id), date);
   return (
     <EditorClient userId={String(me.id)} date={date} initialPlan={plan} live />

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -125,6 +125,24 @@ export default function EditorClient({
     if (nowMinute > endMinute) setEndMinute(MAX_MINUTES);
   }, [live, nowMinute, startMinute, endMinute]);
 
+  // Reload the planner when the system date rolls over so each mode
+  // always operates on the correct day. This lets testers advance time
+  // and have live/next-day logic adjust automatically.
+  useEffect(() => {
+    const checkRollover = () => {
+      const now = new Date();
+      const expected = live
+        ? now.toISOString().slice(0, 10)
+        : new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1)
+            .toISOString()
+            .slice(0, 10);
+      if (expected !== date) window.location.reload();
+    };
+    const id = setInterval(checkRollover, 60_000);
+    checkRollover();
+    return () => clearInterval(id);
+  }, [date, live]);
+
   useEffect(() => {
     try {
       window.localStorage.setItem(reviewKey, JSON.stringify(reviews));

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -4,12 +4,9 @@ import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
 import EditorClient from './client';
 
-export default async function PlanningNextPage({
-  searchParams,
-}: {
-  // Next.js dynamic APIs like `searchParams` are async and must be awaited
-  searchParams: Promise<{ date?: string }>;
-}) {
+export const revalidate = 0;
+
+export default async function PlanningNextPage() {
   const session = await auth();
   if (!session) notFound();
   const me = await ensureUser(session);
@@ -19,8 +16,7 @@ export default async function PlanningNextPage({
     now.getMonth(),
     now.getDate() + 1,
   );
-  const { date: raw } = await searchParams;
-  const date = raw ?? tomorrow.toISOString().slice(0, 10);
+  const date = tomorrow.toISOString().slice(0, 10);
   const plan = await getPlan(String(me.id), date);
   return <EditorClient userId={String(me.id)} date={date} initialPlan={plan} />;
 }

--- a/app/(app)/planning/review/page.tsx
+++ b/app/(app)/planning/review/page.tsx
@@ -4,17 +4,14 @@ import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
 import EditorClient from '../next/client';
 
-export default async function PlanningReviewPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ date?: string }>;
-}) {
+export const revalidate = 0;
+
+export default async function PlanningReviewPage() {
   const session = await auth();
   if (!session) notFound();
   const me = await ensureUser(session);
   const now = new Date();
-  const { date: raw } = await searchParams;
-  const date = raw ?? now.toISOString().slice(0, 10);
+  const date = now.toISOString().slice(0, 10);
   const plan = await getPlan(String(me.id), date);
   return (
     <EditorClient

--- a/app/(view)/view/[viewId]/layout.tsx
+++ b/app/(view)/view/[viewId]/layout.tsx
@@ -39,16 +39,12 @@ export default async function ViewLayout({
   }
 
   return (
-    <html lang="en">
-      <body>
-        <ViewContextProvider value={ctx}>
-          <AppNav />
-          <main className="p-4">
-            <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId || 0}`}>{children}</div>
-          </main>
-          <ViewerBar />
-        </ViewContextProvider>
-      </body>
-    </html>
+    <ViewContextProvider value={ctx}>
+      <AppNav />
+      <main className="p-4">
+        <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId || 0}`}>{children}</div>
+      </main>
+      <ViewerBar />
+    </ViewContextProvider>
   );
 }

--- a/app/(view)/view/[viewId]/planning/live/page.tsx
+++ b/app/(view)/view/[viewId]/planning/live/page.tsx
@@ -3,19 +3,18 @@ import { notFound } from 'next/navigation';
 import { getPlan } from '@/lib/plans-store';
 import EditorClient from '@/app/(app)/planning/next/client';
 
+export const revalidate = 0;
+
 export default async function ViewPlanningLivePage({
   params,
-  searchParams,
 }: {
   params: Promise<{ viewId: string }>;
-  searchParams: Promise<{ date?: string }>;
 }) {
   const { viewId } = await params;
   const user = await getUserByViewId(viewId);
   if (!user) notFound();
   const now = new Date();
-  const { date: raw } = await searchParams;
-  const date = raw ?? now.toISOString().slice(0, 10);
+  const date = now.toISOString().slice(0, 10);
   const plan = await getPlan(String(user.id), date);
   return (
     <section id={`v13w-plan-${user.id}`}>

--- a/app/history/[viewId]/[date]/layout.tsx
+++ b/app/history/[viewId]/[date]/layout.tsx
@@ -31,16 +31,12 @@ export default async function HistoryViewLayout({
     snapshotDate: date,
   });
   return (
-    <html lang="en">
-      <body>
-        <ViewContextProvider value={ctx}>
-          <AppNav />
-          <main className="p-4">
-            <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId || 0}`}>{children}</div>
-          </main>
-          <ViewerBar />
-        </ViewContextProvider>
-      </body>
-    </html>
+    <ViewContextProvider value={ctx}>
+      <AppNav />
+      <main className="p-4">
+        <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId || 0}`}>{children}</div>
+      </main>
+      <ViewerBar />
+    </ViewContextProvider>
   );
 }

--- a/app/history/self/[date]/layout.tsx
+++ b/app/history/self/[date]/layout.tsx
@@ -25,16 +25,12 @@ export default async function HistoryLayout({
     snapshotDate: date,
   });
   return (
-    <html lang="en">
-      <body>
-        <ViewContextProvider value={ctx}>
-          <AppNav />
-          <main className="p-4">
-            <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId}`}>{children}</div>
-          </main>
-          <ViewerBar />
-        </ViewContextProvider>
-      </body>
-    </html>
+    <ViewContextProvider value={ctx}>
+      <AppNav />
+      <main className="p-4">
+        <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId}`}>{children}</div>
+      </main>
+      <ViewerBar />
+    </ViewContextProvider>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,75 @@
 import './globals.css';
+import { cookies } from 'next/headers';
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const cookieStore = await cookies();
+  const offsetStr = cookieStore.get('timeOffset')?.value;
+  const RealDate = (globalThis as any)._realDate || Date;
+  (globalThis as any)._realDate = RealDate;
+  if (offsetStr) {
+    const offset = parseInt(offsetStr, 10);
+    if (!isNaN(offset)) {
+      class MockDate extends RealDate {
+        constructor(...args: any[]) {
+          if (args.length === 0) {
+            super(RealDate.now() + offset);
+          } else {
+            // @ts-ignore -- spread args for Date constructor
+            super(...args);
+          }
+        }
+        static now() {
+          return RealDate.now() + offset;
+        }
+      }
+      // override for this request
+      // @ts-ignore
+      globalThis.Date = MockDate as unknown as DateConstructor;
+    } else {
+      // @ts-ignore
+      globalThis.Date = RealDate as unknown as DateConstructor;
+    }
+  } else {
+    // @ts-ignore
+    globalThis.Date = RealDate as unknown as DateConstructor;
+  }
+
   return (
     <html lang="en">
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => {
+  const RealDate = Date;
+  globalThis._realDate = RealDate;
+  const offsetStr = localStorage.getItem('timeOffset');
+  if (offsetStr) {
+    const offset = parseInt(offsetStr, 10);
+    if (!isNaN(offset)) {
+      class MockDate extends RealDate {
+        constructor(...args) {
+          if (args.length === 0) {
+            super(RealDate.now() + offset);
+          } else {
+            // @ts-ignore -- spread args for Date constructor
+            super(...args);
+          }
+        }
+        static now() {
+          return RealDate.now() + offset;
+        }
+      }
+      globalThis.Date = MockDate;
+    }
+  }
+})();`,
+          }}
+        />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor, type Section } from '@/lib/navigation';
 import { Button } from '@/components/ui/button';
+import { Clock } from '@/components/clock';
 
 const labels: Record<Section, string> = {
   cake: 'Cake',
@@ -21,7 +22,15 @@ export function AppNav() {
   const sections: Section[] =
     ctx.mode === 'viewer'
       ? ['cake', 'planning', 'flavors', 'ingredients', 'review', 'people']
-      : ['cake', 'planning', 'flavors', 'ingredients', 'review', 'people', 'visibility'];
+      : [
+          'cake',
+          'planning',
+          'flavors',
+          'ingredients',
+          'review',
+          'people',
+          'visibility',
+        ];
 
   return (
     <nav className="flex items-center justify-between border-b p-4">
@@ -38,9 +47,12 @@ export function AppNav() {
           );
         })}
       </ul>
-      <form action="/api/auth/signout" method="post">
-        <Button type="submit">Sign out</Button>
-      </form>
+      <div className="flex items-center gap-4">
+        <Clock />
+        <form action="/api/auth/signout" method="post">
+          <Button type="submit">Sign out</Button>
+        </form>
+      </div>
     </nav>
   );
 }

--- a/components/clock.tsx
+++ b/components/clock.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function Clock() {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const formatted = now.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  });
+
+  return <span className="text-sm">{formatted}</span>;
+}

--- a/components/dev/time-machine.tsx
+++ b/components/dev/time-machine.tsx
@@ -12,7 +12,8 @@ export function TimeMachine({ open, onClose }: Props) {
   const [code, setCode] = useState('');
   const [error, setError] = useState('');
   const [date, setDate] = useState('');
-  const realDateRef = useRef<DateConstructor | null>(null);
+  (globalThis as any)._realDate = (globalThis as any)._realDate || Date;
+  const realDateRef = useRef<DateConstructor>((globalThis as any)._realDate);
 
   if (!open) return null;
 
@@ -26,63 +27,53 @@ export function TimeMachine({ open, onClose }: Props) {
     }
   }
 
-  function applyOverride() {
-    if (!date) return;
-    const t = new Date(date).getTime();
-    if (!realDateRef.current) {
-      realDateRef.current = Date;
-    }
+  function override(offset: number) {
     const RealDate = realDateRef.current;
     class MockDate extends RealDate {
       constructor(...args: any[]) {
         if (args.length === 0) {
-          super(t);
+          super(RealDate.now() + offset);
         } else {
           // @ts-ignore -- spread args for Date constructor
           super(...args);
         }
       }
       static now() {
-        return t;
+        return RealDate.now() + offset;
       }
     }
     (globalThis as any).Date = MockDate as unknown as DateConstructor;
+    localStorage.setItem('timeOffset', String(offset));
+    document.cookie = `timeOffset=${offset}; path=/`;
+  }
+
+  function applyOverride() {
+    if (!date) return;
+    const RealDate = realDateRef.current;
+    const target = new Date(date).getTime();
+    const offset = target - RealDate.now();
+    override(offset);
     handleClose();
   }
 
   function resetOverride() {
-    if (realDateRef.current) {
-      (globalThis as any).Date = realDateRef.current;
-      realDateRef.current = null;
-    }
+    const RealDate = realDateRef.current;
+    (globalThis as any).Date = RealDate;
+    localStorage.removeItem('timeOffset');
+    document.cookie = 'timeOffset=; Max-Age=0; path=/';
   }
 
   function resetToCurrentNl() {
-    const amsString = new Date().toLocaleString('en-US', {
+    const RealDate = realDateRef.current;
+    const amsString = new RealDate().toLocaleString('en-US', {
       timeZone: 'Europe/Amsterdam',
       timeZoneName: 'short',
     });
     const [base, tz] = amsString.split(' GMT');
-    const offset = parseInt(tz, 10) * 60 * 60 * 1000;
-    const t = new Date(base).getTime() - offset;
-    if (!realDateRef.current) {
-      realDateRef.current = Date;
-    }
-    const RealDate = realDateRef.current;
-    class MockDate extends RealDate {
-      constructor(...args: any[]) {
-        if (args.length === 0) {
-          super(t);
-        } else {
-          // @ts-ignore -- spread args for Date constructor
-          super(...args);
-        }
-      }
-      static now() {
-        return t;
-      }
-    }
-    (globalThis as any).Date = MockDate as unknown as DateConstructor;
+    const offsetMs = parseInt(tz, 10) * 60 * 60 * 1000;
+    const t = new RealDate(base).getTime() - offsetMs;
+    const offset = t - RealDate.now();
+    override(offset);
     handleClose();
   }
 


### PR DESCRIPTION
## Summary
- sync TimeMachine override with server via cookie and patch Date on the server
- remove nested html/body from sub-layouts to avoid hydration errors
- log the change in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Please sign in)*

------
https://chatgpt.com/codex/tasks/task_e_68a436af7f24832aab4ffac3736cfd6b