### PR TITLE
feat: attach ingredients to planning blocks

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -101,6 +101,8 @@ Modal form IDs:
 - `p1an-meta-tms-{blockId}-{ownerId}` → start time input.
 - `p1an-meta-tme-{blockId}-{ownerId}` → end time input.
 - `p1an-meta-del-{ownerId}` → delete block button.
+- `p1an-meta-igrd-{blockId}-{ownerId}` → ingredient tags container.
+- `p1an-meta-igrd-add-{blockId}-{ownerId}` → add ingredient button.
 - `p1an-vibe-{ownerId}` → general day vibe modal.
 - `p1an-vibe-close-{ownerId}` → close general vibe modal.
 
@@ -154,8 +156,10 @@ Modal form IDs:
 - `1ngred-add-import-{ownerId}` → import ingredient option.
 - `1ngred-imp-pre-{ownerId}` → choose preset import option.
 - `1ngred-imp-srch-{ownerId}` → search others import option.
-- `1ngred-pr3-{index}-{ownerId}` → preset selection button.
-- `1ngred-ppl-{userId}-{ownerId}` → person entry in import search.
+  - `1ngred-pr3-{index}-{ownerId}` → preset selection button.
+  - `1ngred-ppl-{userId}-{ownerId}` → person entry in import search.
+  - `igrd-plan-list-{ownerId}` → ingredient picker list when tagging plan blocks.
+  - `igrd-plan-add-{ingredientId}-{ownerId}` → add ingredient to plan button.
 
 ## History Pages
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -136,3 +136,6 @@
 - 2025-10-20: Synced planner state on client-side navigation and fetched historical plans at snapshot time to show exact past versions without refresh.
 - 2025-10-21: Documented missing ID patterns for planning, flavors, subflavors, people lists, and history pages.
 - 2025-10-21: Completed ID catalog with cake and people sections and pruned unused identifiers.
+- 2025-10-21: Added ingredient selection to planning blocks with snapshot support and read-only viewer mode.
+  - 2025-10-22: Introduced dedicated ingredient picker and detail pages for planning, improved icon rendering, and fixed snapshot ingredient errors.
+  - 2025-10-22: Enabled ingredient preview in picker and persisted additions for live and next-day planning.

--- a/app/(app)/ingredient/[id]/page.tsx
+++ b/app/(app)/ingredient/[id]/page.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable @next/next/no-img-element */
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getIngredient } from '@/lib/ingredients-store';
+import { notFound } from 'next/navigation';
+
+function iconSrc(ic: string) {
+  if (ic.startsWith('data:')) return ic;
+  if (/^[A-Za-z0-9+/=]+$/.test(ic)) return `data:image/png;base64,${ic}`;
+  return null;
+}
+
+export default async function IngredientViewPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const ing = await getIngredient(String(me.id), Number(id), me.id);
+  if (!ing) notFound();
+  const src = iconSrc(ing.icon);
+  return (
+    <div className="mx-auto max-w-xl space-y-2 p-4">
+      <h1 className="text-xl font-semibold">Edit ingredient</h1>
+      <div className="flex items-center gap-2">
+        {src ? (
+          <img src={src} alt="" className="h-8 w-8" />
+        ) : (
+          <span className="text-2xl">{ing.icon}</span>
+        )}
+        <span className="font-medium">{ing.title}</span>
+      </div>
+      <p className="text-sm">{ing.shortDescription}</p>
+      <p>Usefulness ({ing.usefulness})</p>
+      <p>What it is: {ing.description}</p>
+      <p>Why used: {ing.whyUsed}</p>
+      <p>When used / situations: {ing.whenUsed}</p>
+      <p>Tips: {ing.tips}</p>
+      <p>Visibility: {ing.visibility}</p>
+    </div>
+  );
+}
+

