### PR TITLE
Snapshot icon libraries with confirmable imports

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -119,3 +119,4 @@
 - 2025-10-17: Saved preset icon selections to My Icons and added a close button to the icon picker.
 - 2025-10-17: Deduplicated saved icons, removed oversized My Icons unique index, and fixed duplicate-key warnings so icon uploads persist reliably.
 - 2025-10-17: Ensured My Icons saving auto-creates missing user records to prevent foreign key errors and keep icons persistent.
+- 2025-10-18: Snapshots now store user icon libraries and icon picker retrieves historical icons with confirmation before adding to My Icons.

--- a/app/api/users/[id]/icons/route.ts
+++ b/app/api/users/[id]/icons/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { listUserIcons } from '@/lib/icons-store';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
 
 export async function GET(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const session = await auth();
@@ -14,6 +15,14 @@ export async function GET(
   const userId = Number(id);
   if (!userId) {
     return NextResponse.json({ error: 'Invalid user' }, { status: 400 });
+  }
+  const url = new URL(req.url);
+  const at = url.searchParams.get('at');
+  if (at) {
+    const snap = await getProfileSnapshot(userId, at);
+    if (snap && Array.isArray((snap as any).icons)) {
+      return NextResponse.json({ icons: (snap as any).icons });
+    }
   }
   const icons = await listUserIcons(userId);
   return NextResponse.json({ icons });

--- a/components/icon-picker.tsx
+++ b/components/icon-picker.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import type { PeopleLists, Person } from '@/lib/people-store';
+import { useViewContext } from '@/lib/view-context';
 
 interface IconPickerProps {
   value: string;
@@ -35,6 +36,7 @@ export default function IconPicker({
   const [peopleSearch, setPeopleSearch] = useState('');
   const [selectedUser, setSelectedUser] = useState<Person | null>(null);
   const [userIcons, setUserIcons] = useState<string[] | null>(null);
+  const ctx = useViewContext();
 
   // Load the user's saved icons. We first attempt to fetch from the
   // server so icons are shared across devices, falling back to any
@@ -143,7 +145,10 @@ export default function IconPicker({
     setSelectedUser(u);
     setUserIcons(null);
     try {
-      const res = await fetch(`/api/users/${u.id}/icons`);
+      const url = ctx.snapshotDate
+        ? `/api/users/${u.id}/icons?at=${ctx.snapshotDate}`
+        : `/api/users/${u.id}/icons`;
+      const res = await fetch(url);
       if (res.ok) {
         const data = await res.json();
         setUserIcons(Array.isArray(data.icons) ? data.icons : []);
@@ -353,12 +358,16 @@ export default function IconPicker({
                               key={ic}
                               type="button"
                               onClick={() => {
-                                if (!myIcons.includes(ic)) {
-                                  saveMyIcons([...myIcons, ic]);
+                                if (
+                                  window.confirm('Add to your My Icons?')
+                                ) {
+                                  if (!myIcons.includes(ic)) {
+                                    saveMyIcons([...myIcons, ic]);
+                                  }
+                                  onChange(ic);
+                                  setOpen(false);
+                                  setSelectedUser(null);
                                 }
-                                onChange(ic);
-                                setOpen(false);
-                                setSelectedUser(null);
                               }}
                               className="flex h-10 w-10 items-center justify-center rounded border"
                               data-testid="icon-option"

--- a/lib/profile-snapshots.ts
+++ b/lib/profile-snapshots.ts
@@ -2,6 +2,7 @@ import { db } from './db';
 import { profileSnapshots, users, flavors, subflavors } from './db/schema';
 import { eq, and, desc } from 'drizzle-orm';
 import { startOfDay, addDays, toYMD } from './clock';
+import { listUserIcons } from './icons-store';
 
 export async function createProfileSnapshot(
   userId: number,
@@ -27,12 +28,13 @@ export async function createProfileSnapshot(
     .select()
     .from(subflavors)
     .where(eq(subflavors.userId, userId));
+  const icons = await listUserIcons(userId);
   await db
     .insert(profileSnapshots)
     .values({
       userId,
       snapshotDate,
-      data: { user, flavors: flavorRows, subflavors: subflavorRows },
+      data: { user, flavors: flavorRows, subflavors: subflavorRows, icons },
     })
     .onConflictDoNothing();
 }

--- a/tests/history-icons.spec.ts
+++ b/tests/history-icons.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { getUserByHandle } from '@/lib/users';
+import { createProfileSnapshot } from '@/lib/profile-snapshots';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+test('historical icon lists reflect snapshot', async ({ page }) => {
+  const handle = unique('iconuser');
+  const email = `${handle}@example.com`;
+  const dateStr = today();
+
+  // sign up user and save an icon
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Icon User');
+  await page.fill('input[placeholder="Handle"]', handle);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+  await page.evaluate(async () => {
+    await fetch('/api/my-icons', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ icons: ['🍩'] }),
+    });
+  });
+
+  const owner = await getUserByHandle(handle);
+  await createProfileSnapshot(owner.id, dateStr);
+
+  // clear current icons
+  await page.evaluate(async () => {
+    await fetch('/api/my-icons', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ icons: [] }),
+    });
+  });
+
+  const resNow = await page.request.get(`/api/users/${owner.id}/icons`);
+  const nowData = await resNow.json();
+  expect(nowData.icons).not.toContain('🍩');
+
+  const resHist = await page.request.get(
+    `/api/users/${owner.id}/icons?at=${dateStr}`,
+  );
+  const histData = await resHist.json();
+  expect(histData.icons).toContain('🍩');
+});


### PR DESCRIPTION
## Summary
- Store each user's icon library inside profile snapshots
- Allow fetching historical icons via `/api/users/[id]/icons?at=yyyy-mm-dd`
- Icon picker pulls snapshot icons and confirms before adding to My Icons

## Testing
- `pnpm test` *(fails: Error: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b03922a0832a8fca33e048d4a493