### PR TITLE
feat: snapshot historical icons

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -119,3 +119,6 @@
 - 2025-10-17: Saved preset icon selections to My Icons and added a close button to the icon picker.
 - 2025-10-17: Deduplicated saved icons, removed oversized My Icons unique index, and fixed duplicate-key warnings so icon uploads persist reliably.
 - 2025-10-17: Ensured My Icons saving auto-creates missing user records to prevent foreign key errors and keep icons persistent.
+- 2025-10-17: Snapshots capture user icon libraries and prompt before importing historical icons into My Icons.
+- 2025-10-17: Made My Icons API snapshot-aware and allowed copying historical icons without altering past snapshots.
+- 2025-10-17: Fixed My Icons snapshot views to show historical icons only and block edits while allowing copying to the current library.

--- a/app/api/users/[id]/icons/route.ts
+++ b/app/api/users/[id]/icons/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { listUserIcons } from '@/lib/icons-store';
+import { getProfileSnapshot, iconsFromSnapshot } from '@/lib/profile-snapshots';
 
 export async function GET(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const session = await auth();
@@ -15,6 +16,14 @@ export async function GET(
   if (!userId) {
     return NextResponse.json({ error: 'Invalid user' }, { status: 400 });
   }
-  const icons = await listUserIcons(userId);
+  const url = new URL(req.url);
+  const snapshot = url.searchParams.get('snapshot');
+  let icons: string[];
+  if (snapshot) {
+    const snap = await getProfileSnapshot(userId, snapshot);
+    icons = snap ? iconsFromSnapshot(snap) : [];
+  } else {
+    icons = await listUserIcons(userId);
+  }
   return NextResponse.json({ icons });
 }

--- a/components/icon-picker.tsx
+++ b/components/icon-picker.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import type { PeopleLists, Person } from '@/lib/people-store';
+import { useViewContext } from '@/lib/view-context';
 
 interface IconPickerProps {
   value: string;
@@ -29,9 +30,12 @@ export default function IconPicker({
   editable = true,
   people,
 }: IconPickerProps) {
+  const ctx = useViewContext();
+  const canEdit = editable && !ctx.snapshotDate;
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<'mine' | 'preset' | 'people'>('mine');
   const [myIcons, setMyIcons] = useState<string[]>([]);
+  const [snapshotIcons, setSnapshotIcons] = useState<string[]>([]);
   const [peopleSearch, setPeopleSearch] = useState('');
   const [selectedUser, setSelectedUser] = useState<Person | null>(null);
   const [userIcons, setUserIcons] = useState<string[] | null>(null);
@@ -52,27 +56,50 @@ export default function IconPicker({
             if (typeof window !== 'undefined') {
               localStorage.setItem('my-icons', JSON.stringify(unique));
             }
-            return;
           }
         }
       } catch {
         /* ignore network errors */
       }
-      if (typeof window === 'undefined') return;
-      const stored = localStorage.getItem('my-icons');
-      if (stored) {
+      if (ctx.snapshotDate) {
         try {
-          const parsed = JSON.parse(stored);
-          if (Array.isArray(parsed)) {
-            setMyIcons(Array.from(new Set(parsed.map(String))));
+          const res2 = await fetch(`/api/my-icons?snapshot=${ctx.snapshotDate}`);
+          if (res2.ok) {
+            const data2 = await res2.json();
+            if (Array.isArray(data2.icons)) {
+              const unique2 = Array.from(
+                new Set<string>(data2.icons.map((i: unknown) => String(i))),
+              );
+              setSnapshotIcons(unique2);
+            } else {
+              setSnapshotIcons([]);
+            }
+          } else {
+            setSnapshotIcons([]);
           }
         } catch {
-          /* ignore */
+          setSnapshotIcons([]);
+        }
+      } else {
+        setSnapshotIcons([]);
+      }
+      if (typeof window !== 'undefined' && myIcons.length === 0) {
+        const stored = localStorage.getItem('my-icons');
+        if (stored) {
+          try {
+            const parsed = JSON.parse(stored);
+            if (Array.isArray(parsed)) {
+              setMyIcons(Array.from(new Set(parsed.map(String))));
+            }
+          } catch {
+            /* ignore */
+          }
         }
       }
     }
     load();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ctx.snapshotDate]);
 
   // Persist the user's icon library locally and to the server so others
   // can browse it. Errors from the network request are ignored; the
@@ -143,7 +170,8 @@ export default function IconPicker({
     setSelectedUser(u);
     setUserIcons(null);
     try {
-      const res = await fetch(`/api/users/${u.id}/icons`);
+      const query = ctx.snapshotDate ? `?snapshot=${ctx.snapshotDate}` : '';
+      const res = await fetch(`/api/users/${u.id}/icons${query}`);
       if (res.ok) {
         const data = await res.json();
         setUserIcons(Array.isArray(data.icons) ? data.icons : []);
@@ -161,17 +189,31 @@ export default function IconPicker({
     { label: 'Others', list: filterPeople(people?.others) },
   ];
 
-  if (!editable) {
-    return (
-      <div className="flex items-center gap-2">
-        {resolveSrc(value) ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={resolveSrc(value)} alt="icon" className="h-6 w-6" />
-        ) : (
-          <span>{value}</span>
-        )}
-      </div>
+  if (!canEdit) {
+    const content = resolveSrc(value) ? (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img src={resolveSrc(value)} alt="icon" className="h-6 w-6" />
+    ) : (
+      <span>{value}</span>
     );
+    if (ctx.snapshotDate) {
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            if (window.confirm('Add to your My Icons?')) {
+              if (!myIcons.includes(value)) {
+                saveMyIcons([...myIcons, value]);
+              }
+            }
+          }}
+          className="flex items-center gap-2"
+        >
+          {content}
+        </button>
+      );
+    }
+    return <div className="flex items-center gap-2">{content}</div>;
   }
 
   return (
@@ -238,18 +280,29 @@ export default function IconPicker({
             </div>
             {tab === 'mine' && (
               <div className="flex h-full flex-col overflow-hidden">
-                <input type="file" accept="image/*" onChange={handleUpload} />
+                {canEdit && (
+                  <input type="file" accept="image/*" onChange={handleUpload} />
+                )}
                 <div className="mt-2 flex-1 overflow-y-auto">
                   <div className="grid grid-cols-8 gap-2 md:grid-cols-10">
-                    {myIcons.map((ic) => {
+                    {(ctx.snapshotDate ? snapshotIcons : myIcons).map((ic) => {
                       const src = resolveSrc(ic);
                       return (
                         <div key={ic} className="relative">
                           <button
                             type="button"
                             onClick={() => {
-                              onChange(ic);
-                              setOpen(false);
+                              if (ctx.snapshotDate) {
+                                if (window.confirm('Add to your My Icons?')) {
+                                  if (!myIcons.includes(ic)) {
+                                    saveMyIcons([...myIcons, ic]);
+                                  }
+                                }
+                                setOpen(false);
+                              } else {
+                                onChange(ic);
+                                setOpen(false);
+                              }
                             }}
                             className="flex h-10 w-10 items-center justify-center overflow-hidden rounded border"
                             data-testid="icon-option"
@@ -265,13 +318,15 @@ export default function IconPicker({
                               <span className="text-lg">{ic}</span>
                             )}
                           </button>
-                          <button
-                            type="button"
-                            onClick={() => deleteIcon(ic)}
-                            className="absolute -right-1 -top-1 h-4 w-4 rounded-full bg-white text-xs"
-                          >
-                            ×
-                          </button>
+                          {canEdit && (
+                            <button
+                              type="button"
+                              onClick={() => deleteIcon(ic)}
+                              className="absolute -right-1 -top-1 h-4 w-4 rounded-full bg-white text-xs"
+                            >
+                              ×
+                            </button>
+                          )}
                         </div>
                       );
                     })}
@@ -353,10 +408,14 @@ export default function IconPicker({
                               key={ic}
                               type="button"
                               onClick={() => {
-                                if (!myIcons.includes(ic)) {
-                                  saveMyIcons([...myIcons, ic]);
+                                if (
+                                  window.confirm('Add to your My Icons?')
+                                ) {
+                                  if (!myIcons.includes(ic)) {
+                                    saveMyIcons([...myIcons, ic]);
+                                  }
+                                  onChange(ic);
                                 }
-                                onChange(ic);
                                 setOpen(false);
                                 setSelectedUser(null);
                               }}

--- a/lib/profile-snapshots.ts
+++ b/lib/profile-snapshots.ts
@@ -2,6 +2,7 @@ import { db } from './db';
 import { profileSnapshots, users, flavors, subflavors } from './db/schema';
 import { eq, and, desc } from 'drizzle-orm';
 import { startOfDay, addDays, toYMD } from './clock';
+import { listUserIcons } from './icons-store';
 
 export async function createProfileSnapshot(
   userId: number,
@@ -27,12 +28,18 @@ export async function createProfileSnapshot(
     .select()
     .from(subflavors)
     .where(eq(subflavors.userId, userId));
+  const iconList = await listUserIcons(userId);
   await db
     .insert(profileSnapshots)
     .values({
       userId,
       snapshotDate,
-      data: { user, flavors: flavorRows, subflavors: subflavorRows },
+      data: {
+        user,
+        flavors: flavorRows,
+        subflavors: subflavorRows,
+        icons: iconList,
+      },
     })
     .onConflictDoNothing();
 }
@@ -77,4 +84,25 @@ export async function getProfileSnapshot(userId: number, snapshotDate: string) {
       ),
     );
   return row?.data as any;
+}
+
+// Derive the icon set from a profile snapshot. This helper allows older
+// snapshots that predate explicit icon capture to still return the icons
+// associated with flavors and subflavors from that day.
+export function iconsFromSnapshot(snap: any): string[] {
+  const set = new Set<string>();
+  if (Array.isArray(snap?.icons)) {
+    for (const ic of snap.icons) set.add(String(ic));
+  }
+  if (Array.isArray(snap?.flavors)) {
+    for (const f of snap.flavors) {
+      if (f.icon) set.add(String(f.icon));
+    }
+  }
+  if (Array.isArray(snap?.subflavors)) {
+    for (const sf of snap.subflavors) {
+      if (sf.icon) set.add(String(sf.icon));
+    }
+  }
+  return Array.from(set);
 }

--- a/tests/history-icons.spec.ts
+++ b/tests/history-icons.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { getUserByHandle } from '@/lib/users';
+import { createProfileSnapshot } from '@/lib/profile-snapshots';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+test('historical icons reflect snapshot', async ({ page, browser }) => {
+  const handleOwner = unique('owner');
+  const emailOwner = `${handleOwner}@example.com`;
+  const dateStr = today();
+
+  // Owner sign up and create a flavor with the default star icon
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', handleOwner);
+  await page.fill('input[placeholder="Email"]', emailOwner);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+  await page.goto('/flavors');
+  await page.click('button[id^="f7av-add"]');
+  await page.click('button[id^="f7av-add-own"]');
+  await page.fill('input[id^="f7avourn4me-frm"]', 'PastIcon');
+  await page.fill('textarea[id^="f7avourde5cr-frm"]', 'desc');
+  await page.click('button[id^="f7avoursav-frm"]');
+
+  const owner = await getUserByHandle(handleOwner);
+  await createProfileSnapshot(owner.id, dateStr);
+
+  // Change flavor icon to heart after snapshot
+  const row = page.locator('li:has-text("PastIcon")');
+  await row.click();
+  await page.click('button:has-text("Choose Icon")');
+  await page.click('button[data-testid="icon-option"]:has-text("❤️")');
+  await page.click('button[id^="f7avoursav-frm"]');
+
+  // Fetch owner's icons from snapshot vs current
+  const snapRes = await page.request.get(`/api/my-icons?snapshot=${dateStr}`);
+  const snapData = await snapRes.json();
+  expect(snapData.icons).toContain('⭐');
+  expect(snapData.icons).not.toContain('❤️');
+  const curRes = await page.request.get('/api/my-icons');
+  const curData = await curRes.json();
+  expect(curData.icons).toContain('❤️');
+  expect(curData.icons).not.toContain('⭐');
+
+  // Viewer signs up
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  const handleViewer = unique('viewer');
+  const emailViewer = `${handleViewer}@example.com`;
+  await page2.goto('/signup');
+  await page2.fill('input[placeholder="Name"]', 'Viewer');
+  await page2.fill('input[placeholder="Handle"]', handleViewer);
+  await page2.fill('input[placeholder="Email"]', emailViewer);
+  await page2.fill('input[placeholder="Password"]', PASSWORD);
+  await page2.click('text=Sign Up');
+
+  // Fetch owner's icons from snapshot
+  const res = await page2.request.get(
+    `/api/users/${owner.id}/icons?snapshot=${dateStr}`,
+  );
+  const data = await res.json();
+  expect(data.icons).toContain('⭐');
+  expect(data.icons).not.toContain('❤️');
+  await ctx2.close();
+});
+


### PR DESCRIPTION
## Summary
- ensure icons API returns only icons saved in the requested snapshot
- block editing icons while viewing historical snapshots but allow copying them
- derive icons from snapshot data when explicit icon list is missing

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b03922a0832a8fca33e048d4a493