### PR TITLE
feat: add icon picker for flavors

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -105,3 +105,7 @@
 - 2025-10-17: Enabled copying flavors from historical snapshots for owners and viewers and added tests.
 - 2025-10-17: Enabled copying subflavors from historical snapshots for owners and viewers and added tests.
 - 2025-10-17: Added destination picker when copying subflavors from viewer and historical pages.
+- 2025-10-17: Introduced generic IconPicker with custom uploads, presets, and social options; integrated into flavor and subflavor forms.
+- 2025-10-17: Enlarged IconPicker modal and fixed rendering of uploaded icons.
+- 2025-10-17: Enhanced uploaded icon quality and ensured icons fill circular frames edge-to-edge.
+- 2025-10-17: Widened flavor and subflavor icon columns to text so custom images migrate without length errors.

--- a/app/(app)/flavors/[flavorId]/subflavors/client.tsx
+++ b/app/(app)/flavors/[flavorId]/subflavors/client.tsx
@@ -5,8 +5,7 @@ import type { Subflavor, Visibility, SubflavorInput } from '@/types/subflavor';
 import { createSubflavor, updateSubflavor, copySubflavor } from './actions';
 import type { PeopleLists, Person } from '@/lib/people-store';
 import { useViewContext } from '@/lib/view-context';
-
-const ICONS = ['⭐', '❤️', '🌞', '🌙', '📚'];
+import IconPicker from '@/components/icon-picker';
 const VISIBILITIES: Visibility[] = [
   'private',
   'friends',
@@ -48,6 +47,12 @@ const PRESET_SUBFLAVORS: SubflavorInput[] = [
     slug: '',
   },
 ];
