### PR TITLE
feat: expose all user icons

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -111,3 +111,5 @@
 - 2025-10-17: Widened flavor and subflavor icon columns to text so custom images migrate without length errors.
 - 2025-10-17: Added Other People Icons tab with user search and icon import into My Icons.
 - 2025-10-17: Fixed empty icon src errors, awaited user icon route params, and expanded Other People Icons view for larger user lists.
+
+- 2025-10-17: Persisted My Icons server-side and exposed all user icons, including private ones, when browsing profiles.

--- a/app/api/my-icons/route.ts
+++ b/app/api/my-icons/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { getMyIcons, saveMyIcons } from '@/lib/icons-store';
+
+export async function GET() {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const icons = await getMyIcons(Number(userId));
+  return NextResponse.json({ icons });
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const body = await req.json();
+  const icons = Array.isArray(body.icons) ? body.icons.map(String) : [];
+  await saveMyIcons(Number(userId), icons);
+  return NextResponse.json({ ok: true });
+}

--- a/drizzle/0010_create_user_icons.sql
+++ b/drizzle/0010_create_user_icons.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "user_icons" (
+  "id" serial PRIMARY KEY,
+  "user_id" integer REFERENCES "users"("id") ON DELETE CASCADE,
+  "icon" text NOT NULL,
+  "created_at" timestamp DEFAULT now()
+);
+CREATE UNIQUE INDEX "user_icons_user_id_icon_unique" ON "user_icons" ("user_id", "icon");

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -84,7 +84,9 @@ export const ingredients = pgTable(
   'ingredients',
   {
     id: serial('id').primaryKey(),
-    userId: integer('user_id').references(() => users.id).notNull(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
     title: varchar('title', { length: 80 }).notNull(),
     shortDescription: varchar('short_description', { length: 160 }),
     description: text('description'),
@@ -149,11 +151,32 @@ export const notifications = pgTable('notifications', {
   readAt: timestamp('read_at'),
 });
 
+// Store uploaded or imported icons for each user so others can browse them.
+export const userIcons = pgTable(
+  'user_icons',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    icon: text('icon').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserIcon: uniqueIndex('user_icons_user_id_icon_unique').on(
+      table.userId,
+      table.icon,
+    ),
+  }),
+);
+
 export const plans = pgTable(
   'plans',
   {
     id: serial('id').primaryKey(),
-    userId: integer('user_id').references(() => users.id).notNull(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
     date: date('date').notNull(),
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').defaultNow(),
@@ -168,7 +191,9 @@ export const plans = pgTable(
 
 export const planBlocks = pgTable('plan_blocks', {
   id: text('id').primaryKey(),
-  planId: integer('plan_id').references(() => plans.id).notNull(),
+  planId: integer('plan_id')
+    .references(() => plans.id)
+    .notNull(),
   start: timestamp('start').notNull(),
   end: timestamp('end').notNull(),
   title: varchar('title', { length: 60 }),
@@ -182,7 +207,9 @@ export const profileSnapshots = pgTable(
   'profile_snapshots',
   {
     id: serial('id').primaryKey(),
-    userId: integer('user_id').references(() => users.id).notNull(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
     snapshotDate: date('snapshot_date').notNull(),
     data: jsonb('data').notNull(),
     createdAt: timestamp('created_at').defaultNow(),

--- a/lib/icons-store.ts
+++ b/lib/icons-store.ts
@@ -1,21 +1,49 @@
 import { db } from '@/lib/db';
-import { flavors, subflavors } from '@/lib/db/schema';
-import { and, eq, ne } from 'drizzle-orm';
+import { flavors, subflavors, userIcons } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
 
-// Return unique public icons used by a user's flavors and subflavors.
+// Return all unique icons associated with a user. This includes icons
+// from their flavors, subflavors, and any icons they've uploaded or
+// imported into "My Icons". No visibility filters are applied so the
+// list represents the full set of icons a user has.
 export async function listUserIcons(userId: number): Promise<string[]> {
   const flavorRows = await db
-    .select({ icon: flavors.icon, visibility: flavors.visibility })
+    .select({ icon: flavors.icon })
     .from(flavors)
-    .where(and(eq(flavors.userId, userId), ne(flavors.visibility, 'private')));
+    .where(eq(flavors.userId, userId));
 
   const subRows = await db
-    .select({ icon: subflavors.icon, visibility: subflavors.visibility })
+    .select({ icon: subflavors.icon })
     .from(subflavors)
-    .where(and(eq(subflavors.userId, userId), ne(subflavors.visibility, 'private')));
+    .where(eq(subflavors.userId, userId));
+
+  const userRows = await db
+    .select({ icon: userIcons.icon })
+    .from(userIcons)
+    .where(eq(userIcons.userId, userId));
 
   const set = new Set<string>();
   for (const r of flavorRows) if (r.icon) set.add(r.icon);
   for (const r of subRows) if (r.icon) set.add(r.icon);
+  for (const r of userRows) set.add(r.icon);
   return Array.from(set);
+}
+
+// Retrieve the current user's saved "My Icons" list.
+export async function getMyIcons(userId: number): Promise<string[]> {
+  const rows = await db
+    .select({ icon: userIcons.icon })
+    .from(userIcons)
+    .where(eq(userIcons.userId, userId));
+  return rows.map((r) => r.icon);
+}
+
+// Replace the current user's "My Icons" list with the provided icons.
+// This simple approach keeps the client and server in sync.
+export async function saveMyIcons(userId: number, icons: string[]) {
+  await db.delete(userIcons).where(eq(userIcons.userId, userId));
+  const unique = Array.from(new Set(icons));
+  if (unique.length > 0) {
+    await db.insert(userIcons).values(unique.map((icon) => ({ userId, icon })));
+  }
 }


### PR DESCRIPTION
## Summary
- store user icon libraries server-side
- expose full icon sets when browsing other profiles
- sync My Icons between client and server

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a5763a6908832ab84f1b99a0417732