### PR TITLE
feat: snapshot historical icons

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -119,3 +119,4 @@
 - 2025-10-17: Saved preset icon selections to My Icons and added a close button to the icon picker.
 - 2025-10-17: Deduplicated saved icons, removed oversized My Icons unique index, and fixed duplicate-key warnings so icon uploads persist reliably.
 - 2025-10-17: Ensured My Icons saving auto-creates missing user records to prevent foreign key errors and keep icons persistent.
+- 2025-10-17: Snapshots capture user icon libraries and prompt before importing historical icons into My Icons.

--- a/components/icon-picker.tsx
+++ b/components/icon-picker.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import type { PeopleLists, Person } from '@/lib/people-store';
+import { useViewContext } from '@/lib/view-context';
 
 interface IconPickerProps {
   value: string;
@@ -29,6 +30,7 @@ export default function IconPicker({
   editable = true,
   people,
 }: IconPickerProps) {
+  const ctx = useViewContext();
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<'mine' | 'preset' | 'people'>('mine');
   const [myIcons, setMyIcons] = useState<string[]>([]);
@@ -143,7 +145,8 @@ export default function IconPicker({
     setSelectedUser(u);
     setUserIcons(null);
     try {
-      const res = await fetch(`/api/users/${u.id}/icons`);
+      const query = ctx.snapshotDate ? `?snapshot=${ctx.snapshotDate}` : '';
+      const res = await fetch(`/api/users/${u.id}/icons${query}`);
       if (res.ok) {
         const data = await res.json();
         setUserIcons(Array.isArray(data.icons) ? data.icons : []);
@@ -353,10 +356,14 @@ export default function IconPicker({
                               key={ic}
                               type="button"
                               onClick={() => {
-                                if (!myIcons.includes(ic)) {
-                                  saveMyIcons([...myIcons, ic]);
+                                if (
+                                  window.confirm('Add to your My Icons?')
+                                ) {
+                                  if (!myIcons.includes(ic)) {
+                                    saveMyIcons([...myIcons, ic]);
+                                  }
+                                  onChange(ic);
                                 }
-                                onChange(ic);
                                 setOpen(false);
                                 setSelectedUser(null);
                               }}

--- a/lib/profile-snapshots.ts
+++ b/lib/profile-snapshots.ts
@@ -2,6 +2,7 @@ import { db } from './db';
 import { profileSnapshots, users, flavors, subflavors } from './db/schema';
 import { eq, and, desc } from 'drizzle-orm';
 import { startOfDay, addDays, toYMD } from './clock';
+import { listUserIcons } from './icons-store';
 
 export async function createProfileSnapshot(
   userId: number,
@@ -27,12 +28,18 @@ export async function createProfileSnapshot(
     .select()
     .from(subflavors)
     .where(eq(subflavors.userId, userId));
+  const iconList = await listUserIcons(userId);
   await db
     .insert(profileSnapshots)
     .values({
       userId,
       snapshotDate,
-      data: { user, flavors: flavorRows, subflavors: subflavorRows },
+      data: {
+        user,
+        flavors: flavorRows,
+        subflavors: subflavorRows,
+        icons: iconList,
+      },
     })
     .onConflictDoNothing();
 }

--- a/tests/history-icons.spec.ts
+++ b/tests/history-icons.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { getUserByHandle } from '@/lib/users';
+import { createProfileSnapshot } from '@/lib/profile-snapshots';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+test('historical icons reflect snapshot', async ({ page, browser }) => {
+  const handleOwner = unique('owner');
+  const emailOwner = `${handleOwner}@example.com`;
+  const dateStr = today();
+
+  // Owner sign up and create a flavor with the default star icon
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', handleOwner);
+  await page.fill('input[placeholder="Email"]', emailOwner);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+  await page.goto('/flavors');
+  await page.click('button[id^="f7av-add"]');
+  await page.click('button[id^="f7av-add-own"]');
+  await page.fill('input[id^="f7avourn4me-frm"]', 'PastIcon');
+  await page.fill('textarea[id^="f7avourde5cr-frm"]', 'desc');
+  await page.click('button[id^="f7avoursav-frm"]');
+
+  const owner = await getUserByHandle(handleOwner);
+  await createProfileSnapshot(owner.id, dateStr);
+
+  // Change flavor icon to heart after snapshot
+  const row = page.locator('li:has-text("PastIcon")');
+  await row.click();
+  await page.click('button:has-text("Choose Icon")');
+  await page.click('button[data-testid="icon-option"]:has-text("❤️")');
+  await page.click('button[id^="f7avoursav-frm"]');
+
+  // Viewer signs up
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  const handleViewer = unique('viewer');
+  const emailViewer = `${handleViewer}@example.com`;
+  await page2.goto('/signup');
+  await page2.fill('input[placeholder="Name"]', 'Viewer');
+  await page2.fill('input[placeholder="Handle"]', handleViewer);
+  await page2.fill('input[placeholder="Email"]', emailViewer);
+  await page2.fill('input[placeholder="Password"]', PASSWORD);
+  await page2.click('text=Sign Up');
+
+  // Fetch owner's icons from snapshot
+  const res = await page2.request.get(
+    `/api/users/${owner.id}/icons?snapshot=${dateStr}`,
+  );
+  const data = await res.json();
+  expect(data.icons).toContain('⭐');
+  expect(data.icons).not.toContain('❤️');
+  await ctx2.close();
+});
+


### PR DESCRIPTION
## Summary
- snapshot user icon library in profile snapshots
- fetch historical icons via API with confirmation before saving
- add test to ensure icons reflect snapshot state

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*


------
https://chatgpt.com/codex/tasks/task_e_68a5b03922a0832a8fca33e048d4a493