--- a/app/(app)/ingredientsforplanning/client.tsx
+++ b/app/(app)/ingredientsforplanning/client.tsx
@@ -1,0 +1,67 @@
+'use client';
+/* eslint-disable @next/next/no-img-element */
+
+import { Button } from '@/components/ui/button';
+import { addIngredientAction } from '@/app/(app)/planning/next/actions';
+import type { Ingredient } from '@/types/ingredient';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+
+function iconSrc(ic: string) {
+  if (ic.startsWith('data:')) return ic;
+  if (/^[A-Za-z0-9+/=]+$/.test(ic)) return `data:image/png;base64,${ic}`;
+  return null;
+}
+
+export default function IngredientsForPlanningClient({
+  userId,
+  date,
+  blockId,
+  ingredients,
+  mode,
+}: {
+  userId: string;
+  date: string;
+  blockId: string;
+  ingredients: Ingredient[];
+  mode: 'live' | 'next';
+}) {
+  const router = useRouter();
+  return (
+    <div id={`igrd-plan-list-${userId}`} className="space-y-2 p-4">
+      {ingredients.map((ing) => {
+        const src = iconSrc(ing.icon);
+        return (
+          <div
+            key={ing.id}
+            className="flex items-center justify-between rounded border p-2"
+          >
+            <Link
+              href={`/ingredient/${ing.id}`}
+              className="flex items-center gap-2"
+            >
+              {src ? (
+                <img src={src} alt="" className="h-6 w-6" />
+              ) : (
+                <span>{ing.icon}</span>
+              )}
+              <span>{ing.title}</span>
+            </Link>
+            <Button
+              id={`igrd-plan-add-${ing.id}-${userId}`}
+              className="bg-green-500 text-white"
+              onClick={async () => {
+                await addIngredientAction(date, blockId, String(ing.id), mode);
+                router.push(`/planning/${mode}?date=${date}`);
+              }}
+            >
+              +
+            </Button>
+          </div>
+        );
+      })}
+      {ingredients.length === 0 && <p>No ingredients</p>}
+    </div>
+  );
+}
+

--- a/app/(app)/ingredientsforplanning/page.tsx
+++ b/app/(app)/ingredientsforplanning/page.tsx
@@ -1,0 +1,30 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { listIngredients } from '@/lib/ingredients-store';
+import IngredientsForPlanningClient from './client';
+import { notFound } from 'next/navigation';
+
+export default async function IngredientsForPlanningPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ date?: string; block?: string; mode?: string }>;
+}) {
+  const params = await searchParams;
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const ingredients = await listIngredients(String(me.id), me.id);
+  const date = params?.date || '';
+  const blockId = params?.block || '';
+  const mode = params?.mode === 'live' ? 'live' : 'next';
+  return (
+    <IngredientsForPlanningClient
+      userId={String(me.id)}
+      date={date}
+      blockId={blockId}
+      ingredients={ingredients}
+      mode={mode}
+    />
+  );
+}
+

--- a/app/(app)/planning/live/page.tsx
+++ b/app/(app)/planning/live/page.tsx
@@ -6,6 +6,7 @@ import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { getOrCreatePlan } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from '../next/client';
+import { listIngredients } from '@/lib/ingredients-store';
 
 export const revalidate = 0;
 
