### PR TITLE
feat: expand review page with view-mode snapshot test

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -123,3 +123,5 @@
 - 2025-10-17: Made My Icons API snapshot-aware and allowed copying historical icons without altering past snapshots.
 - 2025-10-17: Fixed My Icons snapshot views to show historical icons only and block edits while allowing copying to the current library.
 - 2025-10-17: Clicking snapshot icons now opens the owner's full historical icon library with copy prompts.
+- 2025-10-18: Added split review page with rational and guilty pleasure sections and placeholder for AI panel.
+- 2025-10-18: Enlarged review text boxes, enabled independent scrolling, and added read-only viewing with snapshot test.

--- a/app/(app)/review/page.tsx
+++ b/app/(app)/review/page.tsx
@@ -1,7 +1,20 @@
+import Textarea from '@/components/ui/textarea';
+import { useViewContext } from '@/lib/view-context';
+
 export function ReviewHome() {
+  const { editable } = useViewContext();
   return (
-    <section>
-      <h1 className="text-2xl font-bold">Review</h1>
+    <section className="grid h-screen grid-cols-2 gap-4">
+      <div className="h-full overflow-y-auto pr-4">
+        <h2 className="mb-2 text-xl font-semibold">Youre rational</h2>
+        <Textarea placeholder="Type here" disabled={!editable} />
+        <hr className="my-4" />
+        <h2 className="mb-2 text-xl font-semibold">guilty pleasure</h2>
+        <Textarea placeholder="Type here" disabled={!editable} />
+      </div>
+      <div className="h-full overflow-y-auto border-l pl-4 flex items-center justify-center text-gray-400">
+        AI features coming soon...
+      </div>
     </section>
   );
 }

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, onInput, ...props }, ref) => {
+    const innerRef = React.useRef<HTMLTextAreaElement>(null);
+    React.useImperativeHandle(
+      ref,
+      () => innerRef.current as HTMLTextAreaElement,
+    );
+
+    const resize = (el: HTMLTextAreaElement) => {
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`;
+    };
+
+    const handleInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+      resize(e.currentTarget);
+      onInput?.(e);
+    };
+
+    React.useEffect(() => {
+      if (innerRef.current) {
+        resize(innerRef.current);
+      }
+    }, []);
+
+    return (
+      <textarea
+        ref={innerRef}
+        onInput={handleInput}
+        className={cn(
+          'w-full min-h-[600px] resize-none overflow-hidden rounded border bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = 'Textarea';
+
+export default Textarea;

--- a/tests/view-review.spec.ts
+++ b/tests/view-review.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+import { getUserByHandle } from '@/lib/users';
+import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+test('review page snapshot and viewing mode', async ({ page }) => {
+  const handleOwner = unique('owner');
+  const emailOwner = `${handleOwner}@example.com`;
+
+  // sign up owner
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', handleOwner);
+  await page.fill('input[placeholder="Email"]', emailOwner);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  const owner = await getUserByHandle(handleOwner);
+  let snaps = await listProfileSnapshotDates(owner.id);
+  expect(snaps.length).toBe(0);
+
+  // visiting review should create snapshot
+  await page.goto('/review');
+  await page.waitForTimeout(500);
+  snaps = await listProfileSnapshotDates(owner.id);
+  expect(snaps.length).toBeGreaterThan(0);
+
+  // fetch view link for owner
+  await page.goto(`/u/${handleOwner}`);
+  const viewHref = await page.getAttribute('[id^="pr0ovr-view-"]', 'href');
+
+  // sign out
+  await page.click('text=Sign out');
+
+  // sign up viewer
+  const handleViewer = unique('viewer');
+  const emailViewer = `${handleViewer}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Viewer');
+  await page.fill('input[placeholder="Handle"]', handleViewer);
+  await page.fill('input[placeholder="Email"]', emailViewer);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  // navigate to owner's review via view link
+  await page.goto(`${viewHref}/review`);
+  await expect(page).toHaveURL(/\/view\/.*\/review$/);
+  await expect(page.locator('textarea')).toHaveCount(2);
+  await expect(page.locator('textarea')).toBeDisabled();
+});


### PR DESCRIPTION
## Summary
- enlarge review text areas and make each half scroll independently
- disable editing on review page for viewers and capture profile snapshot
- add Playwright spec covering review viewing and snapshot creation

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d4ded1b8832ab3b1675e6a543894