### PR TITLE
fix: align snapshot dates with user timezone

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -92,3 +92,4 @@
 - 2025-10-09: Added self historical planning route so owners can review their past plans.
 - 2025-10-10: Expanded historical planning with landing screen and live/next/review pages for full time-capsule viewing.
 - 2025-10-10: Removed live indicator from historical planning and allowed all past reviews to open without time gating.
+- 2025-10-11: Fixed profile snapshot date offset by respecting user timezone and displaying correct days in calendar.

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -3,6 +3,7 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { buildViewContext } from '@/lib/profile';
 import { ensureDailyProfileSnapshot } from '@/lib/profile-snapshots';
+import { getUserTimeZone } from '@/lib/clock';
 import { ViewContextProvider } from '@/lib/view-context';
 import { AppNav } from '@/components/app-nav';
 
@@ -16,7 +17,8 @@ export default async function AppLayout({
     redirect('/');
   }
   const me = await ensureUser(session);
-  await ensureDailyProfileSnapshot(me.id);
+  const tz = getUserTimeZone(me as any);
+  await ensureDailyProfileSnapshot(me.id, tz);
   const ctx = buildViewContext({
     ownerId: me.id,
     viewerId: me.id,
@@ -25,7 +27,11 @@ export default async function AppLayout({
   });
 
   if (process.env.NODE_ENV !== 'production') {
-    console.log({ mode: ctx.mode, ownerId: ctx.ownerId, viewerId: ctx.viewerId });
+    console.log({
+      mode: ctx.mode,
+      ownerId: ctx.ownerId,
+      viewerId: ctx.viewerId,
+    });
   }
 
   return (

--- a/components/calendar/side-calendar.tsx
+++ b/components/calendar/side-calendar.tsx
@@ -75,7 +75,7 @@ export function SideCalendar({ snapshotDates }: { snapshotDates: string[] }) {
             ))}
             {days.map((date) => {
               const isToday = date.toDateString() === today.toDateString();
-              const iso = date.toISOString().slice(0, 10);
+              const iso = date.toLocaleDateString('en-CA');
               const hasSnap = snapshotDates.includes(iso);
               return (
                 <button
@@ -85,7 +85,8 @@ export function SideCalendar({ snapshotDates }: { snapshotDates: string[] }) {
                     if (!hasSnap) return;
                     const path =
                       ctx.mode === 'owner' ||
-                      (ctx.mode === 'historical' && ctx.viewerId === ctx.ownerId)
+                      (ctx.mode === 'historical' &&
+                        ctx.viewerId === ctx.ownerId)
                         ? `/history/self/${iso}`
                         : `/history/${ctx.viewId}/${iso}`;
                     router.push(path);

--- a/lib/clock.ts
+++ b/lib/clock.ts
@@ -33,12 +33,11 @@ function getOffset(date: Date, tz: string): number {
   return asUTC - date.getTime();
 }
 
-export function getUserTimeZone(user?: { timeZone?: string }): string {
-  return (
-    user?.timeZone ||
-    Intl.DateTimeFormat().resolvedOptions().timeZone ||
-    'UTC'
-  );
+export function getUserTimeZone(
+  user?: { timeZone?: string } | Record<string, unknown>,
+): string {
+  const tz = (user as any)?.timeZone as string | undefined;
+  return tz || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 }
 
 function first(val?: string | string[]): string | undefined {
@@ -46,7 +45,10 @@ function first(val?: string | string[]): string | undefined {
   return val;
 }
 
-export function getNow(tz: string, req?: ReqLike): { now: Date; override: boolean } {
+export function getNow(
+  tz: string,
+  req?: ReqLike,
+): { now: Date; override: boolean } {
   let override = false;
   let result: Date | undefined;
 


### PR DESCRIPTION
## Summary
- ensure profile snapshots use user timezone when calculating target date
- normalize calendar snapshot matching to local dates
- log change in UPDATE.md

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a473b71da8832a8ae1c617d97f210f