### PR TITLE
Add consolidated subflavor search page

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -100,3 +100,4 @@
 - 2025-10-12: Fixed preset import tags and ensured viewers have user records when copying ingredients.
 - 2025-10-13: Added search filtering for flavors and subflavors.
 - 2025-10-14: Added flavor and subflavor import flows with presets, social search, and copy options.
+- 2025-10-15: Added consolidated subflavor viewing page for importing from others grouped by parent flavor importance.

--- a/app/(app)/flavors/[flavorId]/subflavors/client.tsx
+++ b/app/(app)/flavors/[flavorId]/subflavors/client.tsx
@@ -33,7 +33,7 @@ const PRESET_SUBFLAVORS: SubflavorInput[] = [
     targetMix: 40,
     visibility: 'private',
     orderIndex: 0,
-    slug: undefined,
+    slug: '',
   },
   {
     flavorId: '',
@@ -45,7 +45,7 @@ const PRESET_SUBFLAVORS: SubflavorInput[] = [
     targetMix: 30,
     visibility: 'private',
     orderIndex: 0,
-    slug: undefined,
+    slug: '',
   },
 ];
 
@@ -91,7 +91,9 @@ export default function SubflavorsClient({
   const [modalOpen, setModalOpen] = useState(false);
   const [choiceOpen, setChoiceOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
-  const [importMode, setImportMode] = useState<'choice' | 'preset' | 'search'>('choice');
+  const [importMode, setImportMode] = useState<'choice' | 'preset' | 'search'>(
+    'choice',
+  );
   const [peopleSearch, setPeopleSearch] = useState('');
   const [editing, setEditing] = useState<Subflavor | null>(null);
   const [form, setForm] = useState<FormState>({
@@ -305,7 +307,8 @@ export default function SubflavorsClient({
             tabIndex={0}
             onClick={(e) => openEdit(f, e.currentTarget)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') openEdit(f, e.currentTarget as HTMLElement);
+              if (e.key === 'Enter')
+                openEdit(f, e.currentTarget as HTMLElement);
               if (editable && e.key === 'Delete') remove(f);
             }}
             className="flex items-center gap-4 p-2 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
@@ -459,7 +462,9 @@ export default function SubflavorsClient({
                       onClick={() => importPreset({ ...p, flavorId })}
                     >
                       <div className="font-semibold">{p.name}</div>
-                      <div className="text-sm text-gray-600">{p.description}</div>
+                      <div className="text-sm text-gray-600">
+                        {p.description}
+                      </div>
                     </button>
                   ))}
                 </div>
@@ -504,11 +509,13 @@ export default function SubflavorsClient({
                             <li key={u.id} className="py-2">
                               <a
                                 id={`s7ubflav-ppl-${u.id}-${userId}`}
-                                href={`/view/${u.viewId}/flavors?to=${targetFlavorId ?? flavorId}`}
+                                href={`/view/${u.viewId}/subflavors?to=${targetFlavorId ?? flavorId}`}
                                 className="block"
                               >
                                 {u.displayName ?? u.handle}{' '}
-                                <span className="text-sm text-gray-600">@{u.handle}</span>
+                                <span className="text-sm text-gray-600">
+                                  @{u.handle}
+                                </span>
                               </a>
                             </li>
                           ))}

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -34,7 +34,7 @@ const PRESET_FLAVORS: FlavorInput[] = [
     targetMix: 50,
     visibility: 'private',
     orderIndex: 0,
-    slug: undefined,
+    slug: '',
   },
   {
     name: 'Learning',
@@ -45,7 +45,7 @@ const PRESET_FLAVORS: FlavorInput[] = [
     targetMix: 40,
     visibility: 'private',
     orderIndex: 0,
-    slug: undefined,
+    slug: '',
   },
 ];
 
@@ -88,7 +88,9 @@ export default function FlavorsClient({
   const [modalOpen, setModalOpen] = useState(false);
   const [choiceOpen, setChoiceOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
-  const [importMode, setImportMode] = useState<'choice' | 'preset' | 'search'>('choice');
+  const [importMode, setImportMode] = useState<'choice' | 'preset' | 'search'>(
+    'choice',
+  );
   const [peopleSearch, setPeopleSearch] = useState('');
   const [editing, setEditing] = useState<Flavor | null>(null);
   const [form, setForm] = useState<FormState>({
@@ -302,7 +304,8 @@ export default function FlavorsClient({
             tabIndex={0}
             onClick={(e) => openEdit(f, e.currentTarget)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') openEdit(f, e.currentTarget as HTMLElement);
+              if (e.key === 'Enter')
+                openEdit(f, e.currentTarget as HTMLElement);
               if (editable && e.key === 'Delete') remove(f);
             }}
             className="flex items-center gap-4 p-2 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
@@ -475,7 +478,9 @@ export default function FlavorsClient({
                       onClick={() => importPreset(p)}
                     >
                       <div className="font-semibold">{p.name}</div>
-                      <div className="text-sm text-gray-600">{p.description}</div>
+                      <div className="text-sm text-gray-600">
+                        {p.description}
+                      </div>
                     </button>
                   ))}
                 </div>
@@ -524,7 +529,9 @@ export default function FlavorsClient({
                                 className="block"
                               >
                                 {u.displayName ?? u.handle}{' '}
-                                <span className="text-sm text-gray-600">@{u.handle}</span>
+                                <span className="text-sm text-gray-600">
+                                  @{u.handle}
+                                </span>
                               </a>
                             </li>
                           ))}
@@ -763,7 +770,9 @@ export default function FlavorsClient({
                     onClick={async () => {
                       let withSubs = false;
                       try {
-                        const res = await fetch(`/api/public-subflavors?userId=${userId}&flavorId=${editing.id}`);
+                        const res = await fetch(
+                          `/api/public-subflavors?userId=${userId}&flavorId=${editing.id}`,
+                        );
                         const subs = await res.json();
                         if (Array.isArray(subs) && subs.length > 0) {
                           withSubs = confirm('Also copy the subflavors?');

--- a/app/(view)/view/[viewId]/subflavors/client.tsx
+++ b/app/(view)/view/[viewId]/subflavors/client.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useTransition } from 'react';
+import type { Flavor } from '@/types/flavor';
+import type { Subflavor } from '@/types/subflavor';
+import { copySubflavor } from '@/app/(app)/flavors/[flavorId]/subflavors/actions';
+
+type Group = {
+  flavor: Flavor;
+  subflavors: Subflavor[];
+};
+
+export default function SubflavorsAllClient({
+  fromUserId,
+  groups,
+  targetFlavorId,
+}: {
+  fromUserId: string;
+  groups: Group[];
+  targetFlavorId?: string;
+}) {
+  const [pending, startTransition] = useTransition();
+
+  async function handleCopy(id: string) {
+    if (!targetFlavorId) return;
+    await copySubflavor(fromUserId, id, targetFlavorId);
+    alert('Copied');
+  }
+
+  return (
+    <div className="space-y-6">
+      {groups.map((g) => (
+        <div key={g.flavor.id}>
+          <h2 className="text-lg font-semibold">{g.flavor.name}</h2>
+          <ul className="mt-2 space-y-2">
+            {g.subflavors.map((s) => (
+              <li
+                key={s.id}
+                className="flex items-center justify-between rounded border p-2"
+              >
+                <div>
+                  <div className="font-medium">{s.name}</div>
+                  {s.description && (
+                    <div className="text-sm text-gray-600">{s.description}</div>
+                  )}
+                </div>
+                {targetFlavorId && (
+                  <button
+                    id={`cpysubflav-${s.id}`}
+                    className="rounded bg-orange-500 px-3 py-1 text-white disabled:opacity-50"
+                    disabled={pending}
+                    onClick={() => startTransition(() => handleCopy(s.id))}
+                  >
+                    Copy
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/(view)/view/[viewId]/subflavors/page.tsx
+++ b/app/(view)/view/[viewId]/subflavors/page.tsx
@@ -1,0 +1,50 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { listFlavors } from '@/lib/flavors-store';
+import { listSubflavors } from '@/lib/subflavors-store';
+import type { Flavor } from '@/types/flavor';
+import type { Subflavor } from '@/types/subflavor';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import SubflavorsAllClient from './client';
+
+export default async function ViewAllSubflavorsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ to?: string; at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  const flavors = await listFlavors(String(user.id));
+  const groups: { flavor: Flavor; subflavors: Subflavor[] }[] = [];
+  for (const f of flavors) {
+    const subs = await listSubflavors(String(user.id), f.id);
+    groups.push({ flavor: f, subflavors: subs });
+  }
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: sp?.at ? 'historical' : 'viewer',
+    viewId: user.viewId,
+    snapshotDate: sp?.at,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-allsubflav-${user.id}`}>
+        <SubflavorsAllClient
+          fromUserId={String(user.id)}
+          groups={groups}
+          targetFlavorId={sp?.to}
+        />
+      </section>
+    </ViewContextProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add viewer page listing all subflavors grouped by parent flavor importance with copy support
- update subflavor import search to link directly to the new page
- normalize preset slugs to satisfy TypeScript

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Please sign in)*

------
https://chatgpt.com/codex/tasks/task_e_68a49677da20832a8d09b98adfe9ff39