### PR TITLE
feat: add historical planning viewer

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -88,3 +88,5 @@
 - 2025-10-08: Implemented timezone-safe planning with canonical clock, manual override, and date-resolved plan loading.
 - 2025-10-09: Fixed day arithmetic to keep "next" and "live" planning dates stable across timezones.
 - 2025-10-09: Awaited planning search params to satisfy Next.js dynamic API requirements.
+- 2025-10-09: Added historical planning route to view past plans in read-only mode with Playwright test.
+- 2025-10-09: Added self historical planning route so owners can review their past plans.

--- a/app/history/[viewId]/[date]/planning/page.tsx
+++ b/app/history/[viewId]/[date]/planning/page.tsx
@@ -1,0 +1,32 @@
+import { getUserByViewId } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { getPlanStrict } from '@/lib/plans-store';
+import { getUserTimeZone, toYMD } from '@/lib/clock';
+import EditorClient from '@/app/(app)/planning/next/client';
+
+export default async function HistoryPlanningPage({
+  params,
+}: {
+  params: Promise<{ viewId: string; date: string }>;
+}) {
+  const { viewId, date } = await params;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const snapshot = await getProfileSnapshot(owner.id, date);
+  if (!snapshot) notFound();
+  const plan = await getPlanStrict(owner.id, date);
+  const tz = getUserTimeZone(owner);
+  const todayStr = toYMD(new Date(), tz);
+  return (
+    <section id={`hist-plan-${owner.id}-${date}`}>
+      <EditorClient
+        userId={String(owner.id)}
+        date={date}
+        today={todayStr}
+        tz={tz}
+        initialPlan={plan}
+      />
+    </section>
+  );
+}

--- a/app/history/self/[date]/planning/page.tsx
+++ b/app/history/self/[date]/planning/page.tsx
@@ -1,0 +1,34 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { getPlanStrict } from '@/lib/plans-store';
+import { getUserTimeZone, toYMD } from '@/lib/clock';
+import EditorClient from '@/app/(app)/planning/next/client';
+
+export default async function HistorySelfPlanningPage({
+  params,
+}: {
+  params: Promise<{ date: string }>;
+}) {
+  const { date } = await params;
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const snapshot = await getProfileSnapshot(me.id, date);
+  if (!snapshot) notFound();
+  const plan = await getPlanStrict(me.id, date);
+  const tz = getUserTimeZone(me);
+  const todayStr = toYMD(new Date(), tz);
+  return (
+    <section id={`hist-plan-${me.id}-${date}`}>
+      <EditorClient
+        userId={String(me.id)}
+        date={date}
+        today={todayStr}
+        tz={tz}
+        initialPlan={plan}
+      />
+    </section>
+  );
+}

--- a/tests/history-planning.spec.ts
+++ b/tests/history-planning.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+function yesterday(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+test('viewer can read historical plan without editing', async ({ page }) => {
+  const handleA = unique('owner');
+  const emailA = `${handleA}@example.com`;
+  const dateStr = yesterday();
+
+  // sign up owner and create a plan block for yesterday
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', handleA);
+  await page.fill('input[placeholder="Email"]', emailA);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+  await page.goto(`/planning/live?apoc_date=${dateStr}&apoc_time=12:00`);
+  await page.click('[id^="p1an-add-top-"]');
+  await page.fill('input[id^="p1an-meta-ttl-"]', 'Task');
+  await page.click('button[id^="p1an-meta-close-"]');
+  await page.waitForTimeout(1000);
+
+  // owner can view own historical plan
+  await page.goto(`/history/self/${dateStr}/planning`);
+  await expect(page.locator('[id^="p1an-blk-"]')).toHaveCount(1);
+  await page.click('[id^="p1an-blk-"]');
+  await expect(page.locator('input[id^="p1an-meta-ttl-"]')).toBeDisabled();
+
+  // fetch view link for owner
+  await page.goto(`/u/${handleA}`);
+  const viewHref = await page.getAttribute('[id^="pr0ovr-view-"]', 'href');
+  const viewId = viewHref?.split('/').pop();
+
+  // sign out
+  await page.click('text=Sign out');
+
+  // sign up viewer
+  const handleB = unique('viewer');
+  const emailB = `${handleB}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Viewer');
+  await page.fill('input[placeholder="Handle"]', handleB);
+  await page.fill('input[placeholder="Email"]', emailB);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  // navigate to owner's historical planning as viewer
+  await page.goto(`/history/${viewId}/${dateStr}/planning`);
+
+  // verify block is visible and metadata is read-only
+  await expect(page.locator('[id^="p1an-blk-"]')).toHaveCount(1);
+  await page.click('[id^="p1an-blk-"]');
+  await expect(page.locator('[id^="p1an-meta-"]')).toBeVisible();
+  await expect(page.locator('input[id^="p1an-meta-ttl-"]')).toBeDisabled();
+});


### PR DESCRIPTION
## Summary
- add `/history/self/[date]/planning` route so owners can view past plans in read-only mode
- cover self and viewer historical planning with Playwright test
- log addition in UPDATE.md

## Testing
- `pnpm format` *(fails: Command "format" not found)*
- `pnpm lint`
- `pnpm type-check` *(fails: Command "type-check" not found)*
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a463960c7c832a819fdee7a0aeb8d6