### PR TITLE
feat: add other people icon import

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -109,3 +109,6 @@
 - 2025-10-17: Enlarged IconPicker modal and fixed rendering of uploaded icons.
 - 2025-10-17: Enhanced uploaded icon quality and ensured icons fill circular frames edge-to-edge.
 - 2025-10-17: Widened flavor and subflavor icon columns to text so custom images migrate without length errors.
+- 2025-10-17: Added Other People Icons tab with user search and icon import into My Icons.
+- 2025-10-17: Fixed empty icon src errors, awaited user icon route params, and expanded Other People Icons view for larger user lists.
+- 2025-10-17: Synced My Icons with server storage and API so other profiles display their saved icons for import.

--- a/app/(app)/flavors/[flavorId]/subflavors/client.tsx
+++ b/app/(app)/flavors/[flavorId]/subflavors/client.tsx
@@ -683,6 +683,7 @@ export default function SubflavorsClient({
                 <IconPicker
                   value={form.icon}
                   onChange={(icon) => setForm({ ...form, icon })}
+                  people={people}
                 />
               </div>
               <div>

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -699,6 +699,7 @@ export default function FlavorsClient({
                 <IconPicker
                   value={form.icon}
                   onChange={(icon) => setForm({ ...form, icon })}
+                  people={people}
                 />
               </div>
               <div>

--- a/app/api/my/icons/route.ts
+++ b/app/api/my/icons/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { listUserIcons, setUserIcons } from '@/lib/icons-store';
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const icons = await listUserIcons(Number(session.user.id));
+  return NextResponse.json({ icons });
+}
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const data = await req.json();
+    const icons = Array.isArray(data.icons)
+      ? data.icons.filter((i: unknown) => typeof i === 'string')
+      : [];
+    await setUserIcons(Number(session.user.id), icons);
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+}

--- a/app/api/users/[id]/icons/route.ts
+++ b/app/api/users/[id]/icons/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { listUserIcons } from '@/lib/icons-store';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { id } = await params;
+  const userId = Number(id);
+  if (!userId) {
+    return NextResponse.json({ error: 'Invalid user' }, { status: 400 });
+  }
+  const icons = await listUserIcons(userId);
+  return NextResponse.json({ icons });
+}

--- a/components/icon-picker.tsx
+++ b/components/icon-picker.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import type { PeopleLists, Person } from '@/lib/people-store';
 
 interface IconPickerProps {
   value: string;
   onChange: (value: string) => void;
   editable?: boolean;
+  people?: PeopleLists;
 }
 
 const PRESET_ICONS = [
@@ -21,37 +23,58 @@ const PRESET_ICONS = [
   '🎵',
 ];
 
-const OTHER_USERS = {
-  friends: ['😀', '😎'],
-  following: ['🐱', '🐶'],
-  others: ['🚀', '🍰'],
-};
-
 export default function IconPicker({
   value,
   onChange,
   editable = true,
+  people,
 }: IconPickerProps) {
   const [open, setOpen] = useState(false);
-  const [tab, setTab] = useState<'mine' | 'preset' | 'others'>('mine');
+  const [tab, setTab] = useState<'mine' | 'preset' | 'people'>('mine');
   const [myIcons, setMyIcons] = useState<string[]>([]);
+  const [peopleSearch, setPeopleSearch] = useState('');
+  const [selectedUser, setSelectedUser] = useState<Person | null>(null);
+  const [userIcons, setUserIcons] = useState<string[] | null>(null);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const stored = localStorage.getItem('my-icons');
-    if (stored) {
+    (async () => {
+      let stored: string[] = [];
+      const local = localStorage.getItem('my-icons');
+      if (local) {
+        try {
+          stored = JSON.parse(local);
+        } catch {
+          stored = [];
+        }
+      }
       try {
-        setMyIcons(JSON.parse(stored));
+        const res = await fetch('/api/my/icons');
+        if (res.ok) {
+          const data = await res.json();
+          if (Array.isArray(data.icons)) {
+            stored = data.icons;
+            localStorage.setItem('my-icons', JSON.stringify(stored));
+          }
+        }
       } catch {
         /* ignore */
       }
-    }
+      setMyIcons(stored);
+    })();
   }, []);
 
   function saveMyIcons(icons: string[]) {
     setMyIcons(icons);
     if (typeof window !== 'undefined') {
       localStorage.setItem('my-icons', JSON.stringify(icons));
+      fetch('/api/my/icons', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ icons }),
+      }).catch(() => {
+        /* ignore */
+      });
     }
   }
 
