### PR TITLE
feat: add search for flavors and subflavors

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -98,3 +98,4 @@
 - 2025-10-11: Simplified ingredient image selector to highlight the chosen preset without large preview.
 - 2025-10-12: Added ingredient import flow with preset choices and social search.
 - 2025-10-12: Fixed preset import tags and ensured viewers have user records when copying ingredients.
+- 2025-10-13: Added search filtering for flavors and subflavors.

--- a/app/(app)/flavors/[flavorId]/subflavors/client.tsx
+++ b/app/(app)/flavors/[flavorId]/subflavors/client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import type { Subflavor, Visibility } from '@/types/subflavor';
 import { createSubflavor, updateSubflavor } from './actions';
 import { useViewContext } from '@/lib/view-context';
@@ -53,6 +53,7 @@ export default function SubflavorsClient({
   const [subflavors, setSubflavors] = useState<Subflavor[]>(
     sortSubflavors(initialSubflavors),
   );
+  const [search, setSearch] = useState('');
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<Subflavor | null>(null);
   const [form, setForm] = useState<FormState>({
@@ -72,6 +73,15 @@ export default function SubflavorsClient({
   const modalRef = useRef<HTMLDivElement>(null);
   const formRef = useRef(form);
   const initialFormRef = useRef(initialForm);
+  const filtered = useMemo(
+    () =>
+      subflavors.filter(
+        (f) =>
+          f.name.toLowerCase().includes(search.toLowerCase()) ||
+          f.description.toLowerCase().includes(search.toLowerCase()),
+      ),
+    [subflavors, search],
+  );
 
   useEffect(() => {
     formRef.current = form;
@@ -209,7 +219,7 @@ export default function SubflavorsClient({
 
   return (
     <section>
-      <div className="mb-4 flex justify-end">
+      <div className="mb-4 flex items-center gap-4">
         <button
           onClick={editable ? (e) => openCreate(e.currentTarget) : undefined}
           className="rounded bg-orange-500 px-3 py-2 text-white disabled:opacity-50"
@@ -218,9 +228,16 @@ export default function SubflavorsClient({
         >
           New Subflavor
         </button>
+        <input
+          type="text"
+          placeholder="Search subflavors…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="flex-1 rounded border px-2 py-1"
+        />
       </div>
       <ul className="flex flex-col gap-4" id={`s7ubflavourli5t-${userId}`}>
-        {subflavors.map((f) => (
+        {filtered.map((f) => (
           <li
             key={f.id}
             id={`s7ubflavourrow${f.id}-${userId}`}
@@ -283,7 +300,9 @@ export default function SubflavorsClient({
               <button
                 id={`s7ubflavoured1t${f.id}-${userId}`}
                 className="text-sm text-blue-600 underline disabled:opacity-50"
-                onClick={editable ? (e) => openEdit(f, e.currentTarget) : undefined}
+                onClick={
+                  editable ? (e) => openEdit(f, e.currentTarget) : undefined
+                }
                 disabled={!editable}
               >
                 Edit ▸

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import type { Flavor, Visibility } from '@/types/flavor';
 import { createFlavor, updateFlavor } from './actions';
@@ -53,6 +53,7 @@ export default function FlavorsClient({
   const ctx = useViewContext();
   const { editable } = ctx;
   const [flavors, setFlavors] = useState<Flavor[]>(sortFlavors(initialFlavors));
+  const [search, setSearch] = useState('');
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<Flavor | null>(null);
   const [form, setForm] = useState<FormState>({
@@ -72,6 +73,15 @@ export default function FlavorsClient({
   const modalRef = useRef<HTMLDivElement>(null);
   const formRef = useRef(form);
   const initialFormRef = useRef(initialForm);
+  const filtered = useMemo(
+    () =>
+      flavors.filter(
+        (f) =>
+          f.name.toLowerCase().includes(search.toLowerCase()) ||
+          f.description.toLowerCase().includes(search.toLowerCase()),
+      ),
+    [flavors, search],
+  );
 
   useEffect(() => {
     formRef.current = form;
@@ -209,7 +219,7 @@ export default function FlavorsClient({
 
   return (
     <section>
-      <div className="mb-4 flex justify-end">
+      <div className="mb-4 flex items-center gap-4">
         <button
           onClick={editable ? (e) => openCreate(e.currentTarget) : undefined}
           className="rounded bg-orange-500 px-3 py-2 text-white disabled:opacity-50"
@@ -218,9 +228,16 @@ export default function FlavorsClient({
         >
           New Flavor
         </button>
+        <input
+          type="text"
+          placeholder="Search flavors…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="flex-1 rounded border px-2 py-1"
+        />
       </div>
       <ul className="flex flex-col gap-4" id={`f7avourli5t-${userId}`}>
-        {flavors.map((f) => (
+        {filtered.map((f) => (
           <li
             key={f.id}
             id={`f7avourrow${f.id}-${userId}`}
@@ -298,7 +315,9 @@ export default function FlavorsClient({
               <button
                 id={`f7avoured1t${f.id}-${userId}`}
                 className="text-sm text-blue-600 underline disabled:opacity-50"
-                onClick={editable ? (e) => openEdit(f, e.currentTarget) : undefined}
+                onClick={
+                  editable ? (e) => openEdit(f, e.currentTarget) : undefined
+                }
                 disabled={!editable}
               >
                 Edit ▸

--- a/tests/flavors.spec.ts
+++ b/tests/flavors.spec.ts
@@ -87,6 +87,13 @@ test('flavor CRUD and ordering', async ({ page }) => {
     '❤️',
   );
 
+  // search flavors
+  const flavorSearch = page.locator('input[placeholder="Search flavors…"]');
+  await flavorSearch.fill('Second');
+  await expect(page.locator('li:has-text("Second")')).toBeVisible();
+  await expect(page.locator('li:has-text("First Updated")')).toHaveCount(0);
+  await flavorSearch.fill('');
+
   // keyboard interaction: focus row, open with Enter then close with Esc
   await rows.first().focus();
   await page.keyboard.press('Enter');

--- a/tests/subflavors.spec.ts
+++ b/tests/subflavors.spec.ts
@@ -36,6 +36,12 @@ test('subflavor CRUD', async ({ page }) => {
   await page.click('button[id^="s7ubflavoursav-frm"]');
   await expect(page.locator('li:has-text("Sub1")')).toBeVisible();
 
+  // search subflavors
+  const subSearch = page.locator('input[placeholder="Search subflavors…"]');
+  await subSearch.fill('Nope');
+  await expect(page.locator('ul[id^="s7ubflavourli5t"] > li')).toHaveCount(0);
+  await subSearch.fill('');
+
   const rows = page.locator('ul[id^="s7ubflavourli5t"] > li');
   await rows.first().click();
   await page.fill('input[id^="s7ubflavour1mp-frm"]', '80');


### PR DESCRIPTION
## Summary
- allow filtering flavor and subflavor lists via search input
- cover flavor and subflavor filtering with Playwright tests
- note search update in the changelog

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*


------
https://chatgpt.com/codex/tasks/task_e_68a48c8f3d6c832a855337151a5463a5