### PR TITLE
fix: persist selected icons and add close option

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -116,3 +116,4 @@
 
 - 2025-10-17: Added icon picker and storage for ingredients.
 - 2025-10-17: Shrunk ingredient icons and ensured images fill their circular frames.
+- 2025-10-17: Saved preset icon selections to My Icons and added a close button to the icon picker.

--- a/components/icon-picker.tsx
+++ b/components/icon-picker.tsx
@@ -194,6 +194,16 @@ export default function IconPicker({
       {open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="flex h-[90vh] w-[90vw] max-w-3xl flex-col overflow-hidden rounded bg-white p-4">
+            <div className="mb-2 flex justify-end">
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Close"
+                className="text-xl leading-none"
+              >
+                ×
+              </button>
+            </div>
             <div className="mb-2 flex gap-2 text-sm">
               <button
                 type="button"
@@ -270,6 +280,9 @@ export default function IconPicker({
                     key={ic}
                     type="button"
                     onClick={() => {
+                      if (!myIcons.includes(ic)) {
+                        saveMyIcons([...myIcons, ic]);
+                      }
                       onChange(ic);
                       setOpen(false);
                     }}

--- a/tests/flavors.spec.ts
+++ b/tests/flavors.spec.ts
@@ -90,6 +90,15 @@ test('flavor CRUD and ordering', async ({ page }) => {
     '❤️',
   );
 
+  // reopen picker to confirm icon persists and close without selection
+  await rows.first().click();
+  await page.click('button:has-text("Choose Icon")');
+  await expect(
+    page.locator('button[data-testid="icon-option"]:has-text("❤️")'),
+  ).toBeVisible();
+  await page.click('button[aria-label="Close"]');
+  await page.keyboard.press('Escape');
+
   // search flavors
   const flavorSearch = page.locator('input[placeholder="Search flavors…"]');
   await flavorSearch.fill('Second');


### PR DESCRIPTION
## Summary
- save preset icons to "My Icons" when selected so they're available later
- add a close button to the icon picker modal
- cover icon persistence and close button in flavor test

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a5814e9360832aa3564783a366c093