@@ -26,6 +27,7 @@ export default async function PlanningLivePage({
   const dateStr = toYMD(info.date, info.tz);
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getOrCreatePlan(me.id, dateStr);
+  const ingredients = await listIngredients(String(me.id), me.id);
   const overrideLabel = info.override
     ? `${info.now.toLocaleString('en-US', { timeZone: info.tz })} (tz: ${info.tz})`
     : null;
@@ -39,6 +41,7 @@ export default async function PlanningLivePage({
         tz={info.tz}
         initialPlan={plan}
         live
+        ingredients={ingredients}
       />
     </>
   );

--- a/app/(app)/planning/next/actions.ts
+++ b/app/(app)/planning/next/actions.ts
@@ -3,7 +3,7 @@
 import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { assertOwner } from '@/lib/profile';
-import { savePlan } from '@/lib/plans-store';
+import { savePlan, getPlanStrict } from '@/lib/plans-store';
 import type { PlanBlockInput } from '@/types/plan';
 import { revalidatePath } from 'next/cache';
 
@@ -17,4 +17,28 @@ export async function savePlanAction(
   const plan = await savePlan(String(self.id), date, blocks);
   revalidatePath('/planning');
   return plan;
+}
+
+export async function addIngredientAction(
+  date: string,
+  blockId: string,
+  ingredientId: string,
+  mode: 'next' | 'live' = 'next',
+) {
+  const session = await auth();
+  const self = await ensureUser(session);
+  await assertOwner(self.id, self.id);
+  const plan = await getPlanStrict(self.id, date);
+  const blocks = plan.blocks.map((b) =>
+    b.id === blockId
+      ? {
+          ...b,
+          ingredientIds: b.ingredientIds.includes(Number(ingredientId))
+            ? b.ingredientIds
+            : [...b.ingredientIds, Number(ingredientId)],
+        }
+      : b,
+  );
+  await savePlan(String(self.id), date, blocks);
+  revalidatePath(`/planning/${mode}`);
 }

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -1,10 +1,13 @@
 'use client';
+/* eslint-disable @next/next/no-img-element */
 
 import { useState, useMemo, useRef, useCallback, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
+import Link from 'next/link';
 import { useViewContext } from '@/lib/view-context';
 import PlanningDateNav from './date-nav';
 import type { Plan, PlanBlock, PlanBlockInput } from '@/types/plan';
+import type { Ingredient } from '@/types/ingredient';
 import { savePlanAction } from './actions';
 
 const COLORS = [
@@ -20,6 +23,12 @@ const COLORS = [
   '#94A3B8',
 ];
 
+function iconSrc(ic: string) {
+  if (ic.startsWith('data:')) return ic;
+  if (/^[A-Za-z0-9+/=]+$/.test(ic)) return `data:image/png;base64,${ic}`;
+  return null;
+}
+
 // shrink timeline so 24h fits on one screen
 const BASE_PIXELS_PER_MINUTE = 0.5;
 const TIMELINE_HEIGHT = 24 * 60 * BASE_PIXELS_PER_MINUTE; // full-day height
@@ -34,6 +43,7 @@ interface Props {
   today: string; // today's date YYYY-MM-DD
   tz: string;
   initialPlan: Plan | null;
+  ingredients?: Ingredient[];
   live?: boolean;
   review?: boolean;
 }
@@ -44,6 +54,7 @@ export default function EditorClient({
   today,
   tz,
   initialPlan,
+  ingredients: initialIngredients = [],
   live = false,
   review = false,
 }: Props) {
@@ -58,12 +69,19 @@ export default function EditorClient({
     if (editable && typeof window !== 'undefined') {
       try {
         const raw = window.localStorage.getItem(storageKey);
-        if (raw) return JSON.parse(raw) as PlanBlock[];
+        if (raw)
+          return (JSON.parse(raw) as PlanBlock[]).map((b) => ({
+            ...b,
+            ingredientIds: b.ingredientIds ?? [],
+          }));
       } catch {
         // ignore malformed data
       }
     }
-    return initialPlan?.blocks ?? [];
+    return (initialPlan?.blocks ?? []).map((b) => ({
+      ...b,
+      ingredientIds: b.ingredientIds ?? [],
+    }));
   });
   const [reviews, setReviews] = useState<
     Record<string, { good: string; bad: string }>
@@ -243,6 +261,14 @@ export default function EditorClient({
     );
   }
 
+  function removeIngredient(blockId: string, ingredientId: number) {
+    const blk = blocks.find((b) => b.id === blockId);
+    if (!blk) return;
+    updateBlock(blockId, {
+      ingredientIds: blk.ingredientIds.filter((id) => id !== ingredientId),
+    });
+  }
+
   function addBlock() {
     if (!editable || review) return;
     const sorted = [...blocks].sort(
@@ -303,6 +329,7 @@ export default function EditorClient({
       title: '',
       description: '',
       color: COLORS[0],
+      ingredientIds: [],
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
@@ -362,6 +389,7 @@ export default function EditorClient({
           title: b.title,
           description: b.description,
           color: b.color,
+          ingredientIds: b.ingredientIds,
         }));
         savePlanAction(date, payload).then((plan) => {
           setBlocks(plan.blocks);
@@ -395,6 +423,7 @@ export default function EditorClient({
             title: b.title,
             description: b.description,
             color: b.color,
+            ingredientIds: b.ingredientIds,
           }));
           void savePlanAction(date, payload).then((plan) => {
             const ser = JSON.stringify(plan.blocks);
@@ -791,7 +820,8 @@ export default function EditorClient({
                     onClick={(e) => {
                       e.stopPropagation();
                       if (draggingRef.current) return;
-                      if (review && live && nowMinute < minutesFromIso(b.end)) return;
+                      if (review && live && nowMinute < minutesFromIso(b.end))
+                        return;
                       setSelectedId(b.id);
                     }}
                   >
@@ -998,6 +1028,59 @@ export default function EditorClient({
                         handleTimeChange(selected.id, 'end', e.target.value)
                       }
                     />
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium">
+                    Ingredients
+                  </label>
+                  <div
+                    id={`p1an-meta-igrd-${selected.id}-${userId}`}
+                    className="mb-2 flex flex-wrap gap-2"
+                  >
+                    {(selected.ingredientIds ?? []).map((iid) => {
+                      const ing = initialIngredients.find((i) => i.id === iid);
+                      const src = ing?.icon ? iconSrc(ing.icon) : null;
+                      return (
+                        <Link
+                          key={iid}
+                          href={`/ingredient/${ing?.id ?? ''}`}
+                          className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 shadow"
+                        >
+                          {src ? (
+                            <img src={src} alt="" className="h-4 w-4" />
+                          ) : (
+                            <span>{ing?.icon ?? '❓'}</span>
+                          )}
+                          <span className="text-sm">
+                            {ing?.title ?? 'Unknown'}
+                          </span>
+                          {editable && (
+                            <span
+                              className="ml-1 cursor-pointer"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                removeIngredient(selected.id, iid);
+                              }}
+                            >
+                              ×
+                            </span>
+                          )}
+                        </Link>
+                      );
+                    })}
+                    {editable && (
+                      <Link
+                        id={`p1an-meta-igrd-add-${selected.id}-${userId}`}
+                        href={`/ingredientsforplanning?date=${date}&block=${selected.id}&mode=${
+                          live ? 'live' : 'next'
+                        }`}
+                        className="rounded bg-green-500 px-2 py-1 text-white"
+                      >
+                        Add ingredients +
+                      </Link>
+                    )}
                   </div>
                 </div>
                 <div className="mt-4 flex gap-2">

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -6,6 +6,7 @@ import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { getOrCreatePlan } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from './client';
+import { listIngredients } from '@/lib/ingredients-store';
 
 export const revalidate = 0;
 
@@ -30,6 +31,7 @@ export default async function PlanningNextPage({
   const dateStr = toYMD(info.date, info.tz);
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getOrCreatePlan(me.id, dateStr);
+  const ingredients = await listIngredients(String(me.id), me.id);
   const overrideLabel = info.override
     ? `${info.now.toLocaleString('en-US', { timeZone: info.tz })} (tz: ${info.tz})`
     : null;
@@ -42,6 +44,7 @@ export default async function PlanningNextPage({
         today={todayStr}
         tz={info.tz}
         initialPlan={plan}
+        ingredients={ingredients}
       />
     </>
   );

--- a/app/(app)/planning/review/page.tsx
+++ b/app/(app)/planning/review/page.tsx
@@ -6,6 +6,7 @@ import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { getPlanStrict } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from '../next/client';
+import { listIngredients } from '@/lib/ingredients-store';
 
 export const revalidate = 0;
 
@@ -26,6 +27,7 @@ export default async function PlanningReviewPage({
   const dateStr = toYMD(info.date, info.tz);
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getPlanStrict(me.id, dateStr);
+  const ingredients = await listIngredients(String(me.id), me.id);
   const overrideLabel = info.override
     ? `${info.now.toLocaleString('en-US', { timeZone: info.tz })} (tz: ${info.tz})`
     : null;
@@ -40,6 +42,7 @@ export default async function PlanningReviewPage({
         initialPlan={plan}
         live
         review
+        ingredients={ingredients}
       />
     </>
   );

--- a/app/(view)/view/[viewId]/planning/live/page.tsx
+++ b/app/(view)/view/[viewId]/planning/live/page.tsx
@@ -5,6 +5,7 @@ import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { getPlanStrict } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from '@/app/(app)/planning/next/client';
+import { listIngredients } from '@/lib/ingredients-store';
 
 export const revalidate = 0;
 
@@ -27,6 +28,7 @@ export default async function ViewPlanningLivePage({
   const dateStr = toYMD(info.date, info.tz);
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getPlanStrict(user.id, dateStr);
+  const ingredients = await listIngredients(String(user.id), null);
   const overrideLabel = info.override
     ? `${info.now.toLocaleString('en-US', { timeZone: info.tz })} (tz: ${info.tz})`
     : null;
@@ -40,6 +42,7 @@ export default async function ViewPlanningLivePage({
         tz={info.tz}
         initialPlan={plan}
         live
+        ingredients={ingredients}
       />
     </section>
   );

--- a/app/(view)/view/[viewId]/planning/next/page.tsx
+++ b/app/(view)/view/[viewId]/planning/next/page.tsx
@@ -5,6 +5,7 @@ import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { getPlanStrict } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from '@/app/(app)/planning/next/client';
+import { listIngredients } from '@/lib/ingredients-store';
 
 export const revalidate = 0;
 
@@ -31,6 +32,7 @@ export default async function ViewPlanningNextPage({
   const dateStr = toYMD(info.date, info.tz);
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getPlanStrict(user.id, dateStr);
+  const ingredients = await listIngredients(String(user.id), null);
   const overrideLabel = info.override
     ? `${info.now.toLocaleString('en-US', { timeZone: info.tz })} (tz: ${info.tz})`
     : null;
@@ -43,6 +45,7 @@ export default async function ViewPlanningNextPage({
         today={todayStr}
         tz={info.tz}
         initialPlan={plan}
+        ingredients={ingredients}
       />
     </section>
   );

--- a/app/(view)/view/[viewId]/planning/review/page.tsx
+++ b/app/(view)/view/[viewId]/planning/review/page.tsx
@@ -5,6 +5,7 @@ import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { getPlanStrict } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from '@/app/(app)/planning/next/client';
+import { listIngredients } from '@/lib/ingredients-store';
 
 export const revalidate = 0;
 
@@ -27,6 +28,7 @@ export default async function ViewPlanningReviewPage({
   const dateStr = toYMD(info.date, info.tz);
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getPlanStrict(user.id, dateStr);
+  const ingredients = await listIngredients(String(user.id), null);
   const overrideLabel = info.override
     ? `${info.now.toLocaleString('en-US', { timeZone: info.tz })} (tz: ${info.tz})`
     : null;
@@ -41,6 +43,7 @@ export default async function ViewPlanningReviewPage({
         initialPlan={plan}
         live
         review
+        ingredients={ingredients}
       />
     </section>
   );

--- a/app/history/[viewId]/[date]/planning/live/page.tsx
+++ b/app/history/[viewId]/[date]/planning/live/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
+import { listIngredients } from '@/lib/ingredients-store';
 
 export const revalidate = 0;
 
@@ -22,6 +23,7 @@ export default async function HistoryPlanningLive({
   const dateStr = toYMD(day, tz);
   const at = snapshot.createdAt ?? addDays(day, 1, tz);
   const plan = await getPlanAt(owner.id, dateStr, at);
+  const ingredients = await listIngredients(String(owner.id), null, at);
   return (
     <section id={`hist-plan-live-${owner.id}-${date}`}>
       <EditorClient
@@ -30,6 +32,7 @@ export default async function HistoryPlanningLive({
         today={dateStr}
         tz={tz}
         initialPlan={plan}
+        ingredients={ingredients}
       />
     </section>
   );

--- a/app/history/[viewId]/[date]/planning/next/page.tsx
+++ b/app/history/[viewId]/[date]/planning/next/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
+import { listIngredients } from '@/lib/ingredients-store';
 
 export const revalidate = 0;
 
@@ -33,6 +34,7 @@ export default async function HistoryPlanningNext({
   const todayStr = toYMD(day, tz);
   const at = snapshot.createdAt ?? addDays(day, 1, tz);
   const plan = await getPlanAt(owner.id, dateStr, at);
+  const ingredients = await listIngredients(String(owner.id), null, at);
   return (
     <section id={`hist-plan-next-${owner.id}-${date}`}>
       <EditorClient
@@ -41,6 +43,7 @@ export default async function HistoryPlanningNext({
         today={todayStr}
         tz={tz}
         initialPlan={plan}
+        ingredients={ingredients}
       />
     </section>
   );

--- a/app/history/[viewId]/[date]/planning/review/page.tsx
+++ b/app/history/[viewId]/[date]/planning/review/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
+import { listIngredients } from '@/lib/ingredients-store';
 
 export const revalidate = 0;
 
@@ -22,6 +23,7 @@ export default async function HistoryPlanningReview({
   const dateStr = toYMD(day, tz);
   const at = snapshot.createdAt ?? addDays(day, 1, tz);
   const plan = await getPlanAt(owner.id, dateStr, at);
+  const ingredients = await listIngredients(String(owner.id), null, at);
   return (
     <section id={`hist-plan-review-${owner.id}-${date}`}>
       <EditorClient
@@ -31,6 +33,7 @@ export default async function HistoryPlanningReview({
         tz={tz}
         initialPlan={plan}
         review
+        ingredients={ingredients}
       />
     </section>
   );

--- a/app/history/self/[date]/planning/live/page.tsx
+++ b/app/history/self/[date]/planning/live/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
+import { listIngredients } from '@/lib/ingredients-store';
 
 export const revalidate = 0;
 
@@ -24,6 +25,7 @@ export default async function HistorySelfPlanningLive({
   const dateStr = toYMD(day, tz);
   const at = snapshot.createdAt ?? addDays(day, 1, tz);
   const plan = await getPlanAt(me.id, dateStr, at);
+  const ingredients = await listIngredients(String(me.id), me.id, at);
   return (
     <section id={`hist-self-plan-live-${me.id}-${date}`}>
       <EditorClient
@@ -32,6 +34,7 @@ export default async function HistorySelfPlanningLive({
         today={dateStr}
         tz={tz}
         initialPlan={plan}
+        ingredients={ingredients}
       />
     </section>
   );

--- a/app/history/self/[date]/planning/next/page.tsx
+++ b/app/history/self/[date]/planning/next/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
+import { listIngredients } from '@/lib/ingredients-store';
 
 export const revalidate = 0;
 
@@ -35,6 +36,7 @@ export default async function HistorySelfPlanningNext({
   const todayStr = toYMD(day, tz);
   const at = snapshot.createdAt ?? addDays(day, 1, tz);
   const plan = await getPlanAt(me.id, dateStr, at);
+  const ingredients = await listIngredients(String(me.id), me.id, at);
   return (
     <section id={`hist-self-plan-next-${me.id}-${date}`}>
       <EditorClient
@@ -43,6 +45,7 @@ export default async function HistorySelfPlanningNext({
         today={todayStr}
         tz={tz}
         initialPlan={plan}
+        ingredients={ingredients}
       />
     </section>
   );

--- a/app/history/self/[date]/planning/review/page.tsx
+++ b/app/history/self/[date]/planning/review/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
 import EditorClient from '@/app/(app)/planning/next/client';
+import { listIngredients } from '@/lib/ingredients-store';
 
 export const revalidate = 0;
 
@@ -24,6 +25,7 @@ export default async function HistorySelfPlanningReview({
   const dateStr = toYMD(day, tz);
   const at = snapshot.createdAt ?? addDays(day, 1, tz);
   const plan = await getPlanAt(me.id, dateStr, at);
+  const ingredients = await listIngredients(String(me.id), me.id, at);
   return (
     <section id={`hist-self-plan-review-${me.id}-${date}`}>
       <EditorClient
@@ -33,6 +35,7 @@ export default async function HistorySelfPlanningReview({
         tz={tz}
         initialPlan={plan}
         review
+        ingredients={ingredients}
       />
     </section>
   );

--- a/drizzle/0014_add_plan_block_ingredients.sql
+++ b/drizzle/0014_add_plan_block_ingredients.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "plan_blocks" ADD COLUMN "ingredient_ids" integer[];

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -192,6 +192,7 @@ export const planBlocks = pgTable('plan_blocks', {
   title: varchar('title', { length: 60 }),
   description: text('description'),
   color: varchar('color', { length: 10 }),
+  ingredientIds: integer('ingredient_ids').array(),
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),
 });

--- a/lib/plans-store.ts
+++ b/lib/plans-store.ts
@@ -12,6 +12,7 @@ function toPlanBlock(row: typeof planBlocks.$inferSelect): PlanBlock {
     title: row.title ?? '',
     description: row.description ?? '',
     color: row.color ?? '#888888',
+    ingredientIds: row.ingredientIds ?? [],
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
     updatedAt: row.updatedAt?.toISOString() ?? new Date().toISOString(),
   };
@@ -82,11 +83,15 @@ export async function getPlanAt(
     .orderBy(desc(planRevisions.snapshotAt))
     .limit(1);
   if (rev) {
+    const blocks = ((rev.payload as any).blocks as PlanBlock[]) || [];
     return {
       id: '',
       userId: String(userId),
       date,
-      blocks: ((rev.payload as any).blocks as PlanBlock[]) || [],
+      blocks: blocks.map((b) => ({
+        ...b,
+        ingredientIds: b.ingredientIds ?? [],
+      })),
     };
   }
   // When no revision exists at or before the requested time, the user had not
@@ -129,6 +134,7 @@ export async function savePlan(
           title: blk.title.slice(0, 60),
           description: blk.description.slice(0, 500),
           color: blk.color,
+          ingredientIds: blk.ingredientIds,
           updatedAt: now,
         })
         .where(eq(planBlocks.id, blk.id))
@@ -147,6 +153,7 @@ export async function savePlan(
           title: blk.title.slice(0, 60),
           description: blk.description.slice(0, 500),
           color: blk.color,
+          ingredientIds: blk.ingredientIds,
           createdAt: now,
           updatedAt: now,
         })

--- a/tests/history-plans.spec.ts
+++ b/tests/history-plans.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { getUserByHandle } from '@/lib/users';
 import { savePlan, getPlanAt } from '@/lib/plans-store';
-import { createProfileSnapshot, getProfileSnapshot } from '@/lib/profile-snapshots';
+import {
+  createProfileSnapshot,
+  getProfileSnapshot,
+} from '@/lib/profile-snapshots';
 
 const PASSWORD = 'pass1234';
 
@@ -44,6 +47,7 @@ test('historical plans keep past versions', async ({ page }) => {
       title: 'Old',
       description: '',
       color: '#F87171',
+      ingredientIds: [],
     },
   ];
   await savePlan(String(user.id), future, blocksA);
@@ -58,6 +62,7 @@ test('historical plans keep past versions', async ({ page }) => {
       title: 'New',
       description: '',
       color: '#34D399',
+      ingredientIds: [],
     },
   ];
   await savePlan(String(user.id), future, blocksB);
@@ -92,6 +97,7 @@ test('plans added after snapshot are hidden from past snapshots', async ({
       title: 'Future',
       description: '',
       color: '#FBBF24',
+      ingredientIds: [],
     },
   ];
   await savePlan(String(user.id), future, blocks);

--- a/types/plan.ts
+++ b/types/plan.ts
@@ -9,10 +9,11 @@ export interface PlanBlock {
   id: string;
   planId: string;
   start: string; // ISO datetime
-  end: string;   // ISO datetime
+  end: string; // ISO datetime
   title: string;
   description: string;
   color: string;
+  ingredientIds: number[];
   createdAt: string;
   updatedAt: string;
 }
@@ -24,4 +25,5 @@ export interface PlanBlockInput {
   title: string;
   description: string;
   color: string;
+  ingredientIds: number[];
 }


### PR DESCRIPTION
## Summary
- replace ingredient + icon with "Add ingredients +" link that opens a dedicated picker page
- add read-only ingredient picker and detail view pages to simplify selecting and inspecting ingredients
- render ingredient icons correctly and handle missing historical ingredient data
- allow ingredient preview before tagging and persist additions for live and next-day planning

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ce1d6e3c832aa99590b292217795