### PR TITLE
feat: add daily aim to planning

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -106,6 +106,12 @@ Modal form IDs:
 - `p1an-meta-igrd-none-{blockId}-{ownerId}` → ingredient empty state text.
 - `p1an-vibe-{ownerId}` → general day vibe modal.
 - `p1an-vibe-close-{ownerId}` → close general vibe modal.
+- `p1an-daily-aim-{ownerId}` → open Daily Aim modal.
+- `p1an-day-aim-{ownerId}` → Daily Aim textarea.
+- `p1an-day-igrd-{ownerId}` → Daily ingredients tag container.
+- `p1an-day-igrd-none-{ownerId}` → Daily ingredients empty state text.
+- `p1an-day-add-{ownerId}` → add daily ingredient button.
+- `p1an-day-close-{ownerId}` → close Daily Aim modal.
 
 ## People
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -141,3 +141,6 @@
 - 2025-10-22: Enabled previewing ingredients before attaching and ensured ingredient additions persist for live and next planning.
 - 2025-10-23: Softened add-ingredient pill, added back buttons to picker and detail pages, and allowed viewers to open ingredient details without 404s.
 - 2025-10-23: Display "No ingredient found" placeholders and label hidden ingredients as "Secret 🔒".
+- 2025-10-24: Introduced Daily Aim modal with daily ingredients on planning pages and saved values in plan snapshots.
+- 2025-10-24: Ensured Daily Aim is stored per day, remounting planners on date changes and
+highlighting the Daily Aim button red when empty and green when filled.

