### PR TITLE
feat: enable ingredient feedback in review planning

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -153,3 +153,4 @@
 - 2025-10-24: Increased Daily Aim ingredient list padding and turned Daily Aim button green when text or ingredients present.
 - 2025-10-24: Added matching padding to Daily ingredients heading and add button, and kept Daily Aim button green after edits.
 - 2025-10-24: Colored Daily Aim button red when empty and green when any text or ingredients are added.
+- 2025-10-24: Exposed activity ingredients in review mode and let users write per-ingredient feedback.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -115,16 +115,27 @@ export default function EditorClient({
     }
   }, [initialShowDailyAim, storageKey]);
   const [reviews, setReviews] = useState<
-    Record<string, { good: string; bad: string }>
+    Record<
+      string,
+      { good: string; bad: string; ingredients: Record<number, string> }
+    >
   >(() => {
     if (typeof window !== 'undefined') {
       try {
         const raw = window.localStorage.getItem(reviewKey);
-        if (raw)
-          return JSON.parse(raw) as Record<
+        if (raw) {
+          const parsed = JSON.parse(raw) as Record<
             string,
-            { good: string; bad: string }
+            { good: string; bad: string; ingredients?: Record<number, string> }
           >;
+          for (const k of Object.keys(parsed)) {
+            parsed[k].ingredients = parsed[k].ingredients ?? {};
+          }
+          return parsed as Record<
+            string,
+            { good: string; bad: string; ingredients: Record<number, string> }
+          >;
+        }
       } catch {
         // ignore malformed data
       }
@@ -148,6 +159,15 @@ export default function EditorClient({
     () => blocks.find((b) => b.id === selectedId) || null,
     [blocks, selectedId],
   );
+  const [selectIngredient, setSelectIngredient] = useState(false);
+  useEffect(() => {
+    setSelectIngredient(false);
+  }, [selectedId]);
+  const unreviewedIngredientIds = useMemo(() => {
+    if (!selected) return [] as number[];
+    const reviewed = reviews[selected.id]?.ingredients || {};
+    return (selected.ingredientIds ?? []).filter((iid) => !(iid in reviewed));
+  }, [selected, reviews]);
   const draggingRef = useRef(false);
   const [startMinute, setStartMinute] = useState(DEFAULT_START);
   const [endMinute, setEndMinute] = useState(DEFAULT_END);
@@ -263,7 +283,12 @@ export default function EditorClient({
     if (!review) return;
     setReviews((prev) => {
       const ids = new Set(blocks.map((b) => b.id));
-      const next: Record<string, { good: string; bad: string }> = { ...prev };
+      const next: Record<
+        string,
+        { good: string; bad: string; ingredients: Record<number, string> }
+      > = {
+        ...prev,
+      };
       for (const id of Object.keys(next)) {
         if (!ids.has(id)) delete next[id];
       }
@@ -275,7 +300,12 @@ export default function EditorClient({
     if (!review) return;
     const now = nowMinute;
     setReviews((prev) => {
-      const next: Record<string, { good: string; bad: string }> = { ...prev };
+      const next: Record<
+        string,
+        { good: string; bad: string; ingredients: Record<number, string> }
+      > = {
+        ...prev,
+      };
       for (const b of blocks) {
         if (minutesFromIso(b.end) > now && next[b.id]) {
           delete next[b.id];
@@ -302,6 +332,32 @@ export default function EditorClient({
 
   function removeDailyIngredient(ingredientId: number) {
     setDailyIngredientIds((ids) => ids.filter((id) => id !== ingredientId));
+  }
+
+  function addIngredientReview(blockId: string, ingredientId: number) {
+    setReviews((prev) => ({
+      ...prev,
+      [blockId]: {
+        ...(prev[blockId] || { good: '', bad: '', ingredients: {} }),
+        ingredients: {
+          ...(prev[blockId]?.ingredients || {}),
+          [ingredientId]: '',
+        },
+      },
+    }));
+  }
+
+  function removeIngredientReview(blockId: string, ingredientId: number) {
+    setReviews((prev) => {
+      const copy = { ...prev };
+      const entry = copy[blockId];
+      if (entry) {
+        const ing = { ...entry.ingredients };
+        delete ing[ingredientId];
+        copy[blockId] = { ...entry, ingredients: ing };
+      }
+      return copy;
+    });
   }
 
   function addBlock() {
@@ -976,6 +1032,68 @@ export default function EditorClient({
                 <div className="mb-2 text-sm text-gray-500">
                   {editable ? null : 'Read-only (viewing mode)'}
                 </div>
+                <label className="block text-sm font-medium">Ingredients</label>
+                <div
+                  id={`p1an-meta-igrd-${selected.id}-${userId}`}
+                  className="mb-2 flex flex-wrap gap-2"
+                >
+                  {unreviewedIngredientIds.length === 0 && (
+                    <span
+                      id={`p1an-meta-igrd-none-${selected.id}-${userId}`}
+                      className="text-sm text-gray-500"
+                    >
+                      No ingredient found
+                    </span>
+                  )}
+                  {unreviewedIngredientIds.map((iid) => {
+                    const ing = initialIngredients.find((i) => i.id === iid);
+                    const src = ing?.icon ? iconSrc(ing.icon) : null;
+                    return (
+                      <div
+                        key={iid}
+                        className={cn(
+                          'flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 shadow',
+                          selectIngredient && editable
+                            ? 'cursor-pointer hover:bg-gray-200'
+                            : '',
+                        )}
+                        onClick={() => {
+                          if (selectIngredient && editable) {
+                            addIngredientReview(selected.id, iid);
+                            setSelectIngredient(false);
+                          }
+                        }}
+                      >
+                        {src ? (
+                          <img src={src} alt="" className="h-4 w-4" />
+                        ) : (
+                          <span>{ing?.icon ?? '❓'}</span>
+                        )}
+                        <span className="text-sm">
+                          {ing?.title ?? 'Secret 🔒'}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+                {editable && unreviewedIngredientIds.length > 0 && (
+                  <Button
+                    id={`p1an-meta-igrd-review-${selected.id}-${userId}`}
+                    variant="outline"
+                    size="sm"
+                    className="mb-2"
+                    onClick={() => setSelectIngredient((s) => !s)}
+                  >
+                    {selectIngredient
+                      ? 'Cancel ingredient feedback'
+                      : 'Write feedback on ingredient'}
+                  </Button>
+                )}
+                {selectIngredient && (
+                  <div className="mb-2 text-sm text-gray-500">
+                    Select an ingredient above
+                  </div>
+                )}
                 <label
                   className="block text-sm font-medium"
                   htmlFor={`p1an-meta-good-${selected.id}-${userId}`}
@@ -993,7 +1111,11 @@ export default function EditorClient({
                     setReviews((prev) => ({
                       ...prev,
                       [selected.id]: {
-                        ...(prev[selected.id] || { good: '', bad: '' }),
+                        ...(prev[selected.id] || {
+                          good: '',
+                          bad: '',
+                          ingredients: {},
+                        }),
                         good: e.target.value,
                       },
                     }))
@@ -1016,12 +1138,72 @@ export default function EditorClient({
                     setReviews((prev) => ({
                       ...prev,
                       [selected.id]: {
-                        ...(prev[selected.id] || { good: '', bad: '' }),
+                        ...(prev[selected.id] || {
+                          good: '',
+                          bad: '',
+                          ingredients: {},
+                        }),
                         bad: e.target.value,
                       },
                     }))
                   }
                 />
+                {Object.entries(reviews[selected.id]?.ingredients ?? {}).map(
+                  ([iidStr, text]) => {
+                    const iid = Number(iidStr);
+                    const ing = initialIngredients.find((i) => i.id === iid);
+                    const src = ing?.icon ? iconSrc(ing.icon) : null;
+                    return (
+                      <div key={iid} className="mb-2">
+                        <div className="mb-1 flex items-center justify-between">
+                          <div className="flex items-center gap-1">
+                            {src ? (
+                              <img src={src} alt="" className="h-4 w-4" />
+                            ) : (
+                              <span>{ing?.icon ?? '❓'}</span>
+                            )}
+                            <span className="text-sm">
+                              {ing?.title ?? 'Secret 🔒'}
+                            </span>
+                          </div>
+                          {editable && (
+                            <button
+                              className="text-sm"
+                              onClick={() =>
+                                removeIngredientReview(selected.id, iid)
+                              }
+                            >
+                              ×
+                            </button>
+                          )}
+                        </div>
+                        <textarea
+                          className="w-full border p-1"
+                          value={text}
+                          disabled={!editable}
+                          maxLength={1000}
+                          rows={3}
+                          onChange={(e) =>
+                            setReviews((prev) => ({
+                              ...prev,
+                              [selected.id]: {
+                                ...(prev[selected.id] || {
+                                  good: '',
+                                  bad: '',
+                                  ingredients: {},
+                                }),
+                                ingredients: {
+                                  ...(prev[selected.id]?.ingredients || {}),
+                                  [iid]: e.target.value,
+                                },
+                              },
+                            }))
+                          }
+                        />
+                      </div>
+                    );
+                  },
+                )}
                 <div className="mt-4 flex gap-2">
                   <Button
                     variant="outline"


### PR DESCRIPTION
## Summary
- show ingredients for selected activity while reviewing today's plan
- let users choose an ingredient and record feedback on it
- log change in UPDATE.md

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68a997e13978832aa38e6b40b6baf06d