### PR TITLE
fix: persist future plans across days

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -131,3 +131,4 @@
 - 2025-08-20: Blocked selecting dates earlier than tomorrow in next-day planner and fixed single-day advance navigation.
 - 2025-08-20: Corrected next-day planner navigation to parse dates in the user's timezone, redirect past selections, and advance week jumps by seven days.
 - 2025-08-20: Added reverse and reset controls to future planning date navigation and prevented navigation before upcoming planning date.
+- 2025-10-19: Cached future planning edits in local storage and added cross-day persistence test.


### PR DESCRIPTION
## Summary
- cache future planning edits per user/date in local storage so plans persist across day changes
- verify future plan persistence with a new Playwright test

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test tests/planning.spec.ts -g "future plan persists across day change"` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f832d6b4832a94544baf9909277d