### PR TITLE
feat: add icon picker for flavors

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -105,3 +105,4 @@
 - 2025-10-17: Enabled copying flavors from historical snapshots for owners and viewers and added tests.
 - 2025-10-17: Enabled copying subflavors from historical snapshots for owners and viewers and added tests.
 - 2025-10-17: Added destination picker when copying subflavors from viewer and historical pages.
+- 2025-10-17: Introduced generic IconPicker with custom uploads, presets, and social options; integrated into flavor and subflavor forms.

--- a/app/(app)/flavors/[flavorId]/subflavors/client.tsx
+++ b/app/(app)/flavors/[flavorId]/subflavors/client.tsx
@@ -5,8 +5,7 @@ import type { Subflavor, Visibility, SubflavorInput } from '@/types/subflavor';
 import { createSubflavor, updateSubflavor, copySubflavor } from './actions';
 import type { PeopleLists, Person } from '@/lib/people-store';
 import { useViewContext } from '@/lib/view-context';
-
-const ICONS = ['⭐', '❤️', '🌞', '🌙', '📚'];
+import IconPicker from '@/components/icon-picker';
 const VISIBILITIES: Visibility[] = [
   'private',
   'friends',
@@ -100,7 +99,7 @@ export default function SubflavorsClient({
     name: '',
     description: '',
     color: '#888888',
-    icon: ICONS[0],
+    icon: '⭐',
     importance: 50,
     targetMix: 50,
     visibility: 'private',
@@ -164,7 +163,7 @@ export default function SubflavorsClient({
       name: '',
       description: '',
       color: '#888888',
-      icon: ICONS[0],
+      icon: '⭐',
       importance: 50,
       targetMix: 50,
       visibility: 'private' as Visibility,
@@ -332,7 +331,16 @@ export default function SubflavorsClient({
                 className="text-white"
                 style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
               >
-                {f.icon}
+                {f.icon.startsWith('data:') ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={f.icon}
+                    alt="icon"
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  f.icon
+                )}
               </span>
             </div>
             <div className="flex min-w-0 flex-1 flex-col gap-1">
@@ -657,18 +665,10 @@ export default function SubflavorsClient({
               </div>
               <div>
                 <label className="block text-sm font-medium">Icon</label>
-                <div className="grid grid-cols-5 gap-2">
-                  {ICONS.map((ic) => (
-                    <button
-                      key={ic}
-                      type="button"
-                      onClick={() => setForm({ ...form, icon: ic })}
-                      className={`flex h-8 w-8 items-center justify-center rounded border ${form.icon === ic ? 'bg-gray-200' : ''}`}
-                    >
-                      {ic}
-                    </button>
-                  ))}
-                </div>
+                <IconPicker
+                  value={form.icon}
+                  onChange={(icon) => setForm({ ...form, icon })}
+                />
               </div>
               <div>
                 <label

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -7,8 +7,7 @@ import { createFlavor, updateFlavor, copyFlavor } from './actions';
 import type { PeopleLists, Person } from '@/lib/people-store';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor } from '@/lib/navigation';
-
-const ICONS = ['⭐', '❤️', '🌞', '🌙', '📚'];
+import IconPicker from '@/components/icon-picker';
 const VISIBILITIES: Visibility[] = [
   'private',
   'friends',
@@ -97,7 +96,7 @@ export default function FlavorsClient({
     name: '',
     description: '',
     color: '#888888',
-    icon: ICONS[0],
+    icon: '⭐',
     importance: 50,
     targetMix: 50,
     visibility: 'private',
@@ -160,7 +159,7 @@ export default function FlavorsClient({
       name: '',
       description: '',
       color: '#888888',
-      icon: ICONS[0],
+      icon: '⭐',
       importance: 50,
       targetMix: 50,
       visibility: 'private' as Visibility,
@@ -330,7 +329,16 @@ export default function FlavorsClient({
                   className="text-white"
                   style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
                 >
-                  {f.icon}
+                  {f.icon.startsWith('data:') ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={f.icon}
+                      alt="icon"
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    f.icon
+                  )}
                 </span>
               </div>
               <button
@@ -673,18 +681,10 @@ export default function FlavorsClient({
               </div>
               <div>
                 <label className="block text-sm font-medium">Icon</label>
-                <div className="grid grid-cols-5 gap-2">
-                  {ICONS.map((ic) => (
-                    <button
-                      key={ic}
-                      type="button"
-                      onClick={() => setForm({ ...form, icon: ic })}
-                      className={`flex h-8 w-8 items-center justify-center rounded border ${form.icon === ic ? 'bg-gray-200' : ''}`}
-                    >
-                      {ic}
-                    </button>
-                  ))}
-                </div>
+                <IconPicker
+                  value={form.icon}
+                  onChange={(icon) => setForm({ ...form, icon })}
+                />
               </div>
               <div>
                 <label

--- a/components/icon-picker.tsx
+++ b/components/icon-picker.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface IconPickerProps {
+  value: string;
+  onChange: (value: string) => void;
+  editable?: boolean;
+}
+
+const PRESET_ICONS = [
+  '⭐',
+  '❤️',
+  '🌞',
+  '🌙',
+  '📚',
+  '🔥',
+  '🎯',
+  '🏃',
+  '💼',
+  '🎵',
+];
+
+const OTHER_USERS = {
+  friends: ['😀', '😎'],
+  following: ['🐱', '🐶'],
+  others: ['🚀', '🍰'],
+};
+
+export default function IconPicker({
+  value,
+  onChange,
+  editable = true,
+}: IconPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<'mine' | 'preset' | 'others'>('mine');
+  const [myIcons, setMyIcons] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('my-icons');
+    if (stored) {
+      try {
+        setMyIcons(JSON.parse(stored));
+      } catch {
+        /* ignore */
+      }
+    }
+  }, []);
+
+  function saveMyIcons(icons: string[]) {
+    setMyIcons(icons);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('my-icons', JSON.stringify(icons));
+    }
+  }
+
+  function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const img = new Image();
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = 64;
+        canvas.height = 64;
+        const ctx = canvas.getContext('2d');
+        if (ctx && typeof ev.target?.result === 'string') {
+          img.src = ev.target.result;
+          ctx.drawImage(img, 0, 0, 64, 64);
+          const data = canvas.toDataURL();
+          saveMyIcons([...myIcons, data]);
+        }
+      };
+      if (typeof ev.target?.result === 'string') {
+        img.src = ev.target.result;
+      }
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function deleteIcon(ic: string) {
+    saveMyIcons(myIcons.filter((i) => i !== ic));
+  }
+
+  if (!editable) {
+    return (
+      <div className="flex items-center gap-2">
+        {value.startsWith('data:') ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={value} alt="icon" className="h-6 w-6" />
+        ) : (
+          <span>{value}</span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        className="flex items-center gap-1 rounded border px-2 py-1 text-sm"
+        onClick={() => setOpen(!open)}
+      >
+        {value && (
+          <span>
+            {value.startsWith('data:') ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={value} alt="icon" className="inline h-4 w-4" />
+            ) : (
+              value
+            )}
+          </span>
+        )}
+        Choose Icon
+      </button>
+      {open && (
+        <div className="mt-2 rounded border p-2">
+          <div className="mb-2 flex gap-2 text-sm">
+            <button
+              type="button"
+              onClick={() => setTab('mine')}
+              className={tab === 'mine' ? 'font-bold' : ''}
+            >
+              My Icons
+            </button>
+            <button
+              type="button"
+              onClick={() => setTab('preset')}
+              className={tab === 'preset' ? 'font-bold' : ''}
+            >
+              Preset Icons
+            </button>
+            <button
+              type="button"
+              onClick={() => setTab('others')}
+              className={tab === 'others' ? 'font-bold' : ''}
+            >
+              Other Icons
+            </button>
+          </div>
+          {tab === 'mine' && (
+            <div>
+              <input type="file" accept="image/*" onChange={handleUpload} />
+              <div className="mt-2 grid grid-cols-5 gap-2">
+                {myIcons.map((ic) => (
+                  <div key={ic} className="relative">
+                    <button
+                      type="button"
+                      onClick={() => onChange(ic)}
+                      className="flex h-8 w-8 items-center justify-center overflow-hidden rounded border"
+                      data-testid="icon-option"
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={ic}
+                        alt="icon"
+                        className="h-full w-full object-cover"
+                      />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => deleteIcon(ic)}
+                      className="absolute -right-1 -top-1 h-4 w-4 rounded-full bg-white text-xs"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {tab === 'preset' && (
+            <div className="grid grid-cols-5 gap-2">
+              {PRESET_ICONS.map((ic) => (
+                <button
+                  key={ic}
+                  type="button"
+                  onClick={() => onChange(ic)}
+                  className="flex h-8 w-8 items-center justify-center rounded border"
+                  data-testid="icon-option"
+                >
+                  {ic}
+                </button>
+              ))}
+            </div>
+          )}
+          {tab === 'others' && (
+            <div className="text-sm">
+              <input
+                type="text"
+                placeholder="Search"
+                className="mb-2 w-full rounded border p-1"
+              />
+              <div className="mb-2">
+                <div className="font-medium">Friends</div>
+                <div className="mt-1 grid grid-cols-5 gap-2">
+                  {OTHER_USERS.friends.map((ic) => (
+                    <button
+                      key={ic}
+                      type="button"
+                      onClick={() => onChange(ic)}
+                      className="flex h-8 w-8 items-center justify-center rounded border"
+                      data-testid="icon-option"
+                    >
+                      {ic}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="mb-2">
+                <div className="font-medium">Following</div>
+                <div className="mt-1 grid grid-cols-5 gap-2">
+                  {OTHER_USERS.following.map((ic) => (
+                    <button
+                      key={ic}
+                      type="button"
+                      onClick={() => onChange(ic)}
+                      className="flex h-8 w-8 items-center justify-center rounded border"
+                      data-testid="icon-option"
+                    >
+                      {ic}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <div className="font-medium">Other</div>
+                <div className="mt-1 grid grid-cols-5 gap-2">
+                  {OTHER_USERS.others.map((ic) => (
+                    <button
+                      key={ic}
+                      type="button"
+                      onClick={() => onChange(ic)}
+                      className="flex h-8 w-8 items-center justify-center rounded border"
+                      data-testid="icon-option"
+                    >
+                      {ic}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tests/flavors.spec.ts
+++ b/tests/flavors.spec.ts
@@ -74,7 +74,8 @@ test('flavor CRUD and ordering', async ({ page }) => {
   await rows.first().click();
   await page.fill('input[id^="f7avourn4me-frm"]', 'First Updated');
   await page.fill('input[name="color"]', '#0000ff');
-  await page.click('button:has-text("❤️")');
+  await page.click('button:has-text("Choose Icon")');
+  await page.click('button[data-testid="icon-option"]:has-text("❤️")');
   await page.click('button[id^="f7avoursav-frm"]');
   await page.reload();
   await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText(


### PR DESCRIPTION
## Summary
- replace flavor and subflavor icon grid with generic IconPicker
- allow uploading custom icons, choosing presets, or selecting from others
- update tests for new icon picker

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ce982360832aad3339c070dbe3fb