@@ -92,6 +115,38 @@ export default function IconPicker({
     saveMyIcons(myIcons.filter((i) => i !== ic));
   }
 
+  function filterPeople(list: Person[] | undefined) {
+    if (!list) return [];
+    const q = peopleSearch.toLowerCase();
+    return list.filter(
+      (p) =>
+        p.handle.toLowerCase().includes(q) ||
+        (p.displayName ? p.displayName.toLowerCase().includes(q) : false),
+    );
+  }
+
+  async function openUser(u: Person) {
+    setSelectedUser(u);
+    setUserIcons(null);
+    try {
+      const res = await fetch(`/api/users/${u.id}/icons`);
+      if (res.ok) {
+        const data = await res.json();
+        setUserIcons(Array.isArray(data.icons) ? data.icons : []);
+      } else {
+        setUserIcons([]);
+      }
+    } catch {
+      setUserIcons([]);
+    }
+  }
+
+  const categories = [
+    { label: 'Friends', list: filterPeople(people?.friends) },
+    { label: 'Following', list: filterPeople(people?.following) },
+    { label: 'Others', list: filterPeople(people?.others) },
+  ];
+
   if (!editable) {
     return (
       <div className="flex items-center gap-2">
@@ -130,7 +185,7 @@ export default function IconPicker({
       </button>
       {open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="max-h-[80vh] w-[90vw] max-w-[700px] overflow-y-auto rounded bg-white p-4">
+          <div className="flex h-[90vh] w-[90vw] max-w-3xl flex-col overflow-hidden rounded bg-white p-4">
           <div className="mb-2 flex gap-2 text-sm">
             <button
               type="button"
@@ -148,43 +203,55 @@ export default function IconPicker({
             </button>
             <button
               type="button"
-              onClick={() => setTab('others')}
-              className={tab === 'others' ? 'font-bold' : ''}
+              onClick={() => {
+                setTab('people');
+                setSelectedUser(null);
+              }}
+              className={tab === 'people' ? 'font-bold' : ''}
             >
-              Other Icons
+              Other People Icons
             </button>
           </div>
           {tab === 'mine' && (
-            <div>
+            <div className="flex h-full flex-col overflow-hidden">
               <input type="file" accept="image/*" onChange={handleUpload} />
-              <div className="mt-2 grid grid-cols-8 gap-2 md:grid-cols-10">
-                {myIcons.map((ic) => (
-                  <div key={ic} className="relative">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        onChange(ic);
-                        setOpen(false);
-                      }}
-                      className="flex h-10 w-10 items-center justify-center overflow-hidden rounded border"
-                      data-testid="icon-option"
-                    >
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={resolveSrc(ic)}
-                        alt="icon"
-                        className="h-full w-full object-cover"
-                      />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => deleteIcon(ic)}
-                      className="absolute -right-1 -top-1 h-4 w-4 rounded-full bg-white text-xs"
-                    >
-                      ×
-                    </button>
-                  </div>
-                ))}
+              <div className="mt-2 flex-1 overflow-y-auto">
+                <div className="grid grid-cols-8 gap-2 md:grid-cols-10">
+                  {myIcons.map((ic) => {
+                    const src = resolveSrc(ic);
+                    return (
+                      <div key={ic} className="relative">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            onChange(ic);
+                            setOpen(false);
+                          }}
+                          className="flex h-10 w-10 items-center justify-center overflow-hidden rounded border"
+                          data-testid="icon-option"
+                        >
+                          {src ? (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                              src={src}
+                              alt="icon"
+                              className="h-full w-full object-cover"
+                            />
+                          ) : (
+                            <span className="text-lg">{ic}</span>
+                          )}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => deleteIcon(ic)}
+                          className="absolute -right-1 -top-1 h-4 w-4 rounded-full bg-white text-xs"
+                        >
+                          ×
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
             </div>
           )}
@@ -206,70 +273,86 @@ export default function IconPicker({
               ))}
             </div>
           )}
-          {tab === 'others' && (
-            <div className="text-sm">
-              <input
-                type="text"
-                placeholder="Search"
-                className="mb-2 w-full rounded border p-1"
-              />
-              <div className="mb-2">
-                <div className="font-medium">Friends</div>
-                <div className="mt-1 grid grid-cols-8 gap-2 md:grid-cols-10">
-                  {OTHER_USERS.friends.map((ic) => (
-                    <button
-                      key={ic}
-                      type="button"
-                      onClick={() => {
-                        onChange(ic);
-                        setOpen(false);
-                      }}
-                      className="flex h-10 w-10 items-center justify-center rounded border"
-                      data-testid="icon-option"
-                    >
-                      {ic}
-                    </button>
-                  ))}
+          {tab === 'people' && (
+            <div className="flex h-full flex-col text-sm">
+              {!selectedUser ? (
+                <>
+                  <input
+                    type="text"
+                    placeholder="Search users"
+                    value={peopleSearch}
+                    onChange={(e) => setPeopleSearch(e.target.value)}
+                    className="mb-2 w-full rounded border p-1"
+                  />
+                  <div className="flex-1 overflow-y-auto pr-1">
+                    {categories.map((c) => (
+                      <div key={c.label} className="mb-4">
+                        {c.list.length > 0 && (
+                          <>
+                            <div className="font-medium">{c.label}</div>
+                            <div className="mt-1 grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+                              {c.list.map((p) => (
+                                <button
+                                  key={p.id}
+                                  type="button"
+                                  onClick={() => openUser(p)}
+                                  className="truncate rounded border px-2 py-1 text-left"
+                                >
+                                  {p.displayName || p.handle}
+                                </button>
+                              ))}
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <div className="flex h-full flex-col">
+                  <button
+                    type="button"
+                    onClick={() => setSelectedUser(null)}
+                    className="mb-2 underline"
+                  >
+                    Back to users
+                  </button>
+                  {userIcons === null && <div>Loading…</div>}
+                  {userIcons !== null && (
+                    <div className="flex-1 overflow-y-auto">
+                      <div className="grid grid-cols-8 gap-2 md:grid-cols-10">
+                        {userIcons.map((ic) => (
+                          <button
+                            key={ic}
+                            type="button"
+                            onClick={() => {
+                              if (!myIcons.includes(ic)) {
+                                saveMyIcons([...myIcons, ic]);
+                              }
+                              onChange(ic);
+                              setOpen(false);
+                              setSelectedUser(null);
+                            }}
+                            className="flex h-10 w-10 items-center justify-center rounded border"
+                            data-testid="icon-option"
+                          >
+                            {resolveSrc(ic) ? (
+                              // eslint-disable-next-line @next/next/no-img-element
+                              <img
+                                src={resolveSrc(ic)}
+                                alt="icon"
+                                className="h-full w-full object-cover"
+                              />
+                            ) : (
+                              ic
+                            )}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </div>
-              </div>
-              <div className="mb-2">
-                <div className="font-medium">Following</div>
-                <div className="mt-1 grid grid-cols-8 gap-2 md:grid-cols-10">
-                  {OTHER_USERS.following.map((ic) => (
-                    <button
-                      key={ic}
-                      type="button"
-                      onClick={() => {
-                        onChange(ic);
-                        setOpen(false);
-                      }}
-                      className="flex h-10 w-10 items-center justify-center rounded border"
-                      data-testid="icon-option"
-                    >
-                      {ic}
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div>
-                <div className="font-medium">Other</div>
-                <div className="mt-1 grid grid-cols-8 gap-2 md:grid-cols-10">
-                  {OTHER_USERS.others.map((ic) => (
-                    <button
-                      key={ic}
-                      type="button"
-                      onClick={() => {
-                        onChange(ic);
-                        setOpen(false);
-                      }}
-                      className="flex h-10 w-10 items-center justify-center rounded border"
-                      data-testid="icon-option"
-                    >
-                      {ic}
-                    </button>
-                  ))}
-                </div>
-              </div>
+              )}
             </div>
           )}
         </div>

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -149,6 +149,21 @@ export const notifications = pgTable('notifications', {
   readAt: timestamp('read_at'),
 });
 
+export const userIcons = pgTable(
+  'user_icons',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id').references(() => users.id).notNull(),
+    icon: text('icon').notNull(),
+  },
+  (table) => ({
+    uniqueUserIcon: uniqueIndex('user_icons_user_icon_unique').on(
+      table.userId,
+      table.icon,
+    ),
+  }),
+);
+
 export const plans = pgTable(
   'plans',
   {

--- a/lib/icons-store.ts
+++ b/lib/icons-store.ts
@@ -1,0 +1,45 @@
+import { db } from '@/lib/db';
+import { flavors, subflavors, userIcons } from '@/lib/db/schema';
+import { and, eq, ne } from 'drizzle-orm';
+
+// Return icons saved in a user's My Icons. If none exist, fall back to
+// public icons used by their flavors and subflavors.
+export async function listUserIcons(userId: number): Promise<string[]> {
+  const rows = await db
+    .select({ icon: userIcons.icon })
+    .from(userIcons)
+    .where(eq(userIcons.userId, userId));
+  if (rows.length > 0) {
+    return rows.map((r) => r.icon);
+  }
+
+  const flavorRows = await db
+    .select({ icon: flavors.icon, visibility: flavors.visibility })
+    .from(flavors)
+    .where(and(eq(flavors.userId, userId), ne(flavors.visibility, 'private')));
+
+  const subRows = await db
+    .select({ icon: subflavors.icon, visibility: subflavors.visibility })
+    .from(subflavors)
+    .where(and(eq(subflavors.userId, userId), ne(subflavors.visibility, 'private')));
+
+  const set = new Set<string>();
+  for (const r of flavorRows) if (r.icon) set.add(r.icon);
+  for (const r of subRows) if (r.icon) set.add(r.icon);
+  return Array.from(set);
+}
+
+// Replace a user's My Icons with the provided list.
+export async function setUserIcons(
+  userId: number,
+  icons: string[],
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx.delete(userIcons).where(eq(userIcons.userId, userId));
+    if (icons.length > 0) {
+      await tx.insert(userIcons).values(
+        icons.map((icon) => ({ userId, icon })),
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- store each user's My Icons on the server and expose them for social import
- sync icon picker with server APIs so profiles show and copy other users' icons
- add API for authenticated users to manage their saved icons

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e58ef63c832a9f019479ca9fc429