### PR TITLE
feat: enable ingredient feedback in review planning

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -153,3 +153,5 @@
 - 2025-10-24: Increased Daily Aim ingredient list padding and turned Daily Aim button green when text or ingredients present.
 - 2025-10-24: Added matching padding to Daily ingredients heading and add button, and kept Daily Aim button green after edits.
 - 2025-10-24: Colored Daily Aim button red when empty and green when any text or ingredients are added.
+- 2025-10-24: Exposed activity ingredients in review mode and let users write per-ingredient feedback.
+- 2025-10-24: Moved ingredient list and feedback button below good/bad review fields.


### PR DESCRIPTION
## Summary
- show ingredients for selected activity while reviewing today's plan
- let users choose an ingredient and record feedback on it
- place ingredient list and feedback button below good/bad review fields
- log change in UPDATE.md

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68a997e13978832aa38e6b40b6baf06d