+
+function iconSrc(ic: string) {
+  if (ic.startsWith('data:')) return ic;
+  if (/^[A-Za-z0-9+/=]+$/.test(ic)) return `data:image/png;base64,${ic}`;
+  return null;
+}
 
 function sortSubflavors(list: Subflavor[]) {
   return [...list].sort((a, b) => {
@@ -100,7 +105,7 @@ export default function SubflavorsClient({
     name: '',
     description: '',
     color: '#888888',
-    icon: ICONS[0],
+    icon: '⭐',
     importance: 50,
     targetMix: 50,
     visibility: 'private',
@@ -164,7 +169,7 @@ export default function SubflavorsClient({
       name: '',
       description: '',
       color: '#888888',
-      icon: ICONS[0],
+      icon: '⭐',
       importance: 50,
       targetMix: 50,
       visibility: 'private' as Visibility,
@@ -326,14 +331,23 @@ export default function SubflavorsClient({
                   height: 'var(--diam)',
                 } as React.CSSProperties
               }
-              className="flex items-center justify-center rounded-full shadow-inner"
+              className="flex items-center justify-center overflow-hidden rounded-full shadow-inner"
             >
-              <span
-                className="text-white"
-                style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
-              >
-                {f.icon}
-              </span>
+              {iconSrc(f.icon) ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={iconSrc(f.icon) as string}
+                  alt="icon"
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <span
+                  className="text-white"
+                  style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
+                >
+                  {f.icon}
+                </span>
+              )}
             </div>
             <div className="flex min-w-0 flex-1 flex-col gap-1">
               <div
@@ -573,14 +587,23 @@ export default function SubflavorsClient({
                     height: 'var(--diam)',
                   } as React.CSSProperties
                 }
-                className="flex items-center justify-center rounded-full shadow-inner"
+                className="flex items-center justify-center overflow-hidden rounded-full shadow-inner"
               >
-                <span
-                  className="text-white"
-                  style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
-                >
-                  {form.icon}
-                </span>
+                {iconSrc(form.icon) ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={iconSrc(form.icon) as string}
+                    alt="icon"
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <span
+                    className="text-white"
+                    style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
+                  >
+                    {form.icon}
+                  </span>
+                )}
               </div>
             </div>
             <form
@@ -657,18 +680,10 @@ export default function SubflavorsClient({
               </div>
               <div>
                 <label className="block text-sm font-medium">Icon</label>
-                <div className="grid grid-cols-5 gap-2">
-                  {ICONS.map((ic) => (
-                    <button
-                      key={ic}
-                      type="button"
-                      onClick={() => setForm({ ...form, icon: ic })}
-                      className={`flex h-8 w-8 items-center justify-center rounded border ${form.icon === ic ? 'bg-gray-200' : ''}`}
-                    >
-                      {ic}
-                    </button>
-                  ))}
-                </div>
+                <IconPicker
+                  value={form.icon}
+                  onChange={(icon) => setForm({ ...form, icon })}
+                />
               </div>
               <div>
                 <label

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -7,8 +7,7 @@ import { createFlavor, updateFlavor, copyFlavor } from './actions';
 import type { PeopleLists, Person } from '@/lib/people-store';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor } from '@/lib/navigation';
-
-const ICONS = ['⭐', '❤️', '🌞', '🌙', '📚'];
+import IconPicker from '@/components/icon-picker';
 const VISIBILITIES: Visibility[] = [
   'private',
   'friends',
@@ -48,6 +47,12 @@ const PRESET_FLAVORS: FlavorInput[] = [
     slug: '',
   },
 ];
+
+function iconSrc(ic: string) {
+  if (ic.startsWith('data:')) return ic;
+  if (/^[A-Za-z0-9+/=]+$/.test(ic)) return `data:image/png;base64,${ic}`;
+  return null;
+}
 
 function sortFlavors(list: Flavor[]) {
   return [...list].sort((a, b) => {
@@ -97,7 +102,7 @@ export default function FlavorsClient({
     name: '',
     description: '',
     color: '#888888',
-    icon: ICONS[0],
+    icon: '⭐',
     importance: 50,
     targetMix: 50,
     visibility: 'private',
@@ -160,7 +165,7 @@ export default function FlavorsClient({
       name: '',
       description: '',
       color: '#888888',
-      icon: ICONS[0],
+      icon: '⭐',
       importance: 50,
       targetMix: 50,
       visibility: 'private' as Visibility,
@@ -324,14 +329,23 @@ export default function FlavorsClient({
                     height: 'var(--diam)',
                   } as React.CSSProperties
                 }
-                className="flex items-center justify-center rounded-full shadow-inner"
+                className="flex items-center justify-center overflow-hidden rounded-full shadow-inner"
               >
-                <span
-                  className="text-white"
-                  style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
-                >
-                  {f.icon}
-                </span>
+                {iconSrc(f.icon) ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={iconSrc(f.icon) as string}
+                    alt="icon"
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <span
+                    className="text-white"
+                    style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
+                  >
+                    {f.icon}
+                  </span>
+                )}
               </div>
               <button
                 id={`f7avsubfbtn${f.id}-${userId}`}
@@ -589,14 +603,23 @@ export default function FlavorsClient({
                     height: 'var(--diam)',
                   } as React.CSSProperties
                 }
-                className="flex items-center justify-center rounded-full shadow-inner"
+                className="flex items-center justify-center overflow-hidden rounded-full shadow-inner"
               >
-                <span
-                  className="text-white"
-                  style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
-                >
-                  {form.icon}
-                </span>
+                {iconSrc(form.icon) ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={iconSrc(form.icon) as string}
+                    alt="icon"
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <span
+                    className="text-white"
+                    style={{ fontSize: 'min(44px, calc(var(--diam)*0.48))' }}
+                  >
+                    {form.icon}
+                  </span>
+                )}
               </div>
             </div>
             <form
@@ -673,18 +696,10 @@ export default function FlavorsClient({
               </div>
               <div>
                 <label className="block text-sm font-medium">Icon</label>
-                <div className="grid grid-cols-5 gap-2">
-                  {ICONS.map((ic) => (
-                    <button
-                      key={ic}
-                      type="button"
-                      onClick={() => setForm({ ...form, icon: ic })}
-                      className={`flex h-8 w-8 items-center justify-center rounded border ${form.icon === ic ? 'bg-gray-200' : ''}`}
-                    >
-                      {ic}
-                    </button>
-                  ))}
-                </div>
+                <IconPicker
+                  value={form.icon}
+                  onChange={(icon) => setForm({ ...form, icon })}
+                />
               </div>
               <div>
                 <label

--- a/components/icon-picker.tsx
+++ b/components/icon-picker.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface IconPickerProps {
+  value: string;
+  onChange: (value: string) => void;
+  editable?: boolean;
+}
+
+const PRESET_ICONS = [
+  '⭐',
+  '❤️',
+  '🌞',
+  '🌙',
+  '📚',
+  '🔥',
+  '🎯',
+  '🏃',
+  '💼',
+  '🎵',
+];
+
+const OTHER_USERS = {
+  friends: ['😀', '😎'],
+  following: ['🐱', '🐶'],
+  others: ['🚀', '🍰'],
+};
+
+export default function IconPicker({
+  value,
+  onChange,
+  editable = true,
+}: IconPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<'mine' | 'preset' | 'others'>('mine');
+  const [myIcons, setMyIcons] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('my-icons');
+    if (stored) {
+      try {
+        setMyIcons(JSON.parse(stored));
+      } catch {
+        /* ignore */
+      }
+    }
+  }, []);
+
+  function saveMyIcons(icons: string[]) {
+    setMyIcons(icons);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('my-icons', JSON.stringify(icons));
+    }
+  }
+
+  function resolveSrc(ic: string) {
+    if (ic.startsWith('data:')) return ic;
+    if (/^[A-Za-z0-9+/=]+$/.test(ic)) {
+      return `data:image/png;base64,${ic}`;
+    }
+    return '';
+  }
+
+  function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      if (typeof ev.target?.result !== 'string') return;
+      const img = new Image();
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        const size = 256;
+        canvas.width = size;
+        canvas.height = size;
+        const ctx = canvas.getContext('2d');
+        if (ctx) {
+          ctx.imageSmoothingQuality = 'high';
+          ctx.drawImage(img, 0, 0, size, size);
+          const data = canvas.toDataURL('image/png');
+          saveMyIcons([...myIcons, data]);
+        }
+      };
+      img.src = ev.target.result;
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function deleteIcon(ic: string) {
+    saveMyIcons(myIcons.filter((i) => i !== ic));
+  }
+
+  if (!editable) {
+    return (
+      <div className="flex items-center gap-2">
+        {resolveSrc(value) ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={resolveSrc(value)} alt="icon" className="h-6 w-6" />
+        ) : (
+          <span>{value}</span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        className="flex items-center gap-1 rounded border px-2 py-1 text-sm"
+        onClick={() => setOpen(!open)}
+      >
+        {value && (
+          <span>
+            {resolveSrc(value) ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={resolveSrc(value)}
+                alt="icon"
+                className="inline h-4 w-4"
+              />
+            ) : (
+              value
+            )}
+          </span>
+        )}
+        Choose Icon
+      </button>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="max-h-[80vh] w-[90vw] max-w-[700px] overflow-y-auto rounded bg-white p-4">
+          <div className="mb-2 flex gap-2 text-sm">
+            <button
+              type="button"
+              onClick={() => setTab('mine')}
+              className={tab === 'mine' ? 'font-bold' : ''}
+            >
+              My Icons
+            </button>
+            <button
+              type="button"
+              onClick={() => setTab('preset')}
+              className={tab === 'preset' ? 'font-bold' : ''}
+            >
+              Preset Icons
+            </button>
+            <button
+              type="button"
+              onClick={() => setTab('others')}
+              className={tab === 'others' ? 'font-bold' : ''}
+            >
+              Other Icons
+            </button>
+          </div>
+          {tab === 'mine' && (
+            <div>
+              <input type="file" accept="image/*" onChange={handleUpload} />
+              <div className="mt-2 grid grid-cols-8 gap-2 md:grid-cols-10">
+                {myIcons.map((ic) => (
+                  <div key={ic} className="relative">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onChange(ic);
+                        setOpen(false);
+                      }}
+                      className="flex h-10 w-10 items-center justify-center overflow-hidden rounded border"
+                      data-testid="icon-option"
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={resolveSrc(ic)}
+                        alt="icon"
+                        className="h-full w-full object-cover"
+                      />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => deleteIcon(ic)}
+                      className="absolute -right-1 -top-1 h-4 w-4 rounded-full bg-white text-xs"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {tab === 'preset' && (
+            <div className="grid grid-cols-8 gap-2 md:grid-cols-10">
+              {PRESET_ICONS.map((ic) => (
+                <button
+                  key={ic}
+                  type="button"
+                  onClick={() => {
+                    onChange(ic);
+                    setOpen(false);
+                  }}
+                  className="flex h-10 w-10 items-center justify-center rounded border"
+                  data-testid="icon-option"
+                >
+                  {ic}
+                </button>
+              ))}
+            </div>
+          )}
+          {tab === 'others' && (
+            <div className="text-sm">
+              <input
+                type="text"
+                placeholder="Search"
+                className="mb-2 w-full rounded border p-1"
+              />
+              <div className="mb-2">
+                <div className="font-medium">Friends</div>
+                <div className="mt-1 grid grid-cols-8 gap-2 md:grid-cols-10">
+                  {OTHER_USERS.friends.map((ic) => (
+                    <button
+                      key={ic}
+                      type="button"
+                      onClick={() => {
+                        onChange(ic);
+                        setOpen(false);
+                      }}
+                      className="flex h-10 w-10 items-center justify-center rounded border"
+                      data-testid="icon-option"
+                    >
+                      {ic}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="mb-2">
+                <div className="font-medium">Following</div>
+                <div className="mt-1 grid grid-cols-8 gap-2 md:grid-cols-10">
+                  {OTHER_USERS.following.map((ic) => (
+                    <button
+                      key={ic}
+                      type="button"
+                      onClick={() => {
+                        onChange(ic);
+                        setOpen(false);
+                      }}
+                      className="flex h-10 w-10 items-center justify-center rounded border"
+                      data-testid="icon-option"
+                    >
+                      {ic}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <div className="font-medium">Other</div>
+                <div className="mt-1 grid grid-cols-8 gap-2 md:grid-cols-10">
+                  {OTHER_USERS.others.map((ic) => (
+                    <button
+                      key={ic}
+                      type="button"
+                      onClick={() => {
+                        onChange(ic);
+                        setOpen(false);
+                      }}
+                      className="flex h-10 w-10 items-center justify-center rounded border"
+                      data-testid="icon-option"
+                    >
+                      {ic}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/drizzle/0009_expand_icon_columns.sql
+++ b/drizzle/0009_expand_icon_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "flavors" ALTER COLUMN "icon" TYPE text;
+ALTER TABLE "subflavors" ALTER COLUMN "icon" TYPE text;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -52,7 +52,8 @@ export const flavors = pgTable('flavors', {
   name: varchar('name', { length: 40 }),
   description: text('description'),
   color: varchar('color', { length: 10 }),
-  icon: varchar('icon', { length: 10 }),
+  // Use text for icons to allow storage of data URLs or longer icon identifiers
+  icon: text('icon'),
   importance: integer('importance'),
   targetMix: integer('target_mix'),
   visibility: varchar('visibility', { length: 20 }),
@@ -69,7 +70,8 @@ export const subflavors = pgTable('subflavors', {
   name: varchar('name', { length: 40 }),
   description: text('description'),
   color: varchar('color', { length: 10 }),
-  icon: varchar('icon', { length: 10 }),
+  // Allow longer icon values for custom uploads
+  icon: text('icon'),
   importance: integer('importance'),
   targetMix: integer('target_mix'),
   visibility: varchar('visibility', { length: 20 }),

--- a/tests/flavors.spec.ts
+++ b/tests/flavors.spec.ts
@@ -74,7 +74,8 @@ test('flavor CRUD and ordering', async ({ page }) => {
   await rows.first().click();
   await page.fill('input[id^="f7avourn4me-frm"]', 'First Updated');
   await page.fill('input[name="color"]', '#0000ff');
-  await page.click('button:has-text("❤️")');
+  await page.click('button:has-text("Choose Icon")');
+  await page.click('button[data-testid="icon-option"]:has-text("❤️")');
   await page.click('button[id^="f7avoursav-frm"]');
   await page.reload();
   await expect(rows.first().locator('div[id^="f7avourn4me"]')).toHaveText(


### PR DESCRIPTION
## Summary
- replace flavor and subflavor icon grid with generic IconPicker
- allow uploading custom icons, choosing presets, or selecting from others
- update tests for new icon picker
- enlarge icon picker modal and normalize uploaded icon data to render images
- sharpen custom icon uploads and clip icons to fill circular frames
- widen flavor and subflavor icon columns to text to store custom images

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ce982360832aad3339c070dbe3fb