### PR TITLE
Color daily aim button based on content

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -152,3 +152,4 @@
 - 2025-10-24: Kept Daily Aim modal open after adding ingredients, centered title text, and added spacing to ingredient list.
 - 2025-10-24: Increased Daily Aim ingredient list padding and turned Daily Aim button green when text or ingredients present.
 - 2025-10-24: Added matching padding to Daily ingredients heading and add button, and kept Daily Aim button green after edits.
+- 2025-10-24: Colored Daily Aim button red when empty and green when any text or ingredients are added.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -754,8 +754,8 @@ export default function EditorClient({
               className={cn(
                 'border-2 px-3 py-2',
                 hasDailyAim
-                  ? '!border-green-500 !text-green-600 !bg-green-50'
-                  : '!border-red-500 !text-red-600 !bg-red-50',
+                  ? 'border-green-500 text-green-600 bg-green-50 hover:bg-green-100'
+                  : 'border-red-500 text-red-600 bg-red-50 hover:bg-red-100',
               )}
               onClick={() => setShowDailyAim(true)}
             >


### PR DESCRIPTION
## Summary
- switch daily aim button to red when empty and green when text or daily ingredients are present
- update project log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68a991b5bfd8832aa9ae24c525d67f9e