### PR TITLE
feat: add historical planning viewer

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -88,3 +88,7 @@
 - 2025-10-08: Implemented timezone-safe planning with canonical clock, manual override, and date-resolved plan loading.
 - 2025-10-09: Fixed day arithmetic to keep "next" and "live" planning dates stable across timezones.
 - 2025-10-09: Awaited planning search params to satisfy Next.js dynamic API requirements.
+- 2025-10-09: Added historical planning route to view past plans in read-only mode with Playwright test.
+- 2025-10-09: Added self historical planning route so owners can review their past plans.
+- 2025-10-10: Expanded historical planning with landing screen and live/next/review pages for full time-capsule viewing.
+- 2025-10-10: Removed live indicator from historical planning and allowed all past reviews to open without time gating.

--- a/app/(app)/planning/client.tsx
+++ b/app/(app)/planning/client.tsx
@@ -23,7 +23,8 @@ export default function PlanningLanding({
   reviewLabel,
 }: Props) {
   const router = useRouter();
-  const { editable, viewId } = useViewContext();
+  const { editable, viewId, mode, snapshotDate, ownerId, viewerId } =
+    useViewContext();
   const tooltip = editable ? undefined : 'Read-only in viewing mode.';
 
   useEffect(() => {
@@ -41,19 +42,30 @@ export default function PlanningLanding({
     return () => clearInterval(id);
   }, [tz, today]);
 
+  function navigate(target: string) {
+    if (mode === 'historical') {
+      if (viewerId === ownerId) {
+        router.push(`/history/self/${snapshotDate}/planning/${target}`);
+      } else if (viewId && snapshotDate) {
+        router.push(`/history/${viewId}/${snapshotDate}/planning/${target}`);
+      }
+    } else if (editable) {
+      router.push(`/planning/${target}`);
+    } else if (viewId) {
+      router.push(`/view/${viewId}/planning/${target}`);
+    }
+  }
+
   function handleNext() {
-    if (editable) router.push('/planning/next');
-    else if (viewId) router.push(`/view/${viewId}/planning/next`);
+    navigate('next');
   }
 
   function handleLive() {
-    if (editable) router.push('/planning/live');
-    else if (viewId) router.push(`/view/${viewId}/planning/live`);
+    navigate('live');
   }
 
   function handleReview() {
-    if (editable) router.push('/planning/review');
-    else if (viewId) router.push(`/view/${viewId}/planning/review`);
+    navigate('review');
   }
 
   return (
@@ -82,7 +94,7 @@ export default function PlanningLanding({
       </div>
       <Button
         id={`p1an-btn-review-${userId}`}
-        disabled={!editable}
+        disabled={!editable && viewerId !== ownerId}
         title={tooltip}
         onClick={handleReview}
       >

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -706,7 +706,7 @@ export default function EditorClient({
                       zIndex: z,
                       color: textColor,
                       cursor: review
-                        ? nowMinute >= minutesFromIso(b.end)
+                        ? !live || nowMinute >= minutesFromIso(b.end)
                           ? 'pointer'
                           : 'not-allowed'
                         : editable
@@ -746,7 +746,7 @@ export default function EditorClient({
                     onClick={(e) => {
                       e.stopPropagation();
                       if (draggingRef.current) return;
-                      if (review && nowMinute < minutesFromIso(b.end)) return;
+                      if (review && live && nowMinute < minutesFromIso(b.end)) return;
                       setSelectedId(b.id);
                     }}
                   >

--- a/app/history/[viewId]/[date]/planning/live/page.tsx
+++ b/app/history/[viewId]/[date]/planning/live/page.tsx
@@ -1,0 +1,35 @@
+import { getUserByViewId } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { getPlanStrict } from '@/lib/plans-store';
+import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
+import EditorClient from '@/app/(app)/planning/next/client';
+
+export const revalidate = 0;
+
+export default async function HistoryPlanningLive({
+  params,
+}: {
+  params: Promise<{ viewId: string; date: string }>;
+}) {
+  const { viewId, date } = await params;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const snapshot = await getProfileSnapshot(owner.id, date);
+  if (!snapshot) notFound();
+  const tz = getUserTimeZone(owner);
+  const day = startOfDay(new Date(date), tz);
+  const dateStr = toYMD(day, tz);
+  const plan = await getPlanStrict(owner.id, dateStr);
+  return (
+    <section id={`hist-plan-live-${owner.id}-${date}`}>
+      <EditorClient
+        userId={String(owner.id)}
+        date={dateStr}
+        today={dateStr}
+        tz={tz}
+        initialPlan={plan}
+      />
+    </section>
+  );
+}

--- a/app/history/[viewId]/[date]/planning/next/page.tsx
+++ b/app/history/[viewId]/[date]/planning/next/page.tsx
@@ -1,0 +1,37 @@
+import { getUserByViewId } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { getPlanStrict } from '@/lib/plans-store';
+import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import EditorClient from '@/app/(app)/planning/next/client';
+
+export const revalidate = 0;
+
+export default async function HistoryPlanningNext({
+  params,
+}: {
+  params: Promise<{ viewId: string; date: string }>;
+}) {
+  const { viewId, date } = await params;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const snapshot = await getProfileSnapshot(owner.id, date);
+  if (!snapshot) notFound();
+  const tz = getUserTimeZone(owner);
+  const day = startOfDay(new Date(date), tz);
+  const next = addDays(day, 1, tz);
+  const dateStr = toYMD(next, tz);
+  const todayStr = toYMD(day, tz);
+  const plan = await getPlanStrict(owner.id, dateStr);
+  return (
+    <section id={`hist-plan-next-${owner.id}-${date}`}>
+      <EditorClient
+        userId={String(owner.id)}
+        date={dateStr}
+        today={todayStr}
+        tz={tz}
+        initialPlan={plan}
+      />
+    </section>
+  );
+}

--- a/app/history/[viewId]/[date]/planning/page.tsx
+++ b/app/history/[viewId]/[date]/planning/page.tsx
@@ -1,0 +1,45 @@
+import { getUserByViewId } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import PlanningLanding from '@/app/(app)/planning/client';
+
+export default async function HistoryPlanningLanding({
+  params,
+}: {
+  params: Promise<{ viewId: string; date: string }>;
+}) {
+  const { viewId, date } = await params;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const snapshot = await getProfileSnapshot(owner.id, date);
+  if (!snapshot) notFound();
+  const tz = getUserTimeZone(owner);
+  const day = startOfDay(new Date(date), tz);
+  const next = addDays(day, 1, tz);
+  const liveLabel = day.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    timeZone: tz,
+  });
+  const nextLabel = next.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    timeZone: tz,
+  });
+  const todayStr = toYMD(day, tz);
+  return (
+    <section id={`hist-plan-landing-${owner.id}-${date}`}>
+      <PlanningLanding
+        userId={String(owner.id)}
+        tz={tz}
+        today={todayStr}
+        nextLabel={nextLabel}
+        liveLabel={liveLabel}
+        reviewLabel={liveLabel}
+      />
+    </section>
+  );
+}

--- a/app/history/[viewId]/[date]/planning/review/page.tsx
+++ b/app/history/[viewId]/[date]/planning/review/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { getPlanStrict } from '@/lib/plans-store';
+import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
+import EditorClient from '@/app/(app)/planning/next/client';
+
+export const revalidate = 0;
+
+export default async function HistoryPlanningReview({
+  params,
+}: {
+  params: Promise<{ viewId: string; date: string }>;
+}) {
+  const { viewId, date } = await params;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const snapshot = await getProfileSnapshot(owner.id, date);
+  if (!snapshot) notFound();
+  const tz = getUserTimeZone(owner);
+  const day = startOfDay(new Date(date), tz);
+  const dateStr = toYMD(day, tz);
+  const plan = await getPlanStrict(owner.id, dateStr);
+  return (
+    <section id={`hist-plan-review-${owner.id}-${date}`}>
+      <EditorClient
+        userId={String(owner.id)}
+        date={dateStr}
+        today={dateStr}
+        tz={tz}
+        initialPlan={plan}
+        review
+      />
+    </section>
+  );
+}

--- a/app/history/self/[date]/planning/live/page.tsx
+++ b/app/history/self/[date]/planning/live/page.tsx
@@ -1,0 +1,37 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { getPlanStrict } from '@/lib/plans-store';
+import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
+import EditorClient from '@/app/(app)/planning/next/client';
+
+export const revalidate = 0;
+
+export default async function HistorySelfPlanningLive({
+  params,
+}: {
+  params: Promise<{ date: string }>;
+}) {
+  const { date } = await params;
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const snapshot = await getProfileSnapshot(me.id, date);
+  if (!snapshot) notFound();
+  const tz = getUserTimeZone(me);
+  const day = startOfDay(new Date(date), tz);
+  const dateStr = toYMD(day, tz);
+  const plan = await getPlanStrict(me.id, dateStr);
+  return (
+    <section id={`hist-self-plan-live-${me.id}-${date}`}>
+      <EditorClient
+        userId={String(me.id)}
+        date={dateStr}
+        today={dateStr}
+        tz={tz}
+        initialPlan={plan}
+      />
+    </section>
+  );
+}

--- a/app/history/self/[date]/planning/next/page.tsx
+++ b/app/history/self/[date]/planning/next/page.tsx
@@ -1,0 +1,39 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { getPlanStrict } from '@/lib/plans-store';
+import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import EditorClient from '@/app/(app)/planning/next/client';
+
+export const revalidate = 0;
+
+export default async function HistorySelfPlanningNext({
+  params,
+}: {
+  params: Promise<{ date: string }>;
+}) {
+  const { date } = await params;
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const snapshot = await getProfileSnapshot(me.id, date);
+  if (!snapshot) notFound();
+  const tz = getUserTimeZone(me);
+  const day = startOfDay(new Date(date), tz);
+  const next = addDays(day, 1, tz);
+  const dateStr = toYMD(next, tz);
+  const todayStr = toYMD(day, tz);
+  const plan = await getPlanStrict(me.id, dateStr);
+  return (
+    <section id={`hist-self-plan-next-${me.id}-${date}`}>
+      <EditorClient
+        userId={String(me.id)}
+        date={dateStr}
+        today={todayStr}
+        tz={tz}
+        initialPlan={plan}
+      />
+    </section>
+  );
+}

--- a/app/history/self/[date]/planning/page.tsx
+++ b/app/history/self/[date]/planning/page.tsx
@@ -1,0 +1,47 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import PlanningLanding from '@/app/(app)/planning/client';
+
+export default async function HistorySelfPlanningLanding({
+  params,
+}: {
+  params: Promise<{ date: string }>;
+}) {
+  const { date } = await params;
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const snapshot = await getProfileSnapshot(me.id, date);
+  if (!snapshot) notFound();
+  const tz = getUserTimeZone(me);
+  const day = startOfDay(new Date(date), tz);
+  const next = addDays(day, 1, tz);
+  const liveLabel = day.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    timeZone: tz,
+  });
+  const nextLabel = next.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    timeZone: tz,
+  });
+  const todayStr = toYMD(day, tz);
+  return (
+    <section id={`hist-self-plan-landing-${me.id}-${date}`}>
+      <PlanningLanding
+        userId={String(me.id)}
+        tz={tz}
+        today={todayStr}
+        nextLabel={nextLabel}
+        liveLabel={liveLabel}
+        reviewLabel={liveLabel}
+      />
+    </section>
+  );
+}

--- a/app/history/self/[date]/planning/review/page.tsx
+++ b/app/history/self/[date]/planning/review/page.tsx
@@ -1,0 +1,38 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { getPlanStrict } from '@/lib/plans-store';
+import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
+import EditorClient from '@/app/(app)/planning/next/client';
+
+export const revalidate = 0;
+
+export default async function HistorySelfPlanningReview({
+  params,
+}: {
+  params: Promise<{ date: string }>;
+}) {
+  const { date } = await params;
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const snapshot = await getProfileSnapshot(me.id, date);
+  if (!snapshot) notFound();
+  const tz = getUserTimeZone(me);
+  const day = startOfDay(new Date(date), tz);
+  const dateStr = toYMD(day, tz);
+  const plan = await getPlanStrict(me.id, dateStr);
+  return (
+    <section id={`hist-self-plan-review-${me.id}-${date}`}>
+      <EditorClient
+        userId={String(me.id)}
+        date={dateStr}
+        today={dateStr}
+        tz={tz}
+        initialPlan={plan}
+        review
+      />
+    </section>
+  );
+}

--- a/tests/history-planning.spec.ts
+++ b/tests/history-planning.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+function yesterday(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+test('viewer can read historical plan without editing', async ({ page }) => {
+  const handleA = unique('owner');
+  const emailA = `${handleA}@example.com`;
+  const dateStr = yesterday();
+
+  // sign up owner and create a plan block for yesterday
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', handleA);
+  await page.fill('input[placeholder="Email"]', emailA);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+  await page.goto(`/planning/live?apoc_date=${dateStr}&apoc_time=12:00`);
+  await page.click('[id^="p1an-add-top-"]');
+  await page.fill('input[id^="p1an-meta-ttl-"]', 'Task');
+  await page.click('button[id^="p1an-meta-close-"]');
+  await page.waitForTimeout(1000);
+
+  // owner can view own historical plan
+  await page.goto(`/history/self/${dateStr}/planning`);
+  await page.click('[id^="p1an-btn-live-"]');
+  await expect(page.locator('[id^="p1an-blk-"]')).toHaveCount(1);
+  await page.click('[id^="p1an-blk-"]');
+  await expect(page.locator('input[id^="p1an-meta-ttl-"]')).toBeDisabled();
+  await expect(page.locator('[id^="p1an-now-"]')).toHaveCount(0);
+
+  // owner review shows all blocks without live bar
+  await page.goto(`/history/self/${dateStr}/planning/review`);
+  await expect(page.locator('[id^="p1an-now-"]')).toHaveCount(0);
+  await page.click('[id^="p1an-blk-"]');
+  await expect(page.locator('[id^="p1an-meta-"]')).toBeVisible();
+
+  // fetch view link for owner
+  await page.goto(`/u/${handleA}`);
+  const viewHref = await page.getAttribute('[id^="pr0ovr-view-"]', 'href');
+  const viewId = viewHref?.split('/').pop();
+
+  // sign out
+  await page.click('text=Sign out');
+
+  // sign up viewer
+  const handleB = unique('viewer');
+  const emailB = `${handleB}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Viewer');
+  await page.fill('input[placeholder="Handle"]', handleB);
+  await page.fill('input[placeholder="Email"]', emailB);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  // navigate to owner's historical planning as viewer
+  await page.goto(`/history/${viewId}/${dateStr}/planning`);
+  await page.click('[id^="p1an-btn-live-"]');
+
+  await expect(page.locator('[id^="p1an-blk-"]')).toHaveCount(1);
+  await expect(page.locator('[id^="p1an-now-"]')).toHaveCount(0);
+  await page.click('[id^="p1an-blk-"]');
+  await expect(page.locator('[id^="p1an-meta-"]')).toBeVisible();
+  await expect(page.locator('input[id^="p1an-meta-ttl-"]')).toBeDisabled();
+
+  // viewer can open historical review directly
+  await page.goto(`/history/${viewId}/${dateStr}/planning/review`);
+  await expect(page.locator('[id^="p1an-now-"]')).toHaveCount(0);
+  await page.click('[id^="p1an-blk-"]');
+  await expect(page.locator('[id^="p1an-meta-"]')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- route historical planning through landing screen with live/next/review links
- support historical navigation in `PlanningLanding` and open review only for owners
- update Playwright coverage for navigating historical plans via landing
- hide live indicator in historical planning and allow all past reviews to open

## Testing
- `pnpm lint`
- `pnpm type-check` *(fails: Command "type-check" not found)*
- `pnpm test` *(fails: Error: Please sign in.)*


------
https://chatgpt.com/codex/tasks/task_e_68a463960c7c832a819fdee7a0aeb8d6