### PR TITLE
fix snapshot date offset

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -92,3 +92,4 @@
 - 2025-10-09: Added self historical planning route so owners can review their past plans.
 - 2025-10-10: Expanded historical planning with landing screen and live/next/review pages for full time-capsule viewing.
 - 2025-10-10: Removed live indicator from historical planning and allowed all past reviews to open without time gating.
+- 2025-08-19: Corrected profile snapshot creation to store entries on the actual day they are taken.


### PR DESCRIPTION
## Summary
- store profile snapshots using current local date
- update changelog

## Testing
- `pnpm lint`
- `pnpm tsc` *(fails: Type '{ id: number; handle: string; displayName: string | null; avatarUrl: string | null; viewId: string; accountVisibility: "open" | "closed" | "private"; email: string; name: string | null; passwordHash: string; createdAt: Date | null; updatedAt: Date | null; }' has no properties in common with type '{ timeZone?: string | undefined; }'.)*
- `pnpm test` *(fails: Process from config.webServer exited early.)*

------
https://chatgpt.com/codex/tasks/task_e_68a473b71da8832a8ae1c617d97f210f