### PR TITLE
feat: add daily aim review

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -106,13 +106,15 @@ Modal form IDs:
 - `p1an-meta-igrd-none-{blockId}-{ownerId}` → ingredient empty state text.
 - `p1an-vibe-{ownerId}` → general day vibe modal.
 - `p1an-vibe-close-{ownerId}` → close general vibe modal.
-- `p1an-daily-aim-{ownerId}` → open Daily Aim modal.
+- `p1an-daily-aim-{ownerId}` → open Daily Aim or Review Daily Aim modal.
 - `p1an-day-aim-{ownerId}` → Daily Aim textarea.
 - `p1an-day-igrd-{ownerId}` → Daily ingredients tag container.
 - `p1an-day-igrd-none-{ownerId}` → Daily ingredients empty state text.
 - `p1an-day-add-{ownerId}` → add daily ingredient button.
 - `p1an-day-done-{ownerId}` → confirm Daily Aim modal.
 - `p1an-day-x-{ownerId}` → close Daily Aim modal.
+- `p1an-day-feed-{ownerId}` → Daily feedback textarea.
+- `p1an-day-igrd-review-{ownerId}` → toggle ingredient feedback mode.
 
 ## People
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -156,3 +156,4 @@
 - 2025-10-24: Exposed activity ingredients in review mode and let users write per-ingredient feedback.
 - 2025-10-24: Moved ingredient list and feedback button below good/bad review fields.
 - 2025-10-24: Placed ingredient feedback boxes above the ingredient list in review mode.
+- 2025-10-25: Added read-only Review Daily Aim modal with daily feedback and per-ingredient review.


### PR DESCRIPTION
## Summary
- rename Daily Aim button to Review Daily Aim
- add read-only daily aim review with day feedback and ingredient feedback
- document new ids and update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a5645384832a9df5e74c51fbecaa