### PR TITLE
fix: dedupe icons and drop oversized index

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -116,3 +116,6 @@
 
 - 2025-10-17: Added icon picker and storage for ingredients.
 - 2025-10-17: Shrunk ingredient icons and ensured images fill their circular frames.
+- 2025-10-17: Saved preset icon selections to My Icons and added a close button to the icon picker.
+- 2025-10-17: Deduplicated saved icons, removed oversized My Icons unique index, and fixed duplicate-key warnings so icon uploads persist reliably.
+- 2025-10-17: Ensured My Icons saving auto-creates missing user records to prevent foreign key errors and keep icons persistent.

--- a/app/api/my-icons/route.ts
+++ b/app/api/my-icons/route.ts
@@ -1,25 +1,26 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { getMyIcons, saveMyIcons } from '@/lib/icons-store';
+import { ensureUser } from '@/lib/users';
 
 export async function GET() {
   const session = await auth();
-  const userId = session?.user?.id;
-  if (!userId) {
+  if (!session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const icons = await getMyIcons(Number(userId));
+  const user = await ensureUser(session);
+  const icons = await getMyIcons(user.id);
   return NextResponse.json({ icons });
 }
 
 export async function POST(req: NextRequest) {
   const session = await auth();
-  const userId = session?.user?.id;
-  if (!userId) {
+  if (!session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  const user = await ensureUser(session);
   const body = await req.json();
   const icons = Array.isArray(body.icons) ? body.icons.map(String) : [];
-  await saveMyIcons(Number(userId), icons);
+  await saveMyIcons(user.id, icons);
   return NextResponse.json({ ok: true });
 }

--- a/drizzle/0012_drop_user_icons_unique_index.sql
+++ b/drizzle/0012_drop_user_icons_unique_index.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "user_icons_user_id_icon_unique";

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -154,23 +154,14 @@ export const notifications = pgTable('notifications', {
 });
 
 // Store uploaded or imported icons for each user so others can browse them.
-export const userIcons = pgTable(
-  'user_icons',
-  {
-    id: serial('id').primaryKey(),
-    userId: integer('user_id')
-      .references(() => users.id)
-      .notNull(),
-    icon: text('icon').notNull(),
-    createdAt: timestamp('created_at').defaultNow(),
-  },
-  (table) => ({
-    uniqueUserIcon: uniqueIndex('user_icons_user_id_icon_unique').on(
-      table.userId,
-      table.icon,
-    ),
-  }),
-);
+export const userIcons = pgTable('user_icons', {
+  id: serial('id').primaryKey(),
+  userId: integer('user_id')
+    .references(() => users.id)
+    .notNull(),
+  icon: text('icon').notNull(),
+  createdAt: timestamp('created_at').defaultNow(),
+});
 
 export const plans = pgTable(
   'plans',

--- a/tests/flavors.spec.ts
+++ b/tests/flavors.spec.ts
@@ -90,6 +90,15 @@ test('flavor CRUD and ordering', async ({ page }) => {
     '❤️',
   );
 
+  // reopen picker to confirm icon persists and close without selection
+  await rows.first().click();
+  await page.click('button:has-text("Choose Icon")');
+  await expect(
+    page.locator('button[data-testid="icon-option"]:has-text("❤️")'),
+  ).toBeVisible();
+  await page.click('button[aria-label="Close"]');
+  await page.keyboard.press('Escape');
+
   // search flavors
   const flavorSearch = page.locator('input[placeholder="Search flavors…"]');
   await flavorSearch.fill('Second');


### PR DESCRIPTION
## Summary
- de-duplicate icons on load/save so picker keys stay unique
- remove user icons unique index to support large base64 images
- ensure user records exist before saving My Icons to avoid FK errors

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a5814e9360832aa3564783a366c093