### PR TITLE
Fix daily aim modal closing after adding ingredient

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -143,9 +143,12 @@
 - 2025-10-23: Display "No ingredient found" placeholders and label hidden ingredients as "Secret 🔒".
 - 2025-10-24: Introduced Daily Aim modal with daily ingredients on planning pages and saved values in plan snapshots.
 - 2025-10-24: Ensured Daily Aim is stored per day, remounting planners on date changes and
-highlighting the Daily Aim button red when empty and green when filled.
+  highlighting the Daily Aim button red when empty and green when filled.
 - 2025-10-24: Enlarged Daily Aim editor with top-left close and Done buttons, prevented accidental closing during text selection, and kept toolbar color green when filled.
 - 2025-10-24: Further expanded Daily Aim modal for more editing space and turned toolbar green when text or daily ingredients are present.
 - 2025-10-24: Fixed Daily Aim button colors to show red when empty and green when filled, and greatly enlarged modal editor with a top-left close button.
 - 2025-10-24: Widened Daily Aim modal and restored red/green button colors when empty vs filled.
 - 2025-10-24: Halved Daily Aim modal width, added generous padding, and fixed green state when content present.
+- 2025-10-24: Kept Daily Aim modal open after adding ingredients, centered title text, and added spacing to ingredient list.
+- 2025-10-24: Increased Daily Aim ingredient list padding and turned Daily Aim button green when text or ingredients present.
+- 2025-10-24: Added matching padding to Daily ingredients heading and add button, and kept Daily Aim button green after edits.

--- a/app/(app)/ingredientsforplanning/client.tsx
+++ b/app/(app)/ingredientsforplanning/client.tsx
@@ -102,7 +102,9 @@ export default function IngredientsForPlanningClient({
                 } catch {
                   // ignore
                 }
-                router.push(`/planning/${mode}?date=${date}`);
+                router.push(
+                  `/planning/${mode}?date=${date}${blockId === 'day' ? '&showDailyAim=1' : ''}`,
+                );
               }}
             >
               +

--- a/app/(app)/planning/live/page.tsx
+++ b/app/(app)/planning/live/page.tsx
@@ -20,6 +20,7 @@ export default async function PlanningLivePage({
   const me = await ensureUser(session);
   const cookieStore = await cookies();
   const params = searchParams ? await searchParams : undefined;
+  const showDailyAim = params?.showDailyAim === '1';
   const info = resolvePlanDate('live', me, {
     cookies: cookieStore,
     searchParams: params,
@@ -43,6 +44,7 @@ export default async function PlanningLivePage({
         initialPlan={plan}
         live
         ingredients={ingredients}
+        initialShowDailyAim={showDailyAim}
       />
     </>
   );

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -20,6 +20,7 @@ export default async function PlanningNextPage({
   const me = await ensureUser(session);
   const cookieStore = await cookies();
   const params = searchParams ? await searchParams : undefined;
+  const showDailyAim = params?.showDailyAim === '1';
   const info = resolvePlanDate('next', me, {
     cookies: cookieStore,
     searchParams: params,
@@ -46,6 +47,7 @@ export default async function PlanningNextPage({
         tz={info.tz}
         initialPlan={plan}
         ingredients={ingredients}
+        initialShowDailyAim={showDailyAim}
       />
     </>
   );

--- a/app/(app)/planning/review/page.tsx
+++ b/app/(app)/planning/review/page.tsx
@@ -20,6 +20,7 @@ export default async function PlanningReviewPage({
   const me = await ensureUser(session);
   const cookieStore = await cookies();
   const params = searchParams ? await searchParams : undefined;
+  const showDailyAim = params?.showDailyAim === '1';
   const info = resolvePlanDate('review', me, {
     cookies: cookieStore,
     searchParams: params,
@@ -44,6 +45,7 @@ export default async function PlanningReviewPage({
         live
         review
         ingredients={ingredients}
+        initialShowDailyAim={showDailyAim}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- Keep Daily Aim modal open after adding ingredients
- Center Daily Aim heading and add padding to ingredient list
- Support reopening Daily Aim modal on next, live, and review planning pages
- Add extra padding to Daily ingredients label and add button and ensure Daily Aim button stays green when filled

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a98a61fb68832a9f21b0bc3a21c4fb