### PR TITLE
feat: allow planning for future dates with history snapshots

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -93,6 +93,7 @@
 - 2025-10-09: Added self historical planning route so owners can review their past plans.
 - 2025-10-10: Expanded historical planning with landing screen and live/next/review pages for full time-capsule viewing.
 - 2025-10-10: Removed live indicator from historical planning and allowed all past reviews to open without time gating.
+- 2025-10-19: Enabled future-date planning with date navigation, added plan snapshots for historical time-capsule viewing, and updated tests.
 - 2025-10-11: Fixed profile snapshot date offset by respecting user timezone and displaying correct days in calendar.
 - 2025-10-11: Corrected ingredient owner validation, awaited search params to silence warnings, and swapped image URL input for preset choices.
 - 2025-10-11: Simplified ingredient image selector to highlight the chosen preset without large preview.

--- a/app/(app)/planning/next/actions.ts
+++ b/app/(app)/planning/next/actions.ts
@@ -5,6 +5,7 @@ import { ensureUser } from '@/lib/users';
 import { assertOwner } from '@/lib/profile';
 import { savePlan } from '@/lib/plans-store';
 import type { PlanBlockInput } from '@/types/plan';
+import { getUserTimeZone, getNow, startOfDay, toYMD } from '@/lib/clock';
 import { revalidatePath } from 'next/cache';
 
 export async function savePlanAction(
@@ -14,7 +15,10 @@ export async function savePlanAction(
   const session = await auth();
   const self = await ensureUser(session);
   await assertOwner(self.id, self.id);
-  const plan = await savePlan(String(self.id), date, blocks);
+  const tz = getUserTimeZone(self);
+  const { now } = getNow(tz);
+  const snap = toYMD(startOfDay(now, tz), tz);
+  const plan = await savePlan(String(self.id), date, blocks, snap);
   revalidatePath('/planning');
   return plan;
 }

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { cookies } from 'next/headers';
 import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { getOrCreatePlan } from '@/lib/plans-store';
+import { startOfDay, addDays } from '@/lib/clock';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from './client';
 
@@ -23,7 +24,14 @@ export default async function PlanningNextPage({
     cookies: cookieStore,
     searchParams: params,
   });
-  const dateStr = toYMD(info.date, info.tz);
+  let target = info.date;
+  const qDate = params?.date;
+  if (qDate && typeof qDate === 'string') {
+    const parsed = startOfDay(new Date(qDate), info.tz);
+    const min = addDays(info.today, 1, info.tz);
+    if (parsed >= min) target = parsed;
+  }
+  const dateStr = toYMD(target, info.tz);
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getOrCreatePlan(me.id, dateStr);
   const overrideLabel = info.override

--- a/app/(view)/view/[viewId]/planning/next/page.tsx
+++ b/app/(view)/view/[viewId]/planning/next/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import { cookies } from 'next/headers';
 import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { getPlanStrict } from '@/lib/plans-store';
+import { startOfDay, addDays } from '@/lib/clock';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from '@/app/(app)/planning/next/client';
 
@@ -24,7 +25,14 @@ export default async function ViewPlanningNextPage({
     cookies: cookieStore,
     searchParams: paramsObj,
   });
-  const dateStr = toYMD(info.date, info.tz);
+  let target = info.date;
+  const qDate = paramsObj?.date;
+  if (qDate && typeof qDate === 'string') {
+    const parsed = startOfDay(new Date(qDate), info.tz);
+    const min = addDays(info.today, 1, info.tz);
+    if (parsed >= min) target = parsed;
+  }
+  const dateStr = toYMD(target, info.tz);
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getPlanStrict(user.id, dateStr);
   const overrideLabel = info.override

--- a/app/history/[viewId]/[date]/planning/live/page.tsx
+++ b/app/history/[viewId]/[date]/planning/live/page.tsx
@@ -1,7 +1,7 @@
 import { getUserByViewId } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
-import { getPlanStrict } from '@/lib/plans-store';
+import { getPlanAtSnapshot } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
@@ -20,7 +20,9 @@ export default async function HistoryPlanningLive({
   const tz = getUserTimeZone(owner);
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
-  const plan = await getPlanStrict(owner.id, dateStr);
+  const plan =
+    (await getPlanAtSnapshot(owner.id, date, dateStr)) ||
+    { id: '', userId: String(owner.id), date: dateStr, blocks: [] };
   return (
     <section id={`hist-plan-live-${owner.id}-${date}`}>
       <EditorClient

--- a/app/history/[viewId]/[date]/planning/next/page.tsx
+++ b/app/history/[viewId]/[date]/planning/next/page.tsx
@@ -1,7 +1,7 @@
 import { getUserByViewId } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
-import { getPlanStrict } from '@/lib/plans-store';
+import { getPlanAtSnapshot } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
@@ -9,20 +9,31 @@ export const revalidate = 0;
 
 export default async function HistoryPlanningNext({
   params,
+  searchParams,
 }: {
   params: Promise<{ viewId: string; date: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { viewId, date } = await params;
+  const sp = searchParams ? await searchParams : undefined;
   const owner = await getUserByViewId(viewId);
   if (!owner) notFound();
   const snapshot = await getProfileSnapshot(owner.id, date);
   if (!snapshot) notFound();
   const tz = getUserTimeZone(owner);
   const day = startOfDay(new Date(date), tz);
-  const next = addDays(day, 1, tz);
-  const dateStr = toYMD(next, tz);
+  const min = addDays(day, 1, tz);
+  let target = min;
+  const qDate = sp?.date;
+  if (qDate && typeof qDate === 'string') {
+    const parsed = startOfDay(new Date(qDate), tz);
+    if (parsed >= min) target = parsed;
+  }
+  const dateStr = toYMD(target, tz);
   const todayStr = toYMD(day, tz);
-  const plan = await getPlanStrict(owner.id, dateStr);
+  const plan =
+    (await getPlanAtSnapshot(owner.id, date, dateStr)) ||
+    { id: '', userId: String(owner.id), date: dateStr, blocks: [] };
   return (
     <section id={`hist-plan-next-${owner.id}-${date}`}>
       <EditorClient

--- a/app/history/[viewId]/[date]/planning/review/page.tsx
+++ b/app/history/[viewId]/[date]/planning/review/page.tsx
@@ -1,7 +1,7 @@
 import { getUserByViewId } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
-import { getPlanStrict } from '@/lib/plans-store';
+import { getPlanAtSnapshot } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
@@ -20,7 +20,9 @@ export default async function HistoryPlanningReview({
   const tz = getUserTimeZone(owner);
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
-  const plan = await getPlanStrict(owner.id, dateStr);
+  const plan =
+    (await getPlanAtSnapshot(owner.id, date, dateStr)) ||
+    { id: '', userId: String(owner.id), date: dateStr, blocks: [] };
   return (
     <section id={`hist-plan-review-${owner.id}-${date}`}>
       <EditorClient

--- a/app/history/self/[date]/planning/live/page.tsx
+++ b/app/history/self/[date]/planning/live/page.tsx
@@ -2,7 +2,7 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
-import { getPlanStrict } from '@/lib/plans-store';
+import { getPlanAtSnapshot } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
@@ -22,7 +22,9 @@ export default async function HistorySelfPlanningLive({
   const tz = getUserTimeZone(me);
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
-  const plan = await getPlanStrict(me.id, dateStr);
+  const plan =
+    (await getPlanAtSnapshot(me.id, date, dateStr)) ||
+    { id: '', userId: String(me.id), date: dateStr, blocks: [] };
   return (
     <section id={`hist-self-plan-live-${me.id}-${date}`}>
       <EditorClient

--- a/app/history/self/[date]/planning/review/page.tsx
+++ b/app/history/self/[date]/planning/review/page.tsx
@@ -2,7 +2,7 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
-import { getPlanStrict } from '@/lib/plans-store';
+import { getPlanAtSnapshot } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
@@ -22,7 +22,9 @@ export default async function HistorySelfPlanningReview({
   const tz = getUserTimeZone(me);
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
-  const plan = await getPlanStrict(me.id, dateStr);
+  const plan =
+    (await getPlanAtSnapshot(me.id, date, dateStr)) ||
+    { id: '', userId: String(me.id), date: dateStr, blocks: [] };
   return (
     <section id={`hist-self-plan-review-${me.id}-${date}`}>
       <EditorClient

--- a/drizzle/0013_add_plan_snapshots.sql
+++ b/drizzle/0013_add_plan_snapshots.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "plan_snapshots" (
+    "id" serial PRIMARY KEY,
+    "user_id" integer NOT NULL REFERENCES "users"("id"),
+    "snapshot_date" date NOT NULL,
+    "plan_date" date NOT NULL,
+    "blocks" jsonb NOT NULL,
+    "created_at" timestamptz DEFAULT now()
+);
+
+CREATE UNIQUE INDEX "plan_snapshots_user_snap_plan_unique"
+ON "plan_snapshots" ("user_id", "snapshot_date", "plan_date");
+

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -214,3 +214,24 @@ export const profileSnapshots = pgTable(
     ),
   }),
 );
+
+export const planSnapshots = pgTable(
+  'plan_snapshots',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    snapshotDate: date('snapshot_date').notNull(),
+    planDate: date('plan_date').notNull(),
+    blocks: jsonb('blocks').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserSnapPlan: uniqueIndex('plan_snapshots_user_snap_plan_unique').on(
+      table.userId,
+      table.snapshotDate,
+      table.planDate,
+    ),
+  }),
+);


### PR DESCRIPTION
## Summary
- add date navigation and selection to next-day planner
- support custom plan dates across view and history routes
- record plan snapshots per day and use them for historical planning views

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a5df9e8850832abc1e76a38255f261