### PR TITLE
feat: add reusable icon picker

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -105,3 +105,4 @@
 - 2025-10-17: Enabled copying flavors from historical snapshots for owners and viewers and added tests.
 - 2025-10-17: Enabled copying subflavors from historical snapshots for owners and viewers and added tests.
 - 2025-10-17: Added destination picker when copying subflavors from viewer and historical pages.
+- 2025-10-18: Replaced flavor and subflavor icon grids with reusable icon picker supporting custom and preset icons.

--- a/app/(app)/flavors/[flavorId]/subflavors/client.tsx
+++ b/app/(app)/flavors/[flavorId]/subflavors/client.tsx
@@ -5,8 +5,7 @@ import type { Subflavor, Visibility, SubflavorInput } from '@/types/subflavor';
 import { createSubflavor, updateSubflavor, copySubflavor } from './actions';
 import type { PeopleLists, Person } from '@/lib/people-store';
 import { useViewContext } from '@/lib/view-context';
-
-const ICONS = ['⭐', '❤️', '🌞', '🌙', '📚'];
+import IconPicker from '@/components/icon-picker';
 const VISIBILITIES: Visibility[] = [
   'private',
   'friends',
@@ -100,7 +99,7 @@ export default function SubflavorsClient({
     name: '',
     description: '',
     color: '#888888',
-    icon: ICONS[0],
+    icon: '⭐',
     importance: 50,
     targetMix: 50,
     visibility: 'private',
@@ -164,7 +163,7 @@ export default function SubflavorsClient({
       name: '',
       description: '',
       color: '#888888',
-      icon: ICONS[0],
+      icon: '⭐',
       importance: 50,
       targetMix: 50,
       visibility: 'private' as Visibility,
@@ -657,18 +656,11 @@ export default function SubflavorsClient({
               </div>
               <div>
                 <label className="block text-sm font-medium">Icon</label>
-                <div className="grid grid-cols-5 gap-2">
-                  {ICONS.map((ic) => (
-                    <button
-                      key={ic}
-                      type="button"
-                      onClick={() => setForm({ ...form, icon: ic })}
-                      className={`flex h-8 w-8 items-center justify-center rounded border ${form.icon === ic ? 'bg-gray-200' : ''}`}
-                    >
-                      {ic}
-                    </button>
-                  ))}
-                </div>
+                <IconPicker
+                  id={`s7ubflavouricon-frm-${userId}`}
+                  value={form.icon}
+                  onChange={(icon) => setForm({ ...form, icon })}
+                />
               </div>
               <div>
                 <label

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -7,8 +7,7 @@ import { createFlavor, updateFlavor, copyFlavor } from './actions';
 import type { PeopleLists, Person } from '@/lib/people-store';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor } from '@/lib/navigation';
-
-const ICONS = ['⭐', '❤️', '🌞', '🌙', '📚'];
+import IconPicker from '@/components/icon-picker';
 const VISIBILITIES: Visibility[] = [
   'private',
   'friends',
@@ -97,7 +96,7 @@ export default function FlavorsClient({
     name: '',
     description: '',
     color: '#888888',
-    icon: ICONS[0],
+    icon: '⭐',
     importance: 50,
     targetMix: 50,
     visibility: 'private',
@@ -160,7 +159,7 @@ export default function FlavorsClient({
       name: '',
       description: '',
       color: '#888888',
-      icon: ICONS[0],
+      icon: '⭐',
       importance: 50,
       targetMix: 50,
       visibility: 'private' as Visibility,
@@ -673,18 +672,11 @@ export default function FlavorsClient({
               </div>
               <div>
                 <label className="block text-sm font-medium">Icon</label>
-                <div className="grid grid-cols-5 gap-2">
-                  {ICONS.map((ic) => (
-                    <button
-                      key={ic}
-                      type="button"
-                      onClick={() => setForm({ ...form, icon: ic })}
-                      className={`flex h-8 w-8 items-center justify-center rounded border ${form.icon === ic ? 'bg-gray-200' : ''}`}
-                    >
-                      {ic}
-                    </button>
-                  ))}
-                </div>
+                <IconPicker
+                  id={`f7avouricon-frm-${userId}`}
+                  value={form.icon}
+                  onChange={(icon) => setForm({ ...form, icon })}
+                />
               </div>
               <div>
                 <label

--- a/components/icon-picker.tsx
+++ b/components/icon-picker.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+const PRESET_ICONS = [
+  '⭐',
+  '❤️',
+  '🌞',
+  '🌙',
+  '📚',
+  '🔥',
+  '⚡',
+  '🍀',
+  '🎵',
+  '😊',
+];
+
+export default function IconPicker({
+  value,
+  onChange,
+  id,
+}: {
+  value: string;
+  onChange: (icon: string) => void;
+  id: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<'own' | 'preset' | 'other'>('preset');
+  const [ownIcons, setOwnIcons] = useState<string[]>([]);
+  const [newIcon, setNewIcon] = useState('');
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem('user-icons');
+      if (stored) setOwnIcons(JSON.parse(stored));
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const saveOwnIcons = (icons: string[]) => {
+    setOwnIcons(icons);
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem('user-icons', JSON.stringify(icons));
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  const handleAdd = () => {
+    if (!newIcon) return;
+    if (!ownIcons.includes(newIcon)) {
+      const updated = [...ownIcons, newIcon];
+      saveOwnIcons(updated);
+    }
+    setNewIcon('');
+  };
+
+  const handleUse = (icon: string) => {
+    onChange(icon);
+    setOpen(false);
+  };
+
+  const handleDelete = (icon: string) => {
+    const updated = ownIcons.filter((ic) => ic !== icon);
+    saveOwnIcons(updated);
+  };
+
+  return (
+    <div className="space-y-2">
+      <button
+        id={id}
+        type="button"
+        className="rounded border px-2 py-1"
+        onClick={() => setOpen(true)}
+      >
+        {value ? `Icon: ${value}` : 'Choose icon'}
+      </button>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="max-h-[80vh] w-80 overflow-auto rounded bg-white p-4 shadow">
+            <div className="mb-2 flex gap-2 text-sm">
+              <button
+                type="button"
+                className={tab === 'own' ? 'font-bold' : ''}
+                onClick={() => setTab('own')}
+              >
+                Your icons
+              </button>
+              <button
+                type="button"
+                className={tab === 'preset' ? 'font-bold' : ''}
+                onClick={() => setTab('preset')}
+              >
+                Preset icons
+              </button>
+              <button
+                type="button"
+                className={tab === 'other' ? 'font-bold' : ''}
+                onClick={() => setTab('other')}
+              >
+                Other icons
+              </button>
+            </div>
+            {tab === 'own' && (
+              <div className="space-y-2">
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={newIcon}
+                    onChange={(e) => setNewIcon(e.target.value)}
+                    placeholder="Emoji"
+                    className="w-full rounded border px-2 py-1"
+                  />
+                  <button
+                    type="button"
+                    className="rounded border px-2"
+                    onClick={handleAdd}
+                  >
+                    Add
+                  </button>
+                </div>
+                <div className="grid grid-cols-5 gap-2">
+                  {ownIcons.map((ic) => (
+                    <div key={ic} className="flex flex-col items-center">
+                      <button
+                        type="button"
+                        className="flex h-8 w-8 items-center justify-center rounded border"
+                        onClick={() => handleUse(ic)}
+                      >
+                        {ic}
+                      </button>
+                      <button
+                        type="button"
+                        className="text-xs text-red-500"
+                        onClick={() => handleDelete(ic)}
+                      >
+                        delete
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {tab === 'preset' && (
+              <div className="grid grid-cols-5 gap-2">
+                {PRESET_ICONS.map((ic) => (
+                  <button
+                    key={ic}
+                    type="button"
+                    className="flex h-8 w-8 items-center justify-center rounded border"
+                    onClick={() => handleUse(ic)}
+                  >
+                    {ic}
+                  </button>
+                ))}
+              </div>
+            )}
+            {tab === 'other' && (
+              <p className="text-sm text-gray-500">
+                Search other users coming soon.
+              </p>
+            )}
+            <div className="mt-4 text-right">
+              <button
+                type="button"
+                className="rounded border px-2 py-1"
+                onClick={() => setOpen(false)}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tests/flavors.spec.ts
+++ b/tests/flavors.spec.ts
@@ -26,6 +26,7 @@ test('flavor CRUD and ordering', async ({ page }) => {
   await page.fill('input[id^="f7avourn4me-frm"]', 'First');
   await page.fill('textarea[id^="f7avourde5cr-frm"]', 'desc1');
   await page.fill('input[name="color"]', '#ff0000');
+  await page.click('button[id^="f7avouricon-frm"]');
   await page.click('button:has-text("⭐")');
   await page.fill('input[id^="f7avour1mp-frm"]', '60');
   await page.fill('input[id^="f7avourt4rg-frm"]', '20');
@@ -38,6 +39,7 @@ test('flavor CRUD and ordering', async ({ page }) => {
   await page.fill('input[id^="f7avourn4me-frm"]', 'Second');
   await page.fill('textarea[id^="f7avourde5cr-frm"]', 'desc2');
   await page.fill('input[name="color"]', '#00ff00');
+  await page.click('button[id^="f7avouricon-frm"]');
   await page.click('button:has-text("📚")');
   await page.fill('input[id^="f7avour1mp-frm"]', '80');
   await page.fill('input[id^="f7avourt4rg-frm"]', '30');
@@ -74,6 +76,7 @@ test('flavor CRUD and ordering', async ({ page }) => {
   await rows.first().click();
   await page.fill('input[id^="f7avourn4me-frm"]', 'First Updated');
   await page.fill('input[name="color"]', '#0000ff');
+  await page.click('button[id^="f7avouricon-frm"]');
   await page.click('button:has-text("❤️")');
   await page.click('button[id^="f7avoursav-frm"]');
   await page.reload();


### PR DESCRIPTION
## Summary
- replace flavor and subflavor icon grids with a reusable icon picker component
- allow users to store their own emoji icons in local storage alongside new preset options
- update tests and changelog for icon picker

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ce982360832aad3339c070dbe3fb