### PR TITLE
feat: add icon picker for ingredients

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -113,3 +113,5 @@
 - 2025-10-17: Fixed empty icon src errors, awaited user icon route params, and expanded Other People Icons view for larger user lists.
 
 - 2025-10-17: Persisted My Icons server-side and exposed all user icons, including private ones, when browsing profiles.
+
+- 2025-10-17: Added icon picker and storage for ingredients.

--- a/app/(app)/ingredients/actions.ts
+++ b/app/(app)/ingredients/actions.ts
@@ -13,6 +13,8 @@ function sanitize(form: FormData) {
   obj.usefulness = clamp(Number(obj.usefulness));
   obj.title = String(obj.title || '').slice(0, 80);
   obj.shortDescription = (obj.shortDescription || '').toString().slice(0, 160);
+  obj.imageUrl = typeof obj.imageUrl === 'string' ? obj.imageUrl : null;
+  obj.icon = typeof obj.icon === 'string' ? obj.icon : '⭐';
   obj.visibility = ['private', 'followers', 'friends', 'public'].includes(obj.visibility)
     ? obj.visibility
     : 'private';

--- a/app/(app)/ingredients/client.tsx
+++ b/app/(app)/ingredients/client.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useMemo, useRef } from 'react';
 import Link from 'next/link';
