### PR TITLE
Fix Daily Aim button color and enlarge editor

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -146,3 +146,5 @@
 highlighting the Daily Aim button red when empty and green when filled.
 - 2025-10-24: Enlarged Daily Aim editor with top-left close and Done buttons, prevented accidental closing during text selection, and kept toolbar color green when filled.
 - 2025-10-24: Further expanded Daily Aim modal for more editing space and turned toolbar green when text or daily ingredients are present.
+- 2025-10-24: Fixed Daily Aim button colors to show red when empty and green when filled, and greatly enlarged modal editor with a top-left close button.
+- 2025-10-24: Widened Daily Aim modal and restored red/green button colors when empty vs filled.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -9,6 +9,7 @@ import PlanningDateNav from './date-nav';
 import type { Plan, PlanBlock, PlanBlockInput } from '@/types/plan';
 import type { Ingredient } from '@/types/ingredient';
 import { savePlanAction } from './actions';
+import { cn } from '@/lib/utils';
 
 const COLORS = [
   '#F87171',
@@ -729,11 +730,12 @@ export default function EditorClient({
             )}
             <button
               id={`p1an-daily-aim-${userId}`}
-              className={`rounded border px-3 py-2 ${
+              className={cn(
+                'rounded border-2 px-3 py-2',
                 dailyAim.trim().length > 0 || dailyIngredientIds.length > 0
-                  ? 'border-green-300 bg-green-50 text-green-600'
-                  : 'border-red-300 bg-red-50 text-red-600'
-              }`}
+                  ? 'border-green-500 text-green-600 bg-green-50'
+                  : 'border-red-500 text-red-600 bg-red-50',
+              )}
               onClick={() => setShowDailyAim(true)}
             >
               Daily Aim
@@ -1234,21 +1236,21 @@ export default function EditorClient({
             if (e.target === e.currentTarget) setShowDailyAim(false);
           }}
         >
-          <div className="relative w-[60rem] max-w-[90vw] rounded bg-white p-6 shadow-lg">
+          <div className="relative w-[90vw] max-w-5xl rounded bg-white p-16 shadow-lg">
             <button
               id={`p1an-day-x-${userId}`}
-              className="absolute left-2 top-2 text-gray-500"
+              className="absolute left-4 top-4 text-gray-500"
               onClick={() => setShowDailyAim(false)}
             >
               X
             </button>
-            <h2 className="mb-2 text-lg font-semibold">Daily Aim</h2>
+            <h2 className="mb-4 text-lg font-semibold">Daily Aim</h2>
             <textarea
               id={`p1an-day-aim-${userId}`}
-              className="mb-6 h-48 w-full border p-3"
+              className="mb-8 h-[32rem] w-full border p-6"
               value={dailyAim}
               onChange={(e) => setDailyAim(e.target.value)}
-              rows={8}
+              rows={16}
               maxLength={500}
               disabled={!editable}
             />


### PR DESCRIPTION
## Summary
- enforce red/green styling for Daily Aim button based on content
- widen Daily Aim modal with roomy textarea and padding
- document Daily Aim width and color fixes in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a97127ba98832abdb8c0991fca8d50