### PR TITLE
Add historical planning page routing

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -88,3 +88,4 @@
 - 2025-10-08: Implemented timezone-safe planning with canonical clock, manual override, and date-resolved plan loading.
 - 2025-10-09: Fixed day arithmetic to keep "next" and "live" planning dates stable across timezones.
 - 2025-10-09: Awaited planning search params to satisfy Next.js dynamic API requirements.
+- 2025-10-10: Added historical planning page routing to view past plans via /history/[viewId]/[date]/planning.

--- a/app/history/[viewId]/[date]/planning/page.tsx
+++ b/app/history/[viewId]/[date]/planning/page.tsx
@@ -1,0 +1,32 @@
+import { getUserByViewId } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { getPlanStrict } from '@/lib/plans-store';
+import { getUserTimeZone } from '@/lib/clock';
+import EditorClient from '@/app/(app)/planning/next/client';
+
+export const revalidate = 0;
+
+export default async function HistoryViewPlanningPage({
+  params,
+}: {
+  params: Promise<{ viewId: string; date: string }>;
+}) {
+  const { viewId, date } = await params;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const tz = getUserTimeZone(owner as any);
+  const plan = await getPlanStrict(owner.id, date);
+  const todayStr = date;
+  return (
+    <section id={`hist-plan-${owner.id}-${date}`}>
+      <EditorClient
+        userId={String(owner.id)}
+        date={date}
+        today={todayStr}
+        tz={tz}
+        initialPlan={plan}
+        review
+      />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/history/[viewId]/[date]/planning` route to view archived daily plans in read-only mode
- log new route in project update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early – Please sign in)*

------
https://chatgpt.com/codex/tasks/task_e_68a463960c7c832a819fdee7a0aeb8d6