+import IconPicker from '@/components/icon-picker';
 import type {
   Ingredient,
   Visibility,
@@ -22,14 +23,6 @@ const VISIBILITIES: Visibility[] = [
   'friends',
   'public',
 ];
-const PRESET_IMAGES = [
-  'https://placehold.co/100x100/FF5733/FFFFFF?text=1',
-  'https://placehold.co/100x100/33C3FF/FFFFFF?text=2',
-  'https://placehold.co/100x100/FFC300/FFFFFF?text=3',
-  'https://placehold.co/100x100/DAF7A6/000000?text=4',
-  'https://placehold.co/100x100/C70039/FFFFFF?text=5',
-];
-
 const PRESET_INGREDIENTS: IngredientInput[] = [
   {
     title: 'Morning Run',
@@ -39,7 +32,8 @@ const PRESET_INGREDIENTS: IngredientInput[] = [
     whenUsed: 'Every morning before breakfast.',
     tips: 'Prepare clothes the night before.',
     usefulness: 70,
-    imageUrl: PRESET_IMAGES[0],
+    icon: '🏃',
+    imageUrl: null,
     tags: null,
     visibility: 'private',
   },
@@ -51,11 +45,18 @@ const PRESET_INGREDIENTS: IngredientInput[] = [
     whenUsed: 'Every day after 12pm.',
     tips: 'Keep healthy snacks nearby.',
     usefulness: 60,
-    imageUrl: PRESET_IMAGES[1],
+    icon: '🍬',
+    imageUrl: null,
     tags: null,
     visibility: 'private',
   },
 ];
+
+function iconSrc(ic: string) {
+  if (ic.startsWith('data:')) return ic;
+  if (/^[A-Za-z0-9+/=]+$/.test(ic)) return `data:image/png;base64,${ic}`;
+  return null;
+}
 
 function sortIngredients(list: Ingredient[]) {
   return [...list].sort((a, b) => {
@@ -104,7 +105,7 @@ export default function IngredientsClient({
     whyUsed: '',
     whenUsed: '',
     tips: '',
-    imageUrl: '',
+    icon: '⭐',
     visibility: 'private' as Visibility,
   });
   const initialForm = useRef(form);
@@ -119,7 +120,7 @@ export default function IngredientsClient({
       whyUsed: '',
       whenUsed: '',
       tips: '',
-      imageUrl: '',
+      icon: '⭐',
       visibility: 'private' as Visibility,
     };
     setForm(blank);
@@ -138,7 +139,7 @@ export default function IngredientsClient({
       whyUsed: i.whyUsed,
       whenUsed: i.whenUsed,
       tips: i.tips,
-      imageUrl: i.imageUrl || '',
+      icon: i.icon,
       visibility: i.visibility,
     };
     setForm(data);
@@ -242,25 +243,20 @@ export default function IngredientsClient({
             className="flex cursor-pointer items-center gap-4 rounded border p-4 shadow-sm"
             onClick={() => openEdit(i)}
           >
-            {i.imageUrl ? (
-              <img
-                id={`1ngred-card-img-${i.id}-${userId}`}
-                src={i.imageUrl}
-                alt=""
-                className="h-16 w-16 rounded-full object-cover"
-              />
-            ) : (
-              <div
-                id={`1ngred-card-img-${i.id}-${userId}`}
-                className="flex h-16 w-16 items-center justify-center rounded-full bg-gray-300 text-xl font-bold"
-              >
-                {i.title
-                  .split(' ')
-                  .map((s) => s[0])
-                  .join('')
-                  .slice(0, 2)}
-              </div>
-            )}
+            <div
+              id={`1ngred-card-img-${i.id}-${userId}`}
+              className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-full bg-gray-300"
+            >
+              {iconSrc(i.icon) ? (
+                <img
+                  src={iconSrc(i.icon) as string}
+                  alt="icon"
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <span className="text-2xl">{i.icon}</span>
+              )}
+            </div>
             <div className="flex-1">
               <div className="font-semibold">{i.title}</div>
               <div className="text-sm text-gray-600">{i.shortDescription}</div>
@@ -360,9 +356,22 @@ export default function IngredientsClient({
                       className="rounded border p-2 text-left hover:bg-gray-50"
                       onClick={() => importPreset(p)}
                     >
-                      <div className="font-semibold">{p.title}</div>
-                      <div className="text-sm text-gray-600">
-                        {p.shortDescription}
+                      <div className="flex items-center gap-2">
+                        {iconSrc(p.icon) ? (
+                          <img
+                            src={iconSrc(p.icon) as string}
+                            alt="icon"
+                            className="h-6 w-6 rounded-full object-cover"
+                          />
+                        ) : (
+                          <span className="text-xl">{p.icon}</span>
+                        )}
+                        <div>
+                          <div className="font-semibold">{p.title}</div>
+                          <div className="text-sm text-gray-600">
+                            {p.shortDescription}
+                          </div>
+                        </div>
                       </div>
                     </button>
                   ))}
@@ -457,26 +466,15 @@ export default function IngredientsClient({
               <button onClick={() => setOpen(false)}>✕</button>
             </div>
             <div
-              id={`1ngred-imgup-${editing ? editing.id : 'new'}-${userId}`}
-              className="mb-4 flex flex-wrap justify-center gap-2"
+              className="mb-4"
             >
-              {PRESET_IMAGES.map((url) => (
-                <button
-                  type="button"
-                  key={url}
-                  onClick={() =>
-                    editable && setForm({ ...form, imageUrl: url })
-                  }
-                  disabled={!editable}
-                  className={`h-12 w-12 overflow-hidden rounded-full border-2 ${form.imageUrl === url ? 'border-blue-500' : 'border-transparent'}`}
-                >
-                  <img
-                    src={url}
-                    alt=""
-                    className="h-full w-full object-cover"
-                  />
-                </button>
-              ))}
+              <label className="block text-sm font-medium">Icon</label>
+              <IconPicker
+                value={form.icon}
+                onChange={(icon) => setForm({ ...form, icon })}
+                people={people}
+                editable={editable}
+              />
             </div>
             <label
               className="block text-sm font-medium"

--- a/drizzle/0011_add_ingredient_icon.sql
+++ b/drizzle/0011_add_ingredient_icon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "ingredients" ADD COLUMN "icon" text;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -95,6 +95,8 @@ export const ingredients = pgTable(
     tips: text('tips'),
     usefulness: integer('usefulness').default(0),
     imageUrl: text('image_url'),
+    // Icon for the ingredient, stored as emoji or data URL
+    icon: text('icon'),
     tags: text('tags').array(),
     visibility: varchar('visibility', { length: 20 }),
     createdAt: timestamp('created_at').defaultNow(),

--- a/lib/ingredients-store.ts
+++ b/lib/ingredients-store.ts
@@ -22,6 +22,7 @@ function toIngredient(row: typeof ingredients.$inferSelect): Ingredient {
     tips: row.tips ?? '',
     usefulness: row.usefulness ?? 0,
     imageUrl: row.imageUrl ?? null,
+    icon: row.icon ?? '⭐',
     tags: row.tags ?? null,
     visibility: (row.visibility as Visibility) ?? 'private',
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
@@ -130,6 +131,7 @@ export async function createIngredient(
       tips: input.tips,
       usefulness: clamp(input.usefulness),
       imageUrl: input.imageUrl,
+      icon: input.icon,
       tags: input.tags ?? null,
       visibility: input.visibility,
       createdAt: now,
@@ -148,6 +150,7 @@ export async function createIngredient(
       tips: ing.tips,
       usefulness: ing.usefulness,
       imageUrl: ing.imageUrl,
+      icon: ing.icon,
       tags: ing.tags,
     },
   });
@@ -171,8 +174,10 @@ export async function updateIngredient(
       whyUsed: input.whyUsed,
       whenUsed: input.whenUsed,
       tips: input.tips,
-      usefulness: input.usefulness !== undefined ? clamp(input.usefulness) : undefined,
+      usefulness:
+        input.usefulness !== undefined ? clamp(input.usefulness) : undefined,
       imageUrl: input.imageUrl,
+      icon: input.icon,
       tags: input.tags,
       visibility: input.visibility,
       updatedAt: now,
@@ -192,6 +197,7 @@ export async function updateIngredient(
       tips: ing.tips,
       usefulness: ing.usefulness,
       imageUrl: ing.imageUrl,
+      icon: ing.icon,
       tags: ing.tags,
     },
   });

--- a/types/ingredient.ts
+++ b/types/ingredient.ts
@@ -11,6 +11,7 @@ export interface Ingredient {
   tips: string;
   usefulness: number;
   imageUrl: string | null;
+  icon: string;
   tags: string[] | null;
   visibility: Visibility;
   createdAt: string;


### PR DESCRIPTION
## Summary
- allow choosing and storing custom icons for ingredients
- expose icon picker in ingredient forms and lists
- add database column and types for ingredient icons

## Testing
- `pnpm lint`
- `pnpm type-check` *(fails: Command "type-check" not found)*
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a57abb83f8832a95fce87ae24d9794