### PR TITLE
feat: add daily aim to planning

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -106,6 +106,12 @@ Modal form IDs:
 - `p1an-meta-igrd-none-{blockId}-{ownerId}` → ingredient empty state text.
 - `p1an-vibe-{ownerId}` → general day vibe modal.
 - `p1an-vibe-close-{ownerId}` → close general vibe modal.
+- `p1an-daily-aim-{ownerId}` → open Daily Aim modal.
+- `p1an-day-aim-{ownerId}` → Daily Aim textarea.
+- `p1an-day-igrd-{ownerId}` → Daily ingredients tag container.
+- `p1an-day-igrd-none-{ownerId}` → Daily ingredients empty state text.
+- `p1an-day-add-{ownerId}` → add daily ingredient button.
+- `p1an-day-close-{ownerId}` → close Daily Aim modal.
 
 ## People
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -141,3 +141,4 @@
 - 2025-10-22: Enabled previewing ingredients before attaching and ensured ingredient additions persist for live and next planning.
 - 2025-10-23: Softened add-ingredient pill, added back buttons to picker and detail pages, and allowed viewers to open ingredient details without 404s.
 - 2025-10-23: Display "No ingredient found" placeholders and label hidden ingredients as "Secret 🔒".
+- 2025-10-24: Introduced Daily Aim modal with daily ingredients on planning pages and saved values in plan snapshots.

--- a/app/(app)/ingredientsforplanning/client.tsx
+++ b/app/(app)/ingredientsforplanning/client.tsx
@@ -56,21 +56,49 @@ export default function IngredientsForPlanningClient({
               id={`igrd-plan-add-${ing.id}-${userId}`}
               className="bg-green-500 px-3 text-xl text-white"
               onClick={async () => {
-                await addIngredientAction(date, blockId, String(ing.id)).catch(() => {});
+                await addIngredientAction(date, blockId, String(ing.id)).catch(
+                  () => {},
+                );
                 try {
                   const raw = window.localStorage.getItem(storageKey);
-                  const blocks: PlanBlock[] = raw ? JSON.parse(raw) : [];
-                  const updated = blocks.map((b) =>
-                    b.id === blockId
-                      ? {
-                          ...b,
-                          ingredientIds: b.ingredientIds?.includes(Number(ing.id))
-                            ? b.ingredientIds
-                            : [...(b.ingredientIds ?? []), Number(ing.id)],
-                        }
-                      : b,
+                  let data: {
+                    blocks: PlanBlock[];
+                    dailyAim?: string;
+                    dailyIngredientIds?: number[];
+                  } = { blocks: [] };
+                  if (raw) {
+                    const parsed = JSON.parse(raw);
+                    data = Array.isArray(parsed)
+                      ? { blocks: parsed }
+                      : parsed;
+                  }
+                  if (blockId === 'day') {
+                    data.dailyIngredientIds = (
+                      data.dailyIngredientIds || []
+                    ).includes(Number(ing.id))
+                      ? data.dailyIngredientIds || []
+                      : [...(data.dailyIngredientIds || []), Number(ing.id)];
+                  } else {
+                    data.blocks = data.blocks.map((b) =>
+                      b.id === blockId
+                        ? {
+                            ...b,
+                            ingredientIds: b.ingredientIds?.includes(
+                              Number(ing.id),
+                            )
+                              ? b.ingredientIds
+                              : [
+                                  ...(b.ingredientIds ?? []),
+                                  Number(ing.id),
+                                ],
+                          }
+                        : b,
+                    );
+                  }
+                  window.localStorage.setItem(
+                    storageKey,
+                    JSON.stringify(data),
                   );
-                  window.localStorage.setItem(storageKey, JSON.stringify(updated));
                 } catch {
                   // ignore
                 }

--- a/drizzle/0015_add_plan_daily_aim.sql
+++ b/drizzle/0015_add_plan_daily_aim.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "plans" ADD COLUMN "daily_aim" text;
+ALTER TABLE "plans" ADD COLUMN "daily_ingredient_ids" integer[];

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -171,6 +171,8 @@ export const plans = pgTable(
       .references(() => users.id)
       .notNull(),
     date: date('date').notNull(),
+    dailyAim: text('daily_aim'),
+    dailyIngredientIds: integer('daily_ingredient_ids').array(),
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').defaultNow(),
   },

--- a/types/plan.ts
+++ b/types/plan.ts
@@ -3,6 +3,8 @@ export interface Plan {
   userId: string;
   date: string; // ISO date YYYY-MM-DD
   blocks: PlanBlock[];
+  dailyAim: string;
+  dailyIngredientIds: number[];
 }
 
 export interface PlanBlock {


### PR DESCRIPTION
## Summary
- add Daily Aim modal with per-day ingredients on planning pages
- persist daily aim and ingredients in plans and snapshots
- support daily ingredient picker and ID catalog entries

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e43faea4832ab683d2848364916d