### PR TITLE
fix: keep daily aim open after adding ingredients

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -143,9 +143,10 @@
 - 2025-10-23: Display "No ingredient found" placeholders and label hidden ingredients as "Secret 🔒".
 - 2025-10-24: Introduced Daily Aim modal with daily ingredients on planning pages and saved values in plan snapshots.
 - 2025-10-24: Ensured Daily Aim is stored per day, remounting planners on date changes and
-highlighting the Daily Aim button red when empty and green when filled.
+  highlighting the Daily Aim button red when empty and green when filled.
 - 2025-10-24: Enlarged Daily Aim editor with top-left close and Done buttons, prevented accidental closing during text selection, and kept toolbar color green when filled.
 - 2025-10-24: Further expanded Daily Aim modal for more editing space and turned toolbar green when text or daily ingredients are present.
 - 2025-10-24: Fixed Daily Aim button colors to show red when empty and green when filled, and greatly enlarged modal editor with a top-left close button.
 - 2025-10-24: Widened Daily Aim modal and restored red/green button colors when empty vs filled.
 - 2025-10-24: Halved Daily Aim modal width, added generous padding, and fixed green state when content present.
+- 2025-10-24: Kept Daily Aim modal open after adding ingredients, centered its heading, and indented ingredient list.

--- a/app/(app)/ingredientsforplanning/client.tsx
+++ b/app/(app)/ingredientsforplanning/client.tsx
@@ -68,9 +68,7 @@ export default function IngredientsForPlanningClient({
                   } = { blocks: [] };
                   if (raw) {
                     const parsed = JSON.parse(raw);
-                    data = Array.isArray(parsed)
-                      ? { blocks: parsed }
-                      : parsed;
+                    data = Array.isArray(parsed) ? { blocks: parsed } : parsed;
                   }
                   if (blockId === 'day') {
                     data.dailyIngredientIds = (
@@ -87,22 +85,20 @@ export default function IngredientsForPlanningClient({
                               Number(ing.id),
                             )
                               ? b.ingredientIds
-                              : [
-                                  ...(b.ingredientIds ?? []),
-                                  Number(ing.id),
-                                ],
+                              : [...(b.ingredientIds ?? []), Number(ing.id)],
                           }
                         : b,
                     );
                   }
-                  window.localStorage.setItem(
-                    storageKey,
-                    JSON.stringify(data),
-                  );
+                  window.localStorage.setItem(storageKey, JSON.stringify(data));
                 } catch {
                   // ignore
                 }
-                router.push(`/planning/${mode}?date=${date}`);
+                router.push(
+                  `/planning/${mode}?date=${date}${
+                    blockId === 'day' ? '&dailyAim=1' : ''
+                  }`,
+                );
               }}
             >
               +
@@ -116,4 +112,3 @@ export default function IngredientsForPlanningClient({
     </div>
   );
 }
-

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -4,6 +4,7 @@
 import { useState, useMemo, useRef, useCallback, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { useViewContext } from '@/lib/view-context';
 import PlanningDateNav from './date-nav';
 import type { Plan, PlanBlock, PlanBlockInput } from '@/types/plan';
@@ -89,7 +90,19 @@ export default function EditorClient({
   const [dailyIngredientIds, setDailyIngredientIds] = useState<number[]>(
     () => initialPlan?.dailyIngredientIds ?? [],
   );
+  const searchParams = useSearchParams();
+  const router = useRouter();
   const [showDailyAim, setShowDailyAim] = useState(false);
+  useEffect(() => {
+    if (searchParams.get('dailyAim') === '1') {
+      setShowDailyAim(true);
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete('dailyAim');
+      const query = params.toString();
+      const path = window.location.pathname + (query ? `?${query}` : '');
+      router.replace(path, { scroll: false });
+    }
+  }, [searchParams, router]);
   const hasDailyAim = useMemo(
     () => dailyAim.trim().length > 0 || dailyIngredientIds.length > 0,
     [dailyAim, dailyIngredientIds],
@@ -383,9 +396,7 @@ export default function EditorClient({
         const raw = window.localStorage.getItem(storageKey);
         if (raw) {
           const parsed = JSON.parse(raw);
-          fromStorage = Array.isArray(parsed)
-            ? { blocks: parsed }
-            : parsed;
+          fromStorage = Array.isArray(parsed) ? { blocks: parsed } : parsed;
         }
       } catch {
         // ignore malformed data
@@ -394,9 +405,7 @@ export default function EditorClient({
     const nextBlocks = fromStorage?.blocks ?? initialPlan?.blocks ?? [];
     const nextAim = fromStorage?.dailyAim ?? initialPlan?.dailyAim ?? '';
     const nextIng =
-      fromStorage?.dailyIngredientIds ??
-      initialPlan?.dailyIngredientIds ??
-      [];
+      fromStorage?.dailyIngredientIds ?? initialPlan?.dailyIngredientIds ?? [];
     const serialized = JSON.stringify({
       blocks: nextBlocks,
       dailyAim: nextAim,
@@ -1114,7 +1123,7 @@ export default function EditorClient({
                     id={`p1an-meta-igrd-${selected.id}-${userId}`}
                     className="mb-2 flex flex-wrap gap-2"
                   >
-                    {((selected.ingredientIds ?? []).length === 0) && (
+                    {(selected.ingredientIds ?? []).length === 0 && (
                       <span
                         id={`p1an-meta-igrd-none-${selected.id}-${userId}`}
                         className="text-sm text-gray-500"
@@ -1248,7 +1257,9 @@ export default function EditorClient({
             >
               X
             </button>
-            <h2 className="mb-4 text-lg font-semibold">Daily Aim</h2>
+            <h2 className="mb-4 text-lg font-semibold text-center">
+              Daily Aim
+            </h2>
             <textarea
               id={`p1an-day-aim-${userId}`}
               className="mb-8 h-[32rem] w-full border p-6"
@@ -1259,10 +1270,12 @@ export default function EditorClient({
               disabled={!editable}
             />
             <div className="mb-2">
-              <span className="block text-sm font-medium">Daily ingredients</span>
+              <span className="block text-sm font-medium">
+                Daily ingredients
+              </span>
               <div
                 id={`p1an-day-igrd-${userId}`}
-                className="mb-2 flex flex-wrap gap-2"
+                className="mb-2 flex flex-wrap gap-2 pl-4"
               >
                 {dailyIngredientIds.length === 0 && (
                   <span
@@ -1309,7 +1322,7 @@ export default function EditorClient({
                 <Link
                   id={`p1an-day-add-${userId}`}
                   href={`/ingredientsforplanning?date=${date}&block=day&mode=${mode}`}
-                  className="rounded border px-2 py-1 text-sm"
+                  className="ml-4 rounded border px-2 py-1 text-sm"
                 >
                   Add ingredients +
                 </Link>


### PR DESCRIPTION
## Summary
- reopen Daily Aim modal after adding a daily ingredient
- center Daily Aim heading and add padding to ingredient list for better spacing
- document Daily Aim modal behavior

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a98a61fb68832a9f21b0bc3a21c4fb