### PR TITLE
feat: add review page layout

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -123,3 +123,4 @@
 - 2025-10-17: Made My Icons API snapshot-aware and allowed copying historical icons without altering past snapshots.
 - 2025-10-17: Fixed My Icons snapshot views to show historical icons only and block edits while allowing copying to the current library.
 - 2025-10-17: Clicking snapshot icons now opens the owner's full historical icon library with copy prompts.
+- 2025-10-18: Added split review page with rational and guilty pleasure sections and placeholder for AI panel.

--- a/app/(app)/review/page.tsx
+++ b/app/(app)/review/page.tsx
@@ -1,7 +1,18 @@
+import Textarea from '@/components/ui/textarea';
+
 export function ReviewHome() {
   return (
-    <section>
-      <h1 className="text-2xl font-bold">Review</h1>
+    <section className="grid grid-cols-2 gap-4">
+      <div className="pr-4">
+        <h2 className="text-xl font-semibold mb-2">Youre rational</h2>
+        <Textarea placeholder="Type here" />
+        <hr className="my-4" />
+        <h2 className="text-xl font-semibold mb-2">guilty pleasure</h2>
+        <Textarea placeholder="Type here" />
+      </div>
+      <div className="border-l pl-4 flex items-center justify-center text-gray-400">
+        AI features coming soon...
+      </div>
     </section>
   );
 }

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, onInput, ...props }, ref) => {
+    const innerRef = React.useRef<HTMLTextAreaElement>(null);
+    React.useImperativeHandle(
+      ref,
+      () => innerRef.current as HTMLTextAreaElement,
+    );
+
+    const resize = (el: HTMLTextAreaElement) => {
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`;
+    };
+
+    const handleInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+      resize(e.currentTarget);
+      onInput?.(e);
+    };
+
+    React.useEffect(() => {
+      if (innerRef.current) {
+        resize(innerRef.current);
+      }
+    }, []);
+
+    return (
+      <textarea
+        ref={innerRef}
+        onInput={handleInput}
+        className={cn(
+          'w-full min-h-[200px] resize-none overflow-hidden rounded border bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = 'Textarea';
+
+export default Textarea;


### PR DESCRIPTION
## Summary
- add split review page with rational and guilty pleasure text areas and placeholder AI panel
- create auto-resizing textarea component

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d4ded1b8832ab3b1675e6a543894