### PR TITLE
feat: add flavor import and copy flow

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -99,3 +99,4 @@
 - 2025-10-12: Added ingredient import flow with preset choices and social search.
 - 2025-10-12: Fixed preset import tags and ensured viewers have user records when copying ingredients.
 - 2025-10-13: Added search filtering for flavors and subflavors.
+- 2025-10-14: Added flavor and subflavor import flows with presets, social search, and copy options.

--- a/app/(app)/flavors/[flavorId]/subflavors/page.tsx
+++ b/app/(app)/flavors/[flavorId]/subflavors/page.tsx
@@ -3,6 +3,7 @@ import { ensureUser } from '@/lib/users';
 import { listSubflavors } from '@/lib/subflavors-store';
 import SubflavorsClient from './client';
 import { redirect } from 'next/navigation';
+import { listPeople } from '@/lib/people-store';
 
 export default async function SubflavorsPage({
   params,
@@ -15,11 +16,15 @@ export default async function SubflavorsPage({
   const me = await ensureUser(session);
   const userId = String(me.id);
   const subflavors = await listSubflavors(userId, flavorId);
+  const people = await listPeople(me.id);
   return (
     <SubflavorsClient
       userId={userId}
+      selfId={userId}
       flavorId={flavorId}
       initialSubflavors={subflavors}
+      people={people}
+      targetFlavorId={flavorId}
     />
   );
 }

--- a/app/(app)/flavors/page.tsx
+++ b/app/(app)/flavors/page.tsx
@@ -3,6 +3,9 @@ import { auth } from '@/lib/auth';
 import { listFlavors } from '@/lib/flavors-store';
 import FlavorsClient from './client';
 import { getUserByViewId, ensureUser } from '@/lib/users';
+import { listPeople } from '@/lib/people-store';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
 
 export default async function FlavorsPage({
   params,
@@ -11,16 +14,50 @@ export default async function FlavorsPage({
 }) {
   const session = await auth();
   if (!session) notFound();
-  const viewerId = Number((session.user as any)?.id);
-  let ownerId = viewerId;
+  const viewer = await ensureUser(session);
+  let owner = viewer;
   if (params?.viewId) {
     const user = await getUserByViewId(params.viewId);
     if (!user) notFound();
-    ownerId = user.id;
-  } else {
-    const me = await ensureUser(session);
-    ownerId = me.id;
+    owner = user;
   }
-  const flavors = await listFlavors(String(ownerId));
-  return <FlavorsClient userId={String(ownerId)} initialFlavors={flavors} />;
+  const flavors = await listFlavors(String(owner.id));
+  const people = owner.id === viewer.id ? await listPeople(owner.id) : undefined;
+  const ctx = buildViewContext({
+    ownerId: owner.id,
+    viewerId: viewer.id,
+    mode: owner.id === viewer.id ? 'owner' : 'viewer',
+    viewId: owner.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <FlavorsClient
+        userId={String(owner.id)}
+        selfId={String(viewer.id)}
+        initialFlavors={flavors}
+        people={people}
+      />
+    </ViewContextProvider>
+  );
+}
+
+export function FlavorsHome({
+  userId,
+  selfId,
+  initialFlavors,
+  people,
+}: {
+  userId: string;
+  selfId?: string;
+  initialFlavors: any[];
+  people?: any;
+}) {
+  return (
+    <FlavorsClient
+      userId={userId}
+      selfId={selfId}
+      initialFlavors={initialFlavors as any}
+      people={people as any}
+    />
+  );
 }

--- a/app/(view)/view/[viewId]/flavors/[flavorId]/subflavors/page.tsx
+++ b/app/(view)/view/[viewId]/flavors/[flavorId]/subflavors/page.tsx
@@ -1,23 +1,31 @@
-import { getUserByViewId } from '@/lib/users';
+import { getUserByViewId, ensureUser } from '@/lib/users';
 import { notFound } from 'next/navigation';
 import { listSubflavors } from '@/lib/subflavors-store';
 import SubflavorsClient from '@/app/(app)/flavors/[flavorId]/subflavors/client';
+import { auth } from '@/lib/auth';
 
 export default async function ViewSubflavorsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ viewId: string; flavorId: string }>;
+  searchParams?: Promise<{ to?: string }>;
 }) {
   const { viewId, flavorId } = await params;
+  const sp = await searchParams;
   const user = await getUserByViewId(viewId);
   if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
   const subflavors = await listSubflavors(String(user.id), flavorId);
   return (
     <section id={`v13w-subflav-${user.id}-${flavorId}`}>
       <SubflavorsClient
         userId={String(user.id)}
+        selfId={viewer ? String(viewer.id) : undefined}
         flavorId={flavorId}
         initialSubflavors={subflavors}
+        targetFlavorId={sp?.to}
       />
     </section>
   );

--- a/app/(view)/view/[viewId]/flavors/page.tsx
+++ b/app/(view)/view/[viewId]/flavors/page.tsx
@@ -1,18 +1,42 @@
-import { getUserByViewId } from '@/lib/users';
+import { getUserByViewId, ensureUser } from '@/lib/users';
 import { notFound } from 'next/navigation';
-import FlavorsPage from '@/app/(app)/flavors/page';
+import { auth } from '@/lib/auth';
+import { listFlavors } from '@/lib/flavors-store';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { FlavorsHome } from '@/app/(app)/flavors/page';
 
 export default async function ViewFlavorsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
 }) {
   const { viewId } = await params;
+  const sp = await searchParams;
   const user = await getUserByViewId(viewId);
   if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  const flavors = await listFlavors(String(user.id));
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: sp?.at ? 'historical' : 'viewer',
+    viewId: user.viewId,
+    snapshotDate: sp?.at,
+  });
   return (
-    <section id={`v13w-flav-${user.id}`}>
-      <FlavorsPage params={{ viewId }} />
-    </section>
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-flav-${user.id}`}>
+        <FlavorsHome
+          userId={String(user.id)}
+          selfId={viewerId ? String(viewerId) : undefined}
+          initialFlavors={flavors}
+        />
+      </section>
+    </ViewContextProvider>
   );
 }

--- a/app/api/public-subflavors/route.ts
+++ b/app/api/public-subflavors/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { listSubflavors } from '@/lib/subflavors-store';
+
+export async function GET(req: NextRequest) {
+  const userId = req.nextUrl.searchParams.get('userId');
+  const flavorId = req.nextUrl.searchParams.get('flavorId');
+  if (!userId || !flavorId) {
+    return NextResponse.json({ error: 'Missing params' }, { status: 400 });
+  }
+  const subs = await listSubflavors(userId, flavorId);
+  return NextResponse.json(subs);
+}

--- a/tests/flavors.spec.ts
+++ b/tests/flavors.spec.ts
@@ -21,7 +21,8 @@ test('flavor CRUD and ordering', async ({ page }) => {
   await page.goto('/flavors');
 
   // create first flavor
-  await page.click('text=New Flavor');
+  await page.click('button[id^="f7av-add"]');
+  await page.click('button[id^="f7av-add-own"]');
   await page.fill('input[id^="f7avourn4me-frm"]', 'First');
   await page.fill('textarea[id^="f7avourde5cr-frm"]', 'desc1');
   await page.fill('input[name="color"]', '#ff0000');
@@ -32,7 +33,8 @@ test('flavor CRUD and ordering', async ({ page }) => {
   await expect(page.locator('li:has-text("First")')).toBeVisible();
 
   // create second flavor with higher importance
-  await page.click('text=New Flavor');
+  await page.click('button[id^="f7av-add"]');
+  await page.click('button[id^="f7av-add-own"]');
   await page.fill('input[id^="f7avourn4me-frm"]', 'Second');
   await page.fill('textarea[id^="f7avourde5cr-frm"]', 'desc2');
   await page.fill('input[name="color"]', '#00ff00');

--- a/tests/subflavors.spec.ts
+++ b/tests/subflavors.spec.ts
@@ -13,7 +13,8 @@ test('subflavor CRUD', async ({ page }) => {
   await page.goto('/flavors');
 
   // create a flavor to attach subflavors
-  await page.click('text=New Flavor');
+  await page.click('button[id^="f7av-add"]');
+  await page.click('button[id^="f7av-add-own"]');
   await page.fill('input[id^="f7avourn4me-frm"]', 'Main');
   await page.fill('textarea[id^="f7avourde5cr-frm"]', 'maindesc');
   await page.fill('input[name="color"]', '#ff0000');
@@ -26,7 +27,8 @@ test('subflavor CRUD', async ({ page }) => {
   await page.click('button[id^="f7avsubfbtn"]');
 
   // create subflavor
-  await page.click('text=New Subflavor');
+  await page.click('button[id^="s7ubflav-add"]');
+  await page.click('button[id^="s7ubflav-add-own"]');
   await page.fill('input[id^="s7ubflavourn4me-frm"]', 'Sub1');
   await page.fill('textarea[id^="s7ubflavourde5cr-frm"]', 'sdesc');
   await page.fill('input[name="color"]', '#00ff00');


### PR DESCRIPTION
## Summary
- allow adding flavors via presets or social import
- enable copying flavors with optional subflavor cloning
- mirror import/copy flow for subflavors

## Testing
- `pnpm lint`
- `pnpm type-check` *(fails: Command "type-check" not found)*
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a490056bec832a8782964ae0e60b69