### PR TITLE
feat: copy flavors from history

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -102,3 +102,6 @@
 - 2025-10-14: Added flavor and subflavor import flows with presets, social search, and copy options.
 - 2025-10-15: Added aggregated subflavors viewer listing all subflavors by flavor importance and linked search to it.
 - 2025-10-16: Prompted flavor selection when copying subflavors and allowed promoting subflavor to main flavor.
+- 2025-10-17: Enabled copying flavors from historical snapshots for owners and viewers and added tests.
+- 2025-10-17: Enabled copying subflavors from historical snapshots for owners and viewers and added tests.
+- 2025-10-17: Added destination picker when copying subflavors from viewer and historical pages.

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,9 +1,13 @@
 import { CakeHome } from '@/components/cake/cake-home';
 import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
+import { redirect } from 'next/navigation';
 
 export default async function DashboardPage() {
   const session = await auth();
-  const me = await ensureUser(session!);
+  if (!session) {
+    redirect('/signin');
+  }
+  const me = await ensureUser(session);
   return <CakeHome ownerId={me.id} />;
 }

--- a/app/(view)/view/[viewId]/flavors/[flavorId]/subflavors/page.tsx
+++ b/app/(view)/view/[viewId]/flavors/[flavorId]/subflavors/page.tsx
@@ -1,7 +1,8 @@
 import { getUserByViewId, ensureUser } from '@/lib/users';
 import { notFound } from 'next/navigation';
 import { listSubflavors } from '@/lib/subflavors-store';
