### PR TITLE
feat: allow copying historical flavors

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -102,3 +102,4 @@
 - 2025-10-14: Added flavor and subflavor import flows with presets, social search, and copy options.
 - 2025-10-15: Added aggregated subflavors viewer listing all subflavors by flavor importance and linked search to it.
 - 2025-10-16: Prompted flavor selection when copying subflavors and allowed promoting subflavor to main flavor.
+- 2025-10-17: Enabled copying flavors from historical snapshots, allowing users to duplicate past flavors (and subflavors) from their own or others' profiles.

--- a/app/history/[viewId]/[date]/flavors/page.tsx
+++ b/app/history/[viewId]/[date]/flavors/page.tsx
@@ -1,4 +1,5 @@
-import { getUserByViewId } from '@/lib/users';
+import { auth } from '@/lib/auth';
+import { getUserByViewId, ensureUser } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import FlavorsClient from '@/app/(app)/flavors/client';
@@ -13,13 +14,16 @@ export default async function HistoryViewFlavorsPage({
   if (!owner) notFound();
   const snapshot = await getProfileSnapshot(owner.id, date);
   if (!snapshot) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
   return (
     <section id={`hist-flav-${owner.id}-${date}`}>
       <FlavorsClient
-      userId={String(owner.id)}
-      initialFlavors={snapshot.flavors as any}
-    />
+        userId={String(owner.id)}
+        selfId={viewer ? String(viewer.id) : undefined}
+        initialFlavors={snapshot.flavors as any}
+        snapshotSubflavors={snapshot.subflavors as any}
+      />
     </section>
   );
 }
-


### PR DESCRIPTION
## Summary
- enable copying flavors (and subflavors) from historical snapshots
- show copy button for historical flavors pages when logged in

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c3cf4930832ab062a5c4dbf0c1b5