### PR TITLE
fix: show public icons from other users

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -111,3 +111,4 @@
 - 2025-10-17: Widened flavor and subflavor icon columns to text so custom images migrate without length errors.
 - 2025-10-17: Added Other People Icons tab with user search and icon import into My Icons.
 - 2025-10-17: Fixed empty icon src errors, awaited user icon route params, and expanded Other People Icons view for larger user lists.
+- 2025-10-18: Treated missing visibility as public so other people's icons appear in icon picker.

--- a/lib/icons-store.ts
+++ b/lib/icons-store.ts
@@ -1,18 +1,28 @@
 import { db } from '@/lib/db';
 import { flavors, subflavors } from '@/lib/db/schema';
-import { and, eq, ne } from 'drizzle-orm';
+import { and, eq, ne, or, isNull } from 'drizzle-orm';
 
 // Return unique public icons used by a user's flavors and subflavors.
 export async function listUserIcons(userId: number): Promise<string[]> {
   const flavorRows = await db
     .select({ icon: flavors.icon, visibility: flavors.visibility })
     .from(flavors)
-    .where(and(eq(flavors.userId, userId), ne(flavors.visibility, 'private')));
+    .where(
+      and(
+        eq(flavors.userId, userId),
+        or(isNull(flavors.visibility), ne(flavors.visibility, 'private')),
+      ),
+    );
 
   const subRows = await db
     .select({ icon: subflavors.icon, visibility: subflavors.visibility })
     .from(subflavors)
-    .where(and(eq(subflavors.userId, userId), ne(subflavors.visibility, 'private')));
+    .where(
+      and(
+        eq(subflavors.userId, userId),
+        or(isNull(subflavors.visibility), ne(subflavors.visibility, 'private')),
+      ),
+    );
 
   const set = new Set<string>();
   for (const r of flavorRows) if (r.icon) set.add(r.icon);


### PR DESCRIPTION
## Summary
- treat missing flavor/subflavor visibility as public when collecting user icons
- update changelog

## Testing
- `pnpm lint`
- `pnpm format` *(fails: Command "format" not found)*
- `pnpm type-check` *(fails: Command "type-check" not found)*
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a572857bfc832a969242619418756a