### PR TITLE
Respect snapshot creation time for future planning history

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -132,3 +132,4 @@
 - 2025-08-20: Corrected next-day planner navigation to parse dates in the user's timezone, redirect past selections, and advance week jumps by seven days.
 - 2025-08-20: Added reverse and reset controls to future planning date navigation and prevented navigation before upcoming planning date.
 - 2025-10-19: Cached future planning edits in local storage and added cross-day persistence test.
+- 2025-10-20: Snapshot planning pages honor snapshot creation time so later future-plan edits stay hidden; added test verifying live vs historical future planning views.

--- a/app/api/my-icons/route.ts
+++ b/app/api/my-icons/route.ts
@@ -15,7 +15,7 @@ export async function GET(req: NextRequest) {
   let icons: string[];
   if (snapshot) {
     const snap = await getProfileSnapshot(user.id, snapshot);
-    icons = snap ? iconsFromSnapshot(snap) : [];
+    icons = snap ? iconsFromSnapshot(snap.data) : [];
   } else {
     icons = await getMyIcons(user.id);
   }

--- a/app/api/users/[id]/icons/route.ts
+++ b/app/api/users/[id]/icons/route.ts
@@ -5,7 +5,7 @@ import { getProfileSnapshot, iconsFromSnapshot } from '@/lib/profile-snapshots';
 
 export async function GET(
   req: Request,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ) {
   const session = await auth();
   if (!session?.user?.id) {
@@ -21,7 +21,7 @@ export async function GET(
   let icons: string[];
   if (snapshot) {
     const snap = await getProfileSnapshot(userId, snapshot);
-    icons = snap ? iconsFromSnapshot(snap) : [];
+    icons = snap ? iconsFromSnapshot(snap.data) : [];
   } else {
     icons = await listUserIcons(userId);
   }

--- a/app/history/[viewId]/[date]/flavors/[flavorId]/subflavors/page.tsx
+++ b/app/history/[viewId]/[date]/flavors/[flavorId]/subflavors/page.tsx
@@ -21,12 +21,12 @@ export default async function HistoryViewSubflavorsPage({
   const viewer = session ? await ensureUser(session) : null;
   const snapshot = await getProfileSnapshot(owner.id, date);
   if (!snapshot) notFound();
-  const subflavors = (snapshot.subflavors as any[]).filter(
+  const subflavors = (snapshot.data.subflavors as any[]).filter(
     (s) => s.flavorId === flavorId,
   );
-  const flavor = (snapshot.flavors as any[]).find((f) => f.id === flavorId) as
-    | Flavor
-    | undefined;
+  const flavor = (snapshot.data.flavors as any[]).find(
+    (f) => f.id === flavorId,
+  ) as Flavor | undefined;
   if (!flavor) notFound();
   const viewerFlavors = viewer ? await listFlavors(String(viewer.id)) : [];
   return (
@@ -41,4 +41,3 @@ export default async function HistoryViewSubflavorsPage({
     </section>
   );
 }
-

--- a/app/history/[viewId]/[date]/flavors/page.tsx
+++ b/app/history/[viewId]/[date]/flavors/page.tsx
@@ -21,7 +21,7 @@ export default async function HistoryViewFlavorsPage({
       <FlavorsClient
         userId={String(owner.id)}
         selfId={viewer ? String(viewer.id) : undefined}
-        initialFlavors={snapshot.flavors as any}
+        initialFlavors={snapshot.data.flavors as any}
       />
     </section>
   );

--- a/app/history/[viewId]/[date]/planning/live/page.tsx
+++ b/app/history/[viewId]/[date]/planning/live/page.tsx
@@ -2,7 +2,7 @@ import { getUserByViewId } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
-import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
 export const revalidate = 0;
@@ -20,8 +20,7 @@ export default async function HistoryPlanningLive({
   const tz = getUserTimeZone(owner);
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
-  const at = addDays(day, 1, tz);
-  const plan = await getPlanAt(owner.id, dateStr, at);
+  const plan = await getPlanAt(owner.id, dateStr, snapshot.createdAt);
   return (
     <section id={`hist-plan-live-${owner.id}-${date}`}>
       <EditorClient

--- a/app/history/[viewId]/[date]/planning/next/page.tsx
+++ b/app/history/[viewId]/[date]/planning/next/page.tsx
@@ -31,8 +31,7 @@ export default async function HistoryPlanningNext({
   }
   const dateStr = toYMD(target, tz);
   const todayStr = toYMD(day, tz);
-  const at = addDays(day, 1, tz);
-  const plan = await getPlanAt(owner.id, dateStr, at);
+  const plan = await getPlanAt(owner.id, dateStr, snapshot.createdAt);
   return (
     <section id={`hist-plan-next-${owner.id}-${date}`}>
       <EditorClient

--- a/app/history/[viewId]/[date]/planning/review/page.tsx
+++ b/app/history/[viewId]/[date]/planning/review/page.tsx
@@ -2,7 +2,7 @@ import { getUserByViewId } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
-import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
 export const revalidate = 0;
@@ -20,8 +20,7 @@ export default async function HistoryPlanningReview({
   const tz = getUserTimeZone(owner);
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
-  const at = addDays(day, 1, tz);
-  const plan = await getPlanAt(owner.id, dateStr, at);
+  const plan = await getPlanAt(owner.id, dateStr, snapshot.createdAt);
   return (
     <section id={`hist-plan-review-${owner.id}-${date}`}>
       <EditorClient

--- a/app/history/self/[date]/flavors/[flavorId]/subflavors/page.tsx
+++ b/app/history/self/[date]/flavors/[flavorId]/subflavors/page.tsx
@@ -17,12 +17,12 @@ export default async function HistorySubflavorsPage({
   const me = await ensureUser(session);
   const snapshot = await getProfileSnapshot(me.id, date);
   if (!snapshot) notFound();
-  const subflavors = (snapshot.subflavors as any[]).filter(
+  const subflavors = (snapshot.data.subflavors as any[]).filter(
     (s) => s.flavorId === flavorId,
   );
-  const flavor = (snapshot.flavors as any[]).find((f) => f.id === flavorId) as
-    | Flavor
-    | undefined;
+  const flavor = (snapshot.data.flavors as any[]).find(
+    (f) => f.id === flavorId,
+  ) as Flavor | undefined;
   if (!flavor) notFound();
   const myFlavors = await listFlavors(String(me.id));
   return (
@@ -35,4 +35,3 @@ export default async function HistorySubflavorsPage({
     />
   );
 }
-

--- a/app/history/self/[date]/flavors/page.tsx
+++ b/app/history/self/[date]/flavors/page.tsx
@@ -18,7 +18,7 @@ export default async function HistoryFlavorsPage({
     <FlavorsClient
       userId={String(me.id)}
       selfId={String(me.id)}
-      initialFlavors={snapshot.flavors as any}
+      initialFlavors={snapshot.data.flavors as any}
     />
   );
 }

--- a/app/history/self/[date]/planning/live/page.tsx
+++ b/app/history/self/[date]/planning/live/page.tsx
@@ -3,7 +3,7 @@ import { ensureUser } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
-import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
 export const revalidate = 0;
@@ -22,8 +22,7 @@ export default async function HistorySelfPlanningLive({
   const tz = getUserTimeZone(me);
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
-  const at = addDays(day, 1, tz);
-  const plan = await getPlanAt(me.id, dateStr, at);
+  const plan = await getPlanAt(me.id, dateStr, snapshot.createdAt);
   return (
     <section id={`hist-self-plan-live-${me.id}-${date}`}>
       <EditorClient

--- a/app/history/self/[date]/planning/next/page.tsx
+++ b/app/history/self/[date]/planning/next/page.tsx
@@ -33,8 +33,7 @@ export default async function HistorySelfPlanningNext({
   }
   const dateStr = toYMD(target, tz);
   const todayStr = toYMD(day, tz);
-  const at = addDays(day, 1, tz);
-  const plan = await getPlanAt(me.id, dateStr, at);
+  const plan = await getPlanAt(me.id, dateStr, snapshot.createdAt);
   return (
     <section id={`hist-self-plan-next-${me.id}-${date}`}>
       <EditorClient

--- a/app/history/self/[date]/planning/review/page.tsx
+++ b/app/history/self/[date]/planning/review/page.tsx
@@ -3,7 +3,7 @@ import { ensureUser } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
-import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { getUserTimeZone, startOfDay, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
 
 export const revalidate = 0;
@@ -22,8 +22,7 @@ export default async function HistorySelfPlanningReview({
   const tz = getUserTimeZone(me);
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
-  const at = addDays(day, 1, tz);
-  const plan = await getPlanAt(me.id, dateStr, at);
+  const plan = await getPlanAt(me.id, dateStr, snapshot.createdAt);
   return (
     <section id={`hist-self-plan-review-${me.id}-${date}`}>
       <EditorClient

--- a/lib/profile-snapshots.ts
+++ b/lib/profile-snapshots.ts
@@ -75,7 +75,10 @@ export async function listProfileSnapshotDates(
 
 export async function getProfileSnapshot(userId: number, snapshotDate: string) {
   const [row] = await db
-    .select()
+    .select({
+      data: profileSnapshots.data,
+      createdAt: profileSnapshots.createdAt,
+    })
     .from(profileSnapshots)
     .where(
       and(
@@ -83,7 +86,9 @@ export async function getProfileSnapshot(userId: number, snapshotDate: string) {
         eq(profileSnapshots.snapshotDate, snapshotDate),
       ),
     );
-  return row?.data as any;
+  return row
+    ? { data: row.data as any, createdAt: row.createdAt as Date }
+    : null;
 }
 
 // Derive the icon set from a profile snapshot. This helper allows older

--- a/tests/history-future-plans.spec.ts
+++ b/tests/history-future-plans.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+import { getUserByHandle } from '@/lib/users';
+import { savePlan } from '@/lib/plans-store';
+import { createProfileSnapshot } from '@/lib/profile-snapshots';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr);
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function iso(dateStr: string, hour: number) {
+  return `${dateStr}T${String(hour).padStart(2, '0')}:00:00`;
+}
+
+test('live view shows current future plan while history shows snapshot', async ({
+  page,
+  browser,
+}) => {
+  const handleOwner = unique('owner');
+  const emailOwner = `${handleOwner}@example.com`;
+  const todayStr = today();
+  const future = addDays(todayStr, 8);
+
+  // Owner sign up
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', handleOwner);
+  await page.fill('input[placeholder="Email"]', emailOwner);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  const owner = await getUserByHandle(handleOwner);
+  const oldTitle = 'Alpha';
+  const newTitle = 'Beta';
+  await savePlan(String(owner.id), future, [
+    {
+      start: iso(future, 9),
+      end: iso(future, 10),
+      title: oldTitle,
+      description: '',
+      color: '#F87171',
+    },
+  ]);
+
+  await createProfileSnapshot(owner.id, todayStr);
+  await new Promise((r) => setTimeout(r, 1000));
+
+  await savePlan(String(owner.id), future, [
+    {
+      start: iso(future, 9),
+      end: iso(future, 10),
+      title: newTitle,
+      description: '',
+      color: '#34D399',
+    },
+  ]);
+
+  // Viewer sign up
+  const ctx2 = await browser.newContext();
+  const page2 = await ctx2.newPage();
+  const handleViewer = unique('viewer');
+  const emailViewer = `${handleViewer}@example.com`;
+  await page2.goto('/signup');
+  await page2.fill('input[placeholder="Name"]', 'Viewer');
+  await page2.fill('input[placeholder="Handle"]', handleViewer);
+  await page2.fill('input[placeholder="Email"]', emailViewer);
+  await page2.fill('input[placeholder="Password"]', PASSWORD);
+  await page2.click('text=Sign Up');
+
+  // Live view should show updated plan
+  await page2.goto(`/view/${owner.viewId}/planning/next?date=${future}`);
+  await expect(page2.locator(`span:has-text("${newTitle}")`)).toBeVisible();
+
+  // History snapshot should show old plan
+  await page2.goto(
+    `/history/${owner.viewId}/${todayStr}/planning/next?date=${future}`,
+  );
+  await expect(page2.locator(`span:has-text("${oldTitle}")`)).toBeVisible();
+  await expect(page2.locator(`span:has-text("${newTitle}")`)).toHaveCount(0);
+
+  await ctx2.close();
+});


### PR DESCRIPTION
## Summary
- Include `createdAt` in profile snapshots and use it when retrieving historical plans
- Show future plans in history exactly as they were at snapshot time
- Add Playwright test ensuring live views show current plans while snapshots keep past versions

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fe6851f0832a8f2f0da841f77dd4