### PR TITLE
feat: expand review textareas with snapshots

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -123,3 +123,5 @@
 - 2025-10-17: Made My Icons API snapshot-aware and allowed copying historical icons without altering past snapshots.
 - 2025-10-17: Fixed My Icons snapshot views to show historical icons only and block edits while allowing copying to the current library.
 - 2025-10-17: Clicking snapshot icons now opens the owner's full historical icon library with copy prompts.
+- 2025-10-18: Added split review page with rational and guilty pleasure sections and placeholder for AI panel.
+- 2025-10-18: Enlarged review text areas, added independent scrolling, and captured review page snapshots with viewer read-only mode.

--- a/app/(app)/review/page.tsx
+++ b/app/(app)/review/page.tsx
@@ -1,7 +1,22 @@
+"use client";
+
+import Textarea from '@/components/ui/textarea';
+import { useViewContext } from '@/lib/view-context';
+
 export function ReviewHome() {
+  const { editable } = useViewContext();
   return (
-    <section>
-      <h1 className="text-2xl font-bold">Review</h1>
+    <section className="grid h-[calc(100vh-2rem)] grid-cols-2 gap-4 overflow-hidden">
+      <div className="flex flex-col overflow-y-auto pr-4">
+        <h2 className="mb-2 text-xl font-semibold">Youre rational</h2>
+        <Textarea placeholder="Type here" disabled={!editable} />
+        <hr className="my-4" />
+        <h2 className="mb-2 text-xl font-semibold">guilty pleasure</h2>
+        <Textarea placeholder="Type here" disabled={!editable} />
+      </div>
+      <div className="flex items-center justify-center overflow-y-auto border-l pl-4 text-gray-400">
+        AI features coming soon...
+      </div>
     </section>
   );
 }

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, onInput, ...props }, ref) => {
+    const innerRef = React.useRef<HTMLTextAreaElement>(null);
+    React.useImperativeHandle(
+      ref,
+      () => innerRef.current as HTMLTextAreaElement,
+    );
+
+    const resize = (el: HTMLTextAreaElement) => {
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight}px`;
+    };
+
+    const handleInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
+      resize(e.currentTarget);
+      onInput?.(e);
+    };
+
+    React.useEffect(() => {
+      if (innerRef.current) {
+        resize(innerRef.current);
+      }
+    }, []);
+
+    return (
+      <textarea
+        ref={innerRef}
+        onInput={handleInput}
+        className={cn(
+          'w-full min-h-[600px] resize-none overflow-hidden rounded border bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = 'Textarea';
+
+export default Textarea;

--- a/tests/review.spec.ts
+++ b/tests/review.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+test('owner review page snapshot', async ({ page }) => {
+  const handle = unique('rev');
+  const email = `${handle}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Tester');
+  await page.fill('input[placeholder="Handle"]', handle);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+  await page.goto('/review');
+  await expect(page).toHaveScreenshot('review-owner.png');
+});
+
+test('viewer review page is read-only', async ({ page }) => {
+  const ownerHandle = unique('owner');
+  const ownerEmail = `${ownerHandle}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', ownerHandle);
+  await page.fill('input[placeholder="Email"]', ownerEmail);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  await page.goto(`/u/${ownerHandle}`);
+  const viewHref = await page.getAttribute('[id^="pr0ovr-view-"]', 'href');
+  await page.click('text=Sign out');
+
+  const viewerHandle = unique('viewer');
+  const viewerEmail = `${viewerHandle}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Viewer');
+  await page.fill('input[placeholder="Handle"]', viewerHandle);
+  await page.fill('input[placeholder="Email"]', viewerEmail);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  await page.goto(`${viewHref}/review`);
+  const tasks = page.locator('textarea');
+  await expect(tasks).toHaveCount(2);
+  await expect(tasks.nth(0)).toBeDisabled();
+  await expect(tasks.nth(1)).toBeDisabled();
+  await expect(page).toHaveScreenshot('review-viewer.png');
+});


### PR DESCRIPTION
## Summary
- enlarge review text areas and make review/AI columns scroll independently
- disable review editing in view mode via context
- add Playwright tests capturing review and viewer read-only snapshots

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test tests/review.spec.ts -- --update-snapshots` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d4ded1b8832ab3b1675e6a543894