### PR TITLE
feat: enable future planning date navigation and snapshots

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -126,3 +126,4 @@
 - 2025-10-18: Added split review page with rational and guilty pleasure sections and placeholder for AI panel.
 - 2025-10-18: Enlarged review text areas, added independent scrolling, and captured review page snapshots with viewer read-only mode.
 - 2025-10-18: Expanded review boxes so guilty pleasure starts below the fold and enforced separate scrollbars for review and AI panes with tests.
+- 2025-10-18: Added future planning date navigation with snapshots preserving historical plans.

--- a/app/(app)/planning/next/date-nav.tsx
+++ b/app/(app)/planning/next/date-nav.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { useViewContext } from '@/lib/view-context';
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr + 'T00:00:00');
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+export default function PlanningDateNav({
+  date,
+  today,
+}: {
+  date: string;
+  today: string;
+}) {
+  const router = useRouter();
+  const ctx = useViewContext();
+  const [showPicker, setShowPicker] = useState(false);
+  const minDate = addDays(today, 1);
+  let base = '';
+  if (ctx.mode === 'owner') {
+    base = '/planning/next';
+  } else if (ctx.mode === 'viewer' && ctx.viewId) {
+    base = `/view/${ctx.viewId}/planning/next`;
+  } else if (ctx.mode === 'historical') {
+    if (ctx.viewerId === ctx.ownerId) {
+      base = `/history/self/${ctx.snapshotDate}/planning/next`;
+    } else if (ctx.viewId) {
+      base = `/history/${ctx.viewId}/${ctx.snapshotDate}/planning/next`;
+    }
+  }
+  function navigate(target: string) {
+    if (!base) return;
+    router.push(`${base}?date=${target}`);
+  }
+  const canNav = base !== '';
+  const label = new Date(date).toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  });
+  return (
+    <div className="mb-2 flex justify-end items-center gap-2">
+      <span className="text-sm">Planning for {label}</span>
+      {canNav && (
+        <>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowPicker((v) => !v)}
+          >
+            Change Date
+          </Button>
+          {showPicker && (
+            <input
+              type="date"
+              className="border p-1 text-sm"
+              value={date}
+              min={minDate}
+              onChange={(e) => navigate(e.target.value)}
+            />
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => navigate(addDays(date, 1))}
+          >
+            {'>'}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => navigate(addDays(date, 7))}
+          >
+            {'>>'}
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -6,6 +6,7 @@ import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { getOrCreatePlan } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from './client';
+import PlanningDateNav from './date-nav';
 
 export const revalidate = 0;
 
@@ -32,6 +33,7 @@ export default async function PlanningNextPage({
   return (
     <>
       {overrideLabel && <TimeOverrideBadge label={overrideLabel} />}
+      <PlanningDateNav date={dateStr} today={todayStr} />
       <EditorClient
         userId={String(me.id)}
         date={dateStr}

--- a/app/(view)/view/[viewId]/planning/next/page.tsx
+++ b/app/(view)/view/[viewId]/planning/next/page.tsx
@@ -5,6 +5,7 @@ import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { getPlanStrict } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from '@/app/(app)/planning/next/client';
+import PlanningDateNav from '@/app/(app)/planning/next/date-nav';
 
 export const revalidate = 0;
 
@@ -33,6 +34,7 @@ export default async function ViewPlanningNextPage({
   return (
     <section id={`v13w-plan-${user.id}`}>
       {overrideLabel && <TimeOverrideBadge label={overrideLabel} />}
+      <PlanningDateNav date={dateStr} today={todayStr} />
       <EditorClient
         userId={String(user.id)}
         date={dateStr}

--- a/app/history/[viewId]/[date]/planning/live/page.tsx
+++ b/app/history/[viewId]/[date]/planning/live/page.tsx
@@ -1,8 +1,8 @@
 import { getUserByViewId } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
-import { getPlanStrict } from '@/lib/plans-store';
-import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
+import { getPlanAt } from '@/lib/plans-store';
+import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
 export const revalidate = 0;
@@ -20,7 +20,8 @@ export default async function HistoryPlanningLive({
   const tz = getUserTimeZone(owner);
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
-  const plan = await getPlanStrict(owner.id, dateStr);
+  const at = addDays(day, 1, tz);
+  const plan = await getPlanAt(owner.id, dateStr, at);
   return (
     <section id={`hist-plan-live-${owner.id}-${date}`}>
       <EditorClient

--- a/app/history/[viewId]/[date]/planning/next/page.tsx
+++ b/app/history/[viewId]/[date]/planning/next/page.tsx
@@ -1,30 +1,42 @@
 import { getUserByViewId } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
-import { getPlanStrict } from '@/lib/plans-store';
+import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
+import PlanningDateNav from '@/app/(app)/planning/next/date-nav';
 
 export const revalidate = 0;
 
 export default async function HistoryPlanningNext({
   params,
+  searchParams,
 }: {
   params: Promise<{ viewId: string; date: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { viewId, date } = await params;
+  const query = searchParams ? await searchParams : undefined;
   const owner = await getUserByViewId(viewId);
   if (!owner) notFound();
   const snapshot = await getProfileSnapshot(owner.id, date);
   if (!snapshot) notFound();
   const tz = getUserTimeZone(owner);
   const day = startOfDay(new Date(date), tz);
-  const next = addDays(day, 1, tz);
-  const dateStr = toYMD(next, tz);
+  const base = addDays(day, 1, tz);
+  let target = base;
+  const raw = Array.isArray(query?.date) ? query?.date[0] : query?.date;
+  if (raw) {
+    const cand = startOfDay(new Date(raw), tz);
+    if (cand.getTime() >= base.getTime()) target = cand;
+  }
+  const dateStr = toYMD(target, tz);
   const todayStr = toYMD(day, tz);
-  const plan = await getPlanStrict(owner.id, dateStr);
+  const at = addDays(day, 1, tz);
+  const plan = await getPlanAt(owner.id, dateStr, at);
   return (
     <section id={`hist-plan-next-${owner.id}-${date}`}>
+      <PlanningDateNav date={dateStr} today={todayStr} />
       <EditorClient
         userId={String(owner.id)}
         date={dateStr}

--- a/app/history/[viewId]/[date]/planning/review/page.tsx
+++ b/app/history/[viewId]/[date]/planning/review/page.tsx
@@ -1,8 +1,8 @@
 import { getUserByViewId } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
-import { getPlanStrict } from '@/lib/plans-store';
-import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
+import { getPlanAt } from '@/lib/plans-store';
+import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
 export const revalidate = 0;
@@ -20,7 +20,8 @@ export default async function HistoryPlanningReview({
   const tz = getUserTimeZone(owner);
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
-  const plan = await getPlanStrict(owner.id, dateStr);
+  const at = addDays(day, 1, tz);
+  const plan = await getPlanAt(owner.id, dateStr, at);
   return (
     <section id={`hist-plan-review-${owner.id}-${date}`}>
       <EditorClient

--- a/app/history/self/[date]/planning/live/page.tsx
+++ b/app/history/self/[date]/planning/live/page.tsx
@@ -2,8 +2,8 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
-import { getPlanStrict } from '@/lib/plans-store';
-import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
+import { getPlanAt } from '@/lib/plans-store';
+import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
 export const revalidate = 0;
@@ -22,7 +22,8 @@ export default async function HistorySelfPlanningLive({
   const tz = getUserTimeZone(me);
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
-  const plan = await getPlanStrict(me.id, dateStr);
+  const at = addDays(day, 1, tz);
+  const plan = await getPlanAt(me.id, dateStr, at);
   return (
     <section id={`hist-self-plan-live-${me.id}-${date}`}>
       <EditorClient

--- a/app/history/self/[date]/planning/next/page.tsx
+++ b/app/history/self/[date]/planning/next/page.tsx
@@ -2,18 +2,22 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
-import { getPlanStrict } from '@/lib/plans-store';
+import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
+import PlanningDateNav from '@/app/(app)/planning/next/date-nav';
 
 export const revalidate = 0;
 
 export default async function HistorySelfPlanningNext({
   params,
+  searchParams,
 }: {
   params: Promise<{ date: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { date } = await params;
+  const query = searchParams ? await searchParams : undefined;
   const session = await auth();
   if (!session) notFound();
   const me = await ensureUser(session);
@@ -21,12 +25,20 @@ export default async function HistorySelfPlanningNext({
   if (!snapshot) notFound();
   const tz = getUserTimeZone(me);
   const day = startOfDay(new Date(date), tz);
-  const next = addDays(day, 1, tz);
-  const dateStr = toYMD(next, tz);
+  const base = addDays(day, 1, tz);
+  let target = base;
+  const raw = Array.isArray(query?.date) ? query?.date[0] : query?.date;
+  if (raw) {
+    const cand = startOfDay(new Date(raw), tz);
+    if (cand.getTime() >= base.getTime()) target = cand;
+  }
+  const dateStr = toYMD(target, tz);
   const todayStr = toYMD(day, tz);
-  const plan = await getPlanStrict(me.id, dateStr);
+  const at = addDays(day, 1, tz);
+  const plan = await getPlanAt(me.id, dateStr, at);
   return (
     <section id={`hist-self-plan-next-${me.id}-${date}`}>
+      <PlanningDateNav date={dateStr} today={todayStr} />
       <EditorClient
         userId={String(me.id)}
         date={dateStr}

--- a/app/history/self/[date]/planning/review/page.tsx
+++ b/app/history/self/[date]/planning/review/page.tsx
@@ -2,8 +2,8 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
-import { getPlanStrict } from '@/lib/plans-store';
-import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
+import { getPlanAt } from '@/lib/plans-store';
+import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
 export const revalidate = 0;
@@ -22,7 +22,8 @@ export default async function HistorySelfPlanningReview({
   const tz = getUserTimeZone(me);
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
-  const plan = await getPlanStrict(me.id, dateStr);
+  const at = addDays(day, 1, tz);
+  const plan = await getPlanAt(me.id, dateStr, at);
   return (
     <section id={`hist-self-plan-review-${me.id}-${date}`}>
       <EditorClient

--- a/drizzle/0013_create_plan_revisions.sql
+++ b/drizzle/0013_create_plan_revisions.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS plan_revisions (
+  id serial PRIMARY KEY,
+  user_id integer REFERENCES users(id) NOT NULL,
+  plan_date date NOT NULL,
+  payload jsonb NOT NULL,
+  snapshot_at timestamp DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS plan_revisions_user_date_snapshot_idx ON plan_revisions(user_id, plan_date, snapshot_at);

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -196,6 +196,16 @@ export const planBlocks = pgTable('plan_blocks', {
   updatedAt: timestamp('updated_at').defaultNow(),
 });
 
+export const planRevisions = pgTable('plan_revisions', {
+  id: serial('id').primaryKey(),
+  userId: integer('user_id')
+    .references(() => users.id)
+    .notNull(),
+  planDate: date('plan_date').notNull(),
+  payload: jsonb('payload').notNull(),
+  snapshotAt: timestamp('snapshot_at').defaultNow(),
+});
+
 export const profileSnapshots = pgTable(
   'profile_snapshots',
   {

--- a/lib/plan-date.ts
+++ b/lib/plan-date.ts
@@ -1,6 +1,11 @@
 import type { ReqInit } from './clock';
 import { getUserTimeZone, getNow, startOfDay, addDays, toYMD } from './clock';
 
+function first(val?: string | string[]): string | undefined {
+  if (Array.isArray(val)) return val[0];
+  return val;
+}
+
 export type PageKind = 'next' | 'live' | 'review';
 
 export function resolvePlanDate(
@@ -12,7 +17,16 @@ export function resolvePlanDate(
   const { now, override } = getNow(tz, req);
   const today = startOfDay(now, tz);
   const tomorrow = addDays(today, 1, tz);
-  const date = kind === 'next' ? tomorrow : today;
+  let date = kind === 'next' ? tomorrow : today;
+  if (kind === 'next') {
+    const raw = first(req?.searchParams?.['date']);
+    if (raw) {
+      const candidate = startOfDay(new Date(raw), tz);
+      if (candidate.getTime() >= tomorrow.getTime()) {
+        date = candidate;
+      }
+    }
+  }
   return { tz, date, today, now, override };
 }
 

--- a/tests/history-plans.spec.ts
+++ b/tests/history-plans.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import { getUserByHandle } from '@/lib/users';
+import { savePlan, getPlanAt } from '@/lib/plans-store';
+import { createProfileSnapshot } from '@/lib/profile-snapshots';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr);
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function iso(dateStr: string, hour: number) {
+  return `${dateStr}T${String(hour).padStart(2, '0')}:00:00`;
+}
+
+test('historical plans keep past versions', async ({ page }) => {
+  const handle = unique('planner');
+  const email = `${handle}@example.com`;
+  const todayStr = today();
+  const future = addDays(todayStr, 8);
+
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Planner');
+  await page.fill('input[placeholder="Handle"]', handle);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  const user = await getUserByHandle(handle);
+  const blocksA = [
+    {
+      start: iso(future, 9),
+      end: iso(future, 10),
+      title: 'Old',
+      description: '',
+      color: '#F87171',
+    },
+  ];
+  await savePlan(String(user.id), future, blocksA);
+  const snapTime = new Date();
+  await createProfileSnapshot(user.id, todayStr);
+  await new Promise((r) => setTimeout(r, 1000));
+  const blocksB = [
+    {
+      start: iso(future, 9),
+      end: iso(future, 10),
+      title: 'New',
+      description: '',
+      color: '#34D399',
+    },
+  ];
+  await savePlan(String(user.id), future, blocksB);
+
+  const plan = await getPlanAt(user.id, future, snapTime);
+  expect(plan.blocks[0]?.title).toBe('Old');
+});


### PR DESCRIPTION
## Summary
- allow selecting and navigating to future planning dates
- preserve plan revisions and render historical snapshots
- add regression test for historical plan snapshots

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a5df9e8850832abc1e76a38255f261