-import SubflavorsClient from '@/app/(app)/flavors/[flavorId]/subflavors/client';
+import { getFlavor, listFlavors } from '@/lib/flavors-store';
+import AllSubflavorsClient from '@/app/(view)/view/[viewId]/subflavors/client';
 import { auth } from '@/lib/auth';
 
 export default async function ViewSubflavorsPage({
@@ -18,14 +19,17 @@ export default async function ViewSubflavorsPage({
   const session = await auth();
   const viewer = session ? await ensureUser(session) : null;
   const subflavors = await listSubflavors(String(user.id), flavorId);
+  const flavor = await getFlavor(String(user.id), flavorId);
+  if (!flavor) notFound();
+  const viewerFlavors = viewer ? await listFlavors(String(viewer.id)) : [];
   return (
     <section id={`v13w-subflav-${user.id}-${flavorId}`}>
-      <SubflavorsClient
+      <AllSubflavorsClient
         userId={String(user.id)}
         selfId={viewer ? String(viewer.id) : undefined}
-        flavorId={flavorId}
-        initialSubflavors={subflavors}
+        groups={[{ flavor, subflavors }]}
         targetFlavorId={sp?.to}
+        selfFlavors={viewerFlavors}
       />
     </section>
   );

--- a/app/history/[viewId]/[date]/flavors/[flavorId]/subflavors/page.tsx
+++ b/app/history/[viewId]/[date]/flavors/[flavorId]/subflavors/page.tsx
@@ -1,27 +1,42 @@
-import { getUserByViewId } from '@/lib/users';
+import { getUserByViewId, ensureUser } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
-import SubflavorsClient from '@/app/(app)/flavors/[flavorId]/subflavors/client';
+import { listFlavors } from '@/lib/flavors-store';
+import AllSubflavorsClient from '@/app/(view)/view/[viewId]/subflavors/client';
+import { auth } from '@/lib/auth';
+import type { Flavor } from '@/types/flavor';
 
 export default async function HistoryViewSubflavorsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ viewId: string; date: string; flavorId: string }>;
+  searchParams?: Promise<{ to?: string }>;
 }) {
   const { viewId, date, flavorId } = await params;
+  const sp = await searchParams;
   const owner = await getUserByViewId(viewId);
   if (!owner) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
   const snapshot = await getProfileSnapshot(owner.id, date);
   if (!snapshot) notFound();
   const subflavors = (snapshot.subflavors as any[]).filter(
     (s) => s.flavorId === flavorId,
   );
+  const flavor = (snapshot.flavors as any[]).find((f) => f.id === flavorId) as
+    | Flavor
+    | undefined;
+  if (!flavor) notFound();
+  const viewerFlavors = viewer ? await listFlavors(String(viewer.id)) : [];
   return (
     <section id={`hist-subflav-${owner.id}-${flavorId}-${date}`}>
-      <SubflavorsClient
+      <AllSubflavorsClient
         userId={String(owner.id)}
-        flavorId={flavorId}
-        initialSubflavors={subflavors as any}
+        selfId={viewer ? String(viewer.id) : undefined}
+        groups={[{ flavor: flavor as any, subflavors: subflavors as any }]}
+        targetFlavorId={sp?.to}
+        selfFlavors={viewerFlavors}
       />
     </section>
   );

--- a/app/history/[viewId]/[date]/flavors/page.tsx
+++ b/app/history/[viewId]/[date]/flavors/page.tsx
@@ -1,6 +1,7 @@
-import { getUserByViewId } from '@/lib/users';
+import { getUserByViewId, ensureUser } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
 import FlavorsClient from '@/app/(app)/flavors/client';
 
 export default async function HistoryViewFlavorsPage({
@@ -11,15 +12,17 @@ export default async function HistoryViewFlavorsPage({
   const { viewId, date } = await params;
   const owner = await getUserByViewId(viewId);
   if (!owner) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
   const snapshot = await getProfileSnapshot(owner.id, date);
   if (!snapshot) notFound();
   return (
     <section id={`hist-flav-${owner.id}-${date}`}>
       <FlavorsClient
-      userId={String(owner.id)}
-      initialFlavors={snapshot.flavors as any}
-    />
+        userId={String(owner.id)}
+        selfId={viewer ? String(viewer.id) : undefined}
+        initialFlavors={snapshot.flavors as any}
+      />
     </section>
   );
 }
-

--- a/app/history/self/[date]/flavors/[flavorId]/subflavors/page.tsx
+++ b/app/history/self/[date]/flavors/[flavorId]/subflavors/page.tsx
@@ -2,7 +2,9 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound, redirect } from 'next/navigation';
-import SubflavorsClient from '@/app/(app)/flavors/[flavorId]/subflavors/client';
+import { listFlavors } from '@/lib/flavors-store';
+import AllSubflavorsClient from '@/app/(view)/view/[viewId]/subflavors/client';
+import type { Flavor } from '@/types/flavor';
 
 export default async function HistorySubflavorsPage({
   params,
@@ -18,11 +20,18 @@ export default async function HistorySubflavorsPage({
   const subflavors = (snapshot.subflavors as any[]).filter(
     (s) => s.flavorId === flavorId,
   );
+  const flavor = (snapshot.flavors as any[]).find((f) => f.id === flavorId) as
+    | Flavor
+    | undefined;
+  if (!flavor) notFound();
+  const myFlavors = await listFlavors(String(me.id));
   return (
-    <SubflavorsClient
+    <AllSubflavorsClient
       userId={String(me.id)}
-      flavorId={flavorId}
-      initialSubflavors={subflavors as any}
+      selfId={String(me.id)}
+      groups={[{ flavor: flavor as any, subflavors: subflavors as any }]}
+      targetFlavorId={flavorId}
+      selfFlavors={myFlavors}
     />
   );
 }

--- a/app/history/self/[date]/flavors/page.tsx
+++ b/app/history/self/[date]/flavors/page.tsx
@@ -17,8 +17,8 @@ export default async function HistoryFlavorsPage({
   return (
     <FlavorsClient
       userId={String(me.id)}
+      selfId={String(me.id)}
       initialFlavors={snapshot.flavors as any}
     />
   );
 }
-

--- a/tests/history-flavors.spec.ts
+++ b/tests/history-flavors.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import { getUserByHandle } from '@/lib/users';
+import { createProfileSnapshot } from '@/lib/profile-snapshots';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+test('copy flavors from historical snapshots', async ({ page, browser }) => {
+  page.on('dialog', (d) => d.accept());
+  const handleOwner = unique('owner');
+  const emailOwner = `${handleOwner}@example.com`;
+  const dateStr = today();
+
+  // sign up owner and create a flavor
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', handleOwner);
+  await page.fill('input[placeholder="Email"]', emailOwner);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+  await page.goto('/flavors');
+  await page.click('button[id^="f7av-add"]');
+  await page.click('button[id^="f7av-add-own"]');
+  await page.fill('input[id^="f7avourn4me-frm"]', 'Past');
+  await page.fill('textarea[id^="f7avourde5cr-frm"]', 'desc');
+  await page.click('button[id^="f7avoursav-frm"]');
+
+  // snapshot today's profile and delete flavor
+  const owner = await getUserByHandle(handleOwner);
+  await createProfileSnapshot(owner.id, dateStr);
+  const row = page.locator('li:has-text("Past")');
+  await row.locator('button:has-text("Delete")').click();
+  await expect(page.locator('li:has-text("Past")')).toHaveCount(0);
+
+  // copy from own history
+  await page.goto(`/history/self/${dateStr}/flavors`);
+  await page.locator('li:has-text("Past")').click();
+  await page.click('button:has-text("Copy flavor")');
+  await page.goto('/flavors');
+  await expect(page.locator('li:has-text("Past")')).toHaveCount(1);
+
+  // fetch owner's view id
+  await page.goto(`/u/${handleOwner}`);
+  const viewHref = await page.getAttribute('[id^="pr0ovr-view-"]', 'href');
+  const viewId = viewHref?.split('/').pop();
+
+  // viewer signs up and copies from owner's history
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  const handleViewer = unique('viewer');
+  const emailViewer = `${handleViewer}@example.com`;
+  await page2.goto('/signup');
+  await page2.fill('input[placeholder="Name"]', 'Viewer');
+  await page2.fill('input[placeholder="Handle"]', handleViewer);
+  await page2.fill('input[placeholder="Email"]', emailViewer);
+  await page2.fill('input[placeholder="Password"]', PASSWORD);
+  await page2.click('text=Sign Up');
+  await page2.goto(`/history/${viewId}/${dateStr}/flavors`);
+  await page2.locator('li:has-text("Past")').click();
+  await page2.click('button:has-text("Copy flavor")');
+  await page2.goto('/flavors');
+  await expect(page2.locator('li:has-text("Past")')).toHaveCount(1);
+  await ctx2.close();
+});

--- a/tests/history-subflavors.spec.ts
+++ b/tests/history-subflavors.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+import { getUserByHandle } from '@/lib/users';
+import { createProfileSnapshot } from '@/lib/profile-snapshots';
+import { listFlavors } from '@/lib/flavors-store';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+test('copy subflavors from historical snapshots', async ({ page, browser }) => {
+  page.on('dialog', (d) => d.accept());
+  const handleOwner = unique('owner');
+  const emailOwner = `${handleOwner}@example.com`;
+  const dateStr = today();
+
+  // sign up owner and create a flavor
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', handleOwner);
+  await page.fill('input[placeholder="Email"]', emailOwner);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+  await page.goto('/flavors');
+  await page.click('button[id^="f7av-add"]');
+  await page.click('button[id^="f7av-add-own"]');
+  await page.fill('input[id^="f7avourn4me-frm"]', 'Past');
+  await page.fill('textarea[id^="f7avourde5cr-frm"]', 'desc');
+  await page.click('button[id^="f7avoursav-frm"]');
+
+  // go to subflavors
+  await page.click('button[id^="f7avsubfbtn"]');
+
+  // create subflavors
+  await page.click('button[id^="s7ubflav-add"]');
+  await page.click('button[id^="s7ubflav-add-own"]');
+  await page.fill('input[id^="s7ubflavourn4me-frm"]', 'PastSub');
+  await page.fill('textarea[id^="s7ubflavourde5cr-frm"]', 'sdesc');
+  await page.click('button[id^="s7ubflavoursav-frm"]');
+  await page.click('button[id^="s7ubflav-add"]');
+  await page.click('button[id^="s7ubflav-add-own"]');
+  await page.fill('input[id^="s7ubflavourn4me-frm"]', 'LiveSub');
+  await page.fill('textarea[id^="s7ubflavourde5cr-frm"]', 'lsdesc');
+  await page.click('button[id^="s7ubflavoursav-frm"]');
+
+  // snapshot and delete past subflavor
+  const owner = await getUserByHandle(handleOwner);
+  await createProfileSnapshot(owner.id, dateStr);
+  const pastRow = page.locator('li:has-text("PastSub")');
+  await pastRow.locator('button:has-text("Delete")').click();
+  await expect(pastRow).toHaveCount(0);
+
+  const ownerFlavors = await listFlavors(String(owner.id));
+  const flavorId = ownerFlavors.find((f) => f.name === 'Past')!.id;
+
+  // copy from own history
+  await page.goto(`/history/self/${dateStr}/flavors/${flavorId}/subflavors`);
+  await page
+    .locator('li:has-text("PastSub") button:has-text("Copy")')
+    .click();
+  await page.selectOption('#copy-dest', flavorId);
+  await page.locator('button:has-text("Copy")').last().click();
+  await page.goto(`/flavors/${flavorId}/subflavors`);
+  await expect(page.locator('li:has-text("PastSub")')).toHaveCount(1);
+
+  // fetch owner's view id
+  await page.goto(`/u/${handleOwner}`);
+  const viewHref = await page.getAttribute('[id^="pr0ovr-view-"]', 'href');
+  const viewId = viewHref?.split('/').pop();
+
+  // viewer signs up and creates a target flavor
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  const handleViewer = unique('viewer');
+  const emailViewer = `${handleViewer}@example.com`;
+  await page2.goto('/signup');
+  await page2.fill('input[placeholder="Name"]', 'Viewer');
+  await page2.fill('input[placeholder="Handle"]', handleViewer);
+  await page2.fill('input[placeholder="Email"]', emailViewer);
+  await page2.fill('input[placeholder="Password"]', PASSWORD);
+  await page2.click('text=Sign Up');
+  await page2.goto('/flavors');
+  await page2.click('button[id^="f7av-add"]');
+  await page2.click('button[id^="f7av-add-own"]');
+  await page2.fill('input[id^="f7avourn4me-frm"]', 'Target');
+  await page2.fill('textarea[id^="f7avourde5cr-frm"]', 'desc');
+  await page2.click('button[id^="f7avoursav-frm"]');
+
+  const viewerUser = await getUserByHandle(handleViewer);
+  const viewerFlavors = await listFlavors(String(viewerUser.id));
+  const targetFlavorId = viewerFlavors.find((f) => f.name === 'Target')!.id;
+
+  await page2.goto(`/history/${viewId}/${dateStr}/flavors/${flavorId}/subflavors?to=${targetFlavorId}`);
+  await page2
+    .locator('li:has-text("PastSub") button:has-text("Copy")')
+    .click();
+  await page2.selectOption('#copy-dest', targetFlavorId);
+  await page2.locator('button:has-text("Copy")').last().click();
+  await page2.goto(`/flavors/${targetFlavorId}/subflavors`);
+  await expect(page2.locator('li:has-text("PastSub")')).toHaveCount(1);
+
+  // copy current subflavor from live view
+  await page2.goto(`/view/${viewId}/flavors/${flavorId}/subflavors?to=${targetFlavorId}`);
+  await page2
+    .locator('li:has-text("LiveSub") button:has-text("Copy")')
+    .click();
+  await page2.selectOption('#copy-dest', targetFlavorId);
+  await page2.locator('button:has-text("Copy")').last().click();
+  await page2.goto(`/flavors/${targetFlavorId}/subflavors`);
+  await expect(page2.locator('li:has-text("LiveSub")')).toHaveCount(1);
+  await ctx2.close();
+});


### PR DESCRIPTION
## Summary
- allow owners and viewers to copy flavors and subflavors from historical snapshots
- redirect unauthenticated dashboard access to sign-in
- test copying flavors and subflavors from history
- prompt for destination flavor when copying subflavors from view or historical pages

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test tests/history-flavors.spec.ts tests/history-subflavors.spec.ts` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c3cf4930832ab062a5c4dbf0c1b5