--- a/app/(app)/ingredientsforplanning/client.tsx
+++ b/app/(app)/ingredientsforplanning/client.tsx
@@ -56,21 +56,49 @@ export default function IngredientsForPlanningClient({
               id={`igrd-plan-add-${ing.id}-${userId}`}
               className="bg-green-500 px-3 text-xl text-white"
               onClick={async () => {
-                await addIngredientAction(date, blockId, String(ing.id)).catch(() => {});
+                await addIngredientAction(date, blockId, String(ing.id)).catch(
+                  () => {},
+                );
                 try {
                   const raw = window.localStorage.getItem(storageKey);
-                  const blocks: PlanBlock[] = raw ? JSON.parse(raw) : [];
-                  const updated = blocks.map((b) =>
-                    b.id === blockId
-                      ? {
-                          ...b,
-                          ingredientIds: b.ingredientIds?.includes(Number(ing.id))
-                            ? b.ingredientIds
-                            : [...(b.ingredientIds ?? []), Number(ing.id)],
-                        }
-                      : b,
+                  let data: {
+                    blocks: PlanBlock[];
+                    dailyAim?: string;
+                    dailyIngredientIds?: number[];
+                  } = { blocks: [] };
+                  if (raw) {
+                    const parsed = JSON.parse(raw);
+                    data = Array.isArray(parsed)
+                      ? { blocks: parsed }
+                      : parsed;
+                  }
+                  if (blockId === 'day') {
+                    data.dailyIngredientIds = (
+                      data.dailyIngredientIds || []
+                    ).includes(Number(ing.id))
+                      ? data.dailyIngredientIds || []
+                      : [...(data.dailyIngredientIds || []), Number(ing.id)];
+                  } else {
+                    data.blocks = data.blocks.map((b) =>
+                      b.id === blockId
+                        ? {
+                            ...b,
+                            ingredientIds: b.ingredientIds?.includes(
+                              Number(ing.id),
+                            )
+                              ? b.ingredientIds
+                              : [
+                                  ...(b.ingredientIds ?? []),
+                                  Number(ing.id),
+                                ],
+                          }
+                        : b,
+                    );
+                  }
+                  window.localStorage.setItem(
+                    storageKey,
+                    JSON.stringify(data),
                   );
-                  window.localStorage.setItem(storageKey, JSON.stringify(updated));
                 } catch {
                   // ignore
                 }

--- a/app/(app)/planning/live/page.tsx
+++ b/app/(app)/planning/live/page.tsx
@@ -35,6 +35,7 @@ export default async function PlanningLivePage({
     <>
       {overrideLabel && <TimeOverrideBadge label={overrideLabel} />}
       <EditorClient
+        key={dateStr}
         userId={String(me.id)}
         date={dateStr}
         today={todayStr}

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -84,6 +84,11 @@ export default function EditorClient({
       ingredientIds: b.ingredientIds ?? [],
     }));
   });
+  const [dailyAim, setDailyAim] = useState(() => initialPlan?.dailyAim ?? '');
+  const [dailyIngredientIds, setDailyIngredientIds] = useState<number[]>(
+    () => initialPlan?.dailyIngredientIds ?? [],
+  );
+  const [showDailyAim, setShowDailyAim] = useState(false);
   const [reviews, setReviews] = useState<
     Record<string, { good: string; bad: string }>
   >(() => {
@@ -270,6 +275,10 @@ export default function EditorClient({
     });
   }
 
+  function removeDailyIngredient(ingredientId: number) {
+    setDailyIngredientIds((ids) => ids.filter((id) => id !== ingredientId));
+  }
+
   function addBlock() {
     if (!editable || review) return;
     const sorted = [...blocks].sort(
@@ -338,30 +347,60 @@ export default function EditorClient({
     setSelectedId(id);
   }
 
-  const lastSaved = useRef(JSON.stringify(blocks));
+  const lastSaved = useRef(
+    JSON.stringify({ blocks, dailyAim, dailyIngredientIds }),
+  );
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const blocksRef = useRef(blocks);
+  const dailyAimRef = useRef(dailyAim);
+  const dailyIngredientIdsRef = useRef(dailyIngredientIds);
   useEffect(() => {
     blocksRef.current = blocks;
   }, [blocks]);
+  useEffect(() => {
+    dailyAimRef.current = dailyAim;
+  }, [dailyAim]);
+  useEffect(() => {
+    dailyIngredientIdsRef.current = dailyIngredientIds;
+  }, [dailyIngredientIds]);
 
   // When navigating between dates or users, refresh the block list so it
   // matches the server-provided plan (or cached local copy) without requiring
   // a full page reload.
   useEffect(() => {
-    let fromStorage: PlanBlock[] | null = null;
+    let fromStorage: {
+      blocks?: PlanBlock[];
+      dailyAim?: string;
+      dailyIngredientIds?: number[];
+    } | null = null;
     if (editable && typeof window !== 'undefined') {
       try {
         const raw = window.localStorage.getItem(storageKey);
-        if (raw) fromStorage = JSON.parse(raw) as PlanBlock[];
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          fromStorage = Array.isArray(parsed)
+            ? { blocks: parsed }
+            : parsed;
+        }
       } catch {
         // ignore malformed data
       }
     }
-    const next = fromStorage ?? initialPlan?.blocks ?? [];
-    const serialized = JSON.stringify(next);
+    const nextBlocks = fromStorage?.blocks ?? initialPlan?.blocks ?? [];
+    const nextAim = fromStorage?.dailyAim ?? initialPlan?.dailyAim ?? '';
+    const nextIng =
+      fromStorage?.dailyIngredientIds ??
+      initialPlan?.dailyIngredientIds ??
+      [];
+    const serialized = JSON.stringify({
+      blocks: nextBlocks,
+      dailyAim: nextAim,
+      dailyIngredientIds: nextIng,
+    });
     if (serialized !== lastSaved.current) {
-      setBlocks(next);
+      setBlocks(nextBlocks);
+      setDailyAim(nextAim);
+      setDailyIngredientIds(nextIng);
       lastSaved.current = serialized;
     }
     if (editable && !fromStorage) {
@@ -371,19 +410,64 @@ export default function EditorClient({
         // ignore write errors
       }
     }
-  }, [editable, storageKey, initialPlan]);
+  }, [editable, storageKey, initialPlan, date]);
 
   useEffect(() => {
     if (!editable || review) return;
-    const serialized = JSON.stringify(blocks);
+    const serialized = JSON.stringify({
+      blocks,
+      dailyAim,
+      dailyIngredientIds,
+    });
     if (serialized === lastSaved.current) return;
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(() => {
-      if (live) {
-        window.localStorage.setItem(storageKey, serialized);
-        lastSaved.current = serialized;
-      } else {
-        const payload: PlanBlockInput[] = blocks.map((b) => ({
+      const payload: PlanBlockInput[] = blocks.map((b) => ({
+        id: b.id,
+        start: b.start,
+        end: b.end,
+        title: b.title,
+        description: b.description,
+        color: b.color,
+        ingredientIds: b.ingredientIds,
+      }));
+      savePlanAction(date, payload, dailyAim, dailyIngredientIds).then(
+        (plan) => {
+          setBlocks(plan.blocks);
+          setDailyAim(plan.dailyAim);
+          setDailyIngredientIds(plan.dailyIngredientIds);
+          const ser = JSON.stringify({
+            blocks: plan.blocks,
+            dailyAim: plan.dailyAim,
+            dailyIngredientIds: plan.dailyIngredientIds,
+          });
+          lastSaved.current = ser;
+          try {
+            window.localStorage.setItem(storageKey, ser);
+          } catch {
+            // ignore write errors
+          }
+        },
+      );
+      saveTimer.current = null;
+    }, 500);
+  }, [
+    blocks,
+    dailyAim,
+    dailyIngredientIds,
+    date,
+    editable,
+    live,
+    storageKey,
+    review,
+  ]);
+
+  useEffect(() => {
+    if (!editable || review) return;
+    return () => {
+      if (saveTimer.current) {
+        clearTimeout(saveTimer.current);
+        const payload: PlanBlockInput[] = blocksRef.current.map((b) => ({
           id: b.id,
           start: b.start,
           end: b.end,
@@ -392,9 +476,17 @@ export default function EditorClient({
           color: b.color,
           ingredientIds: b.ingredientIds,
         }));
-        savePlanAction(date, payload).then((plan) => {
-          setBlocks(plan.blocks);
-          const ser = JSON.stringify(plan.blocks);
+        void savePlanAction(
+          date,
+          payload,
+          dailyAimRef.current,
+          dailyIngredientIdsRef.current,
+        ).then((plan) => {
+          const ser = JSON.stringify({
+            blocks: plan.blocks,
+            dailyAim: plan.dailyAim,
+            dailyIngredientIds: plan.dailyIngredientIds,
+          });
           lastSaved.current = ser;
           try {
             window.localStorage.setItem(storageKey, ser);
@@ -403,42 +495,8 @@ export default function EditorClient({
           }
         });
       }
-      saveTimer.current = null;
-    }, 500);
-  }, [blocks, date, editable, live, storageKey, review]);
-
-  useEffect(() => {
-    if (!editable || review) return;
-    return () => {
-      if (saveTimer.current) {
-        clearTimeout(saveTimer.current);
-        if (live) {
-          const serialized = JSON.stringify(blocksRef.current);
-          window.localStorage.setItem(storageKey, serialized);
-          lastSaved.current = serialized;
-        } else {
-          const payload: PlanBlockInput[] = blocksRef.current.map((b) => ({
-            id: b.id,
-            start: b.start,
-            end: b.end,
-            title: b.title,
-            description: b.description,
-            color: b.color,
-            ingredientIds: b.ingredientIds,
-          }));
-          void savePlanAction(date, payload).then((plan) => {
-            const ser = JSON.stringify(plan.blocks);
-            lastSaved.current = ser;
-            try {
-              window.localStorage.setItem(storageKey, ser);
-            } catch {
-              // ignore write errors
-            }
-          });
-        }
-      }
     };
-  }, [date, editable, live, storageKey, review]);
+  }, [date, editable, storageKey, review]);
 
   function handleTimeChange(id: string, field: 'start' | 'end', value: string) {
     if (review) return;
@@ -601,7 +659,7 @@ export default function EditorClient({
           onPointerDown={() => setSelectedId(null)}
         >
           <div
-            className="sticky top-0 z-10 flex flex-wrap items-center gap-2 bg-gray-100 p-2 text-sm"
+            className="sticky top-0 z-10 flex flex-wrap items-end gap-2 bg-gray-100 p-2 text-sm"
             onClick={(e) => e.stopPropagation()}
           >
             {review ? (
@@ -669,6 +727,17 @@ export default function EditorClient({
                 Load later
               </button>
             )}
+            <button
+              id={`p1an-daily-aim-${userId}`}
+              className={`rounded border px-3 py-2 ${
+                dailyAim
+                  ? 'border-green-300 bg-green-50 text-green-600'
+                  : 'border-red-300 bg-red-50 text-red-600'
+              }`}
+              onClick={() => setShowDailyAim(true)}
+            >
+              Daily Aim
+            </button>
             {(startMinute !== DEFAULT_START || endMinute !== DEFAULT_END) && (
               <button
                 id={`p1an-close-range-${userId}`}
@@ -1151,6 +1220,94 @@ export default function EditorClient({
                 variant="outline"
                 id={`p1an-vibe-close-${userId}`}
                 onClick={() => setShowVibe(false)}
+              >
+                Close
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+      {showDailyAim && (
+        <div
+          className="fixed inset-0 z-[1000000] flex items-center justify-center bg-black/50 backdrop-blur"
+          onClick={() => setShowDailyAim(false)}
+        >
+          <div
+            className="w-96 max-w-full rounded bg-white p-4 shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="mb-2 text-lg font-semibold">Daily Aim</h2>
+            <textarea
+              id={`p1an-day-aim-${userId}`}
+              className="mb-4 w-full border p-1"
+              value={dailyAim}
+              onChange={(e) => setDailyAim(e.target.value)}
+              rows={3}
+              maxLength={500}
+              disabled={!editable}
+            />
+            <div className="mb-2">
+              <span className="block text-sm font-medium">Daily ingredients</span>
+              <div
+                id={`p1an-day-igrd-${userId}`}
+                className="mb-2 flex flex-wrap gap-2"
+              >
+                {dailyIngredientIds.length === 0 && (
+                  <span
+                    id={`p1an-day-igrd-none-${userId}`}
+                    className="text-sm text-gray-500"
+                  >
+                    No ingredient found
+                  </span>
+                )}
+                {dailyIngredientIds.map((iid) => {
+                  const ing = initialIngredients.find((i) => i.id === iid);
+                  const src = ing?.icon ? iconSrc(ing.icon) : null;
+                  return (
+                    <Link
+                      key={iid}
+                      id={`p1an-day-igrd-${iid}-${userId}`}
+                      href={
+                        viewId
+                          ? `/view/${viewId}/ingredient/${ing?.id ?? ''}`
+                          : `/ingredient/${ing?.id ?? ''}`
+                      }
+                      className="flex items-center gap-1 rounded border px-2 py-1"
+                    >
+                      {src ? (
+                        <img src={src} alt="" className="h-4 w-4" />
+                      ) : (
+                        <span>{ing?.icon}</span>
+                      )}
+                      <span className="text-sm">{ing?.title}</span>
+                      {editable && (
+                        <button
+                          type="button"
+                          className="ml-1 text-xs text-red-500"
+                          onClick={() => removeDailyIngredient(iid)}
+                        >
+                          X
+                        </button>
+                      )}
+                    </Link>
+                  );
+                })}
+              </div>
+              {editable && (
+                <Link
+                  id={`p1an-day-add-${userId}`}
+                  href={`/ingredientsforplanning?date=${date}&block=day&mode=${mode}`}
+                  className="rounded border px-2 py-1 text-sm"
+                >
+                  Add ingredients +
+                </Link>
+              )}
+            </div>
+            <div className="mt-2 text-right">
+              <Button
+                variant="outline"
+                id={`p1an-day-close-${userId}`}
+                onClick={() => setShowDailyAim(false)}
               >
                 Close
               </Button>

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -39,6 +39,7 @@ export default async function PlanningNextPage({
     <>
       {overrideLabel && <TimeOverrideBadge label={overrideLabel} />}
       <EditorClient
+        key={dateStr}
         userId={String(me.id)}
         date={dateStr}
         today={todayStr}

--- a/app/(app)/planning/review/page.tsx
+++ b/app/(app)/planning/review/page.tsx
@@ -35,6 +35,7 @@ export default async function PlanningReviewPage({
     <>
       {overrideLabel && <TimeOverrideBadge label={overrideLabel} />}
       <EditorClient
+        key={dateStr}
         userId={String(me.id)}
         date={dateStr}
         today={todayStr}

--- a/app/(view)/view/[viewId]/planning/live/page.tsx
+++ b/app/(view)/view/[viewId]/planning/live/page.tsx
@@ -36,6 +36,7 @@ export default async function ViewPlanningLivePage({
     <section id={`v13w-plan-${user.id}`}>
       {overrideLabel && <TimeOverrideBadge label={overrideLabel} />}
       <EditorClient
+        key={dateStr}
         userId={String(user.id)}
         date={dateStr}
         today={todayStr}

--- a/app/(view)/view/[viewId]/planning/next/page.tsx
+++ b/app/(view)/view/[viewId]/planning/next/page.tsx
@@ -40,6 +40,7 @@ export default async function ViewPlanningNextPage({
     <section id={`v13w-plan-${user.id}`}>
       {overrideLabel && <TimeOverrideBadge label={overrideLabel} />}
       <EditorClient
+        key={dateStr}
         userId={String(user.id)}
         date={dateStr}
         today={todayStr}

--- a/app/(view)/view/[viewId]/planning/review/page.tsx
+++ b/app/(view)/view/[viewId]/planning/review/page.tsx
@@ -36,6 +36,7 @@ export default async function ViewPlanningReviewPage({
     <section id={`v13w-plan-${user.id}`}>
       {overrideLabel && <TimeOverrideBadge label={overrideLabel} />}
       <EditorClient
+        key={dateStr}
         userId={String(user.id)}
         date={dateStr}
         today={todayStr}

--- a/app/history/[viewId]/[date]/planning/live/page.tsx
+++ b/app/history/[viewId]/[date]/planning/live/page.tsx
@@ -27,6 +27,7 @@ export default async function HistoryPlanningLive({
   return (
     <section id={`hist-plan-live-${owner.id}-${date}`}>
       <EditorClient
+        key={dateStr}
         userId={String(owner.id)}
         date={dateStr}
         today={dateStr}

--- a/app/history/[viewId]/[date]/planning/next/page.tsx
+++ b/app/history/[viewId]/[date]/planning/next/page.tsx
@@ -38,6 +38,7 @@ export default async function HistoryPlanningNext({
   return (
     <section id={`hist-plan-next-${owner.id}-${date}`}>
       <EditorClient
+        key={dateStr}
         userId={String(owner.id)}
         date={dateStr}
         today={todayStr}

--- a/app/history/[viewId]/[date]/planning/review/page.tsx
+++ b/app/history/[viewId]/[date]/planning/review/page.tsx
@@ -27,6 +27,7 @@ export default async function HistoryPlanningReview({
   return (
     <section id={`hist-plan-review-${owner.id}-${date}`}>
       <EditorClient
+        key={dateStr}
         userId={String(owner.id)}
         date={dateStr}
         today={dateStr}

--- a/app/history/self/[date]/planning/live/page.tsx
+++ b/app/history/self/[date]/planning/live/page.tsx
@@ -29,6 +29,7 @@ export default async function HistorySelfPlanningLive({
   return (
     <section id={`hist-self-plan-live-${me.id}-${date}`}>
       <EditorClient
+        key={dateStr}
         userId={String(me.id)}
         date={dateStr}
         today={dateStr}

--- a/app/history/self/[date]/planning/next/page.tsx
+++ b/app/history/self/[date]/planning/next/page.tsx
@@ -40,6 +40,7 @@ export default async function HistorySelfPlanningNext({
   return (
     <section id={`hist-self-plan-next-${me.id}-${date}`}>
       <EditorClient
+        key={dateStr}
         userId={String(me.id)}
         date={dateStr}
         today={todayStr}

--- a/app/history/self/[date]/planning/review/page.tsx
+++ b/app/history/self/[date]/planning/review/page.tsx
@@ -29,6 +29,7 @@ export default async function HistorySelfPlanningReview({
   return (
     <section id={`hist-self-plan-review-${me.id}-${date}`}>
       <EditorClient
+        key={dateStr}
         userId={String(me.id)}
         date={dateStr}
         today={dateStr}

--- a/drizzle/0015_add_plan_daily_aim.sql
+++ b/drizzle/0015_add_plan_daily_aim.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "plans" ADD COLUMN "daily_aim" text;
+ALTER TABLE "plans" ADD COLUMN "daily_ingredient_ids" integer[];

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -171,6 +171,8 @@ export const plans = pgTable(
       .references(() => users.id)
       .notNull(),
     date: date('date').notNull(),
+    dailyAim: text('daily_aim'),
+    dailyIngredientIds: integer('daily_ingredient_ids').array(),
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').defaultNow(),
   },

--- a/types/plan.ts
+++ b/types/plan.ts
@@ -3,6 +3,8 @@ export interface Plan {
   userId: string;
   date: string; // ISO date YYYY-MM-DD
   blocks: PlanBlock[];
+  dailyAim: string;
+  dailyIngredientIds: number[];
 }
 
 export interface PlanBlock {


### PR DESCRIPTION
## Summary
- add Daily Aim modal with per-day ingredients on planning pages
- persist daily aim and ingredients in plans and snapshots
- support daily ingredient picker and ID catalog entries
- ensure daily aims are unique per day and show button status

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*
- `pnpm format` *(fails: Command "format" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e43faea4832ab683d2848364916d