### PR TITLE
feat: add color preset picker for planning

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -164,3 +164,4 @@
 - 2025-10-24: Extended NextAuth session tolerance to prevent JWT expiry when overriding the site clock.
 - 2025-10-25: Enabled viewing mode access to Review Today’s Planning, documented new IDs, and added viewer review test.
 - 2025-10-25: Show ingredient names in viewer modes, link public ingredients to detail pages, and label private ones as Secret.
+- 2025-10-25: Added color preset picker with default palettes and personal presets; viewers can copy presets from plans.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -10,6 +10,8 @@ import type { Plan, PlanBlock, PlanBlockInput } from '@/types/plan';
 import type { Ingredient } from '@/types/ingredient';
 import { savePlanAction } from './actions';
 import { cn } from '@/lib/utils';
+import ColorPresetPicker from '@/components/color-preset-picker';
+import { addUserColorPreset } from '@/lib/color-presets';
 
 const COLORS = [
   '#F87171',
@@ -61,7 +63,7 @@ export default function EditorClient({
   review = false,
   initialShowDailyAim = false,
 }: Props) {
-  const { editable, viewId } = useViewContext();
+  const { editable, viewId, viewerId } = useViewContext();
   const mode = live ? 'live' : 'next';
   // Persist plans per-user and per-date. Live and review modes share the
   // same key while future planning uses its own so adjustments remain across
@@ -76,6 +78,7 @@ export default function EditorClient({
           return (JSON.parse(raw) as PlanBlock[]).map((b) => ({
             ...b,
             ingredientIds: b.ingredientIds ?? [],
+            colorPreset: b.colorPreset ?? '',
           }));
       } catch {
         // ignore malformed data
@@ -84,6 +87,7 @@ export default function EditorClient({
     return (initialPlan?.blocks ?? []).map((b) => ({
       ...b,
       ingredientIds: b.ingredientIds ?? [],
+      colorPreset: b.colorPreset ?? '',
     }));
   });
   const [dailyAim, setDailyAim] = useState(() => initialPlan?.dailyAim ?? '');
@@ -141,6 +145,7 @@ export default function EditorClient({
     }
     return {};
   });
+  const [showPresetPicker, setShowPresetPicker] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const selected = useMemo(
     () => blocks.find((b) => b.id === selectedId) || null,
@@ -416,6 +421,7 @@ export default function EditorClient({
       title: '',
       description: '',
       color: COLORS[0],
+      colorPreset: '',
       ingredientIds: [],
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -461,7 +467,13 @@ export default function EditorClient({
         // ignore malformed data
       }
     }
-    const nextBlocks = fromStorage?.blocks ?? initialPlan?.blocks ?? [];
+    const nextBlocks = (fromStorage?.blocks ?? initialPlan?.blocks ?? []).map(
+      (b) => ({
+        ...b,
+        ingredientIds: b.ingredientIds ?? [],
+        colorPreset: b.colorPreset ?? '',
+      }),
+    );
     const nextAim = fromStorage?.dailyAim ?? initialPlan?.dailyAim ?? '';
     const nextIng =
       fromStorage?.dailyIngredientIds ?? initialPlan?.dailyIngredientIds ?? [];
@@ -502,6 +514,7 @@ export default function EditorClient({
         title: b.title,
         description: b.description,
         color: b.color,
+        colorPreset: b.colorPreset,
         ingredientIds: b.ingredientIds,
       }));
       savePlanAction(date, payload, dailyAim, dailyIngredientIds).then(
@@ -547,6 +560,7 @@ export default function EditorClient({
           title: b.title,
           description: b.description,
           color: b.color,
+          colorPreset: b.colorPreset,
           ingredientIds: b.ingredientIds,
         }));
         void savePlanAction(
@@ -735,8 +749,8 @@ export default function EditorClient({
             className="sticky top-0 z-10 flex flex-wrap items-end gap-2 bg-gray-100 p-2 text-sm"
             onClick={(e) => e.stopPropagation()}
           >
-            {!review && (
-              editable ? (
+            {!review &&
+              (editable ? (
                 <button
                   id={`p1an-add-top-${userId}`}
                   onClick={() => addBlock()}
@@ -754,8 +768,7 @@ export default function EditorClient({
                 >
                   + Add timeslot
                 </button>
-              )
-            )}
+              ))}
             <button
               id={`p1an-range-btn-${userId}`}
               className="rounded border px-2 py-1"
@@ -1077,7 +1090,10 @@ export default function EditorClient({
                       <div key={iid} className="mb-2">
                         <div className="mb-1 flex items-center justify-between">
                           {link ? (
-                            <Link href={link} className="flex items-center gap-1">
+                            <Link
+                              href={link}
+                              className="flex items-center gap-1"
+                            >
                               {src ? (
                                 <img src={src} alt="" className="h-4 w-4" />
                               ) : (
@@ -1212,7 +1228,7 @@ export default function EditorClient({
                       : 'Write feedback on ingredient'}
                   </Button>
                 )}
-                  {selectIngredient && (
+                {selectIngredient && (
                   <div className="mb-2 text-sm text-gray-500">
                     Select an ingredient above
                   </div>
@@ -1276,12 +1292,62 @@ export default function EditorClient({
                       className="h-6 w-6 rounded"
                       style={{ background: c }}
                       onClick={() =>
-                        editable && updateBlock(selected.id, { color: c })
+                        editable &&
+                        updateBlock(selected.id, { color: c, colorPreset: '' })
                       }
                       disabled={!editable}
                     />
                   ))}
                 </div>
+                {selected.colorPreset && (
+                  <div className="mb-2 text-xs text-gray-500">
+                    Preset: {selected.colorPreset}
+                  </div>
+                )}
+                {editable ? (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="mb-2"
+                      id={`p1an-meta-col-pre-${selected.id}-${userId}`}
+                      onClick={() => setShowPresetPicker((s) => !s)}
+                    >
+                      Presets
+                    </Button>
+                    {showPresetPicker && (
+                      <ColorPresetPicker
+                        userId={String(viewerId ?? Number(userId))}
+                        onSelect={({ name, color }) => {
+                          updateBlock(selected.id, {
+                            color,
+                            colorPreset: name,
+                          });
+                          setShowPresetPicker(false);
+                        }}
+                        onClose={() => setShowPresetPicker(false)}
+                      />
+                    )}
+                  </>
+                ) : (
+                  selected.colorPreset &&
+                  viewerId && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="mb-2"
+                      id={`p1an-meta-col-copy-${selected.id}-${userId}`}
+                      onClick={() =>
+                        addUserColorPreset(String(viewerId), {
+                          name: selected.colorPreset || '',
+                          colors: [selected.color],
+                        })
+                      }
+                    >
+                      Copy preset
+                    </Button>
+                  )
+                )}
                 <div className="mb-2 flex gap-2">
                   <div>
                     <label
@@ -1514,7 +1580,9 @@ export default function EditorClient({
                           </span>
                         )}
                         {dailyIngredientIds.map((iid) => {
-                          const ing = initialIngredients.find((i) => i.id === iid);
+                          const ing = initialIngredients.find(
+                            (i) => i.id === iid,
+                          );
                           const src = ing?.icon ? iconSrc(ing.icon) : null;
                           const selectable = selectDailyIngredient && editable;
                           const content = (
@@ -1537,7 +1605,9 @@ export default function EditorClient({
                               : `/ingredient/${ing.id}`);
                           const cls = cn(
                             'flex items-center gap-1 rounded border px-2 py-1',
-                            selectable ? 'cursor-pointer bg-gray-100 hover:bg-gray-200' : '',
+                            selectable
+                              ? 'cursor-pointer bg-gray-100 hover:bg-gray-200'
+                              : '',
                           );
                           if (link) {
                             return (
@@ -1565,7 +1635,9 @@ export default function EditorClient({
                       {Object.entries(reviews['day']?.ingredients ?? {}).map(
                         ([iidStr, text]) => {
                           const iid = Number(iidStr);
-                          const ing = initialIngredients.find((i) => i.id === iid);
+                          const ing = initialIngredients.find(
+                            (i) => i.id === iid,
+                          );
                           const src = ing?.icon ? iconSrc(ing.icon) : null;
                           const link =
                             ing &&
@@ -1653,9 +1725,7 @@ export default function EditorClient({
                           variant="outline"
                           size="sm"
                           className="mb-2"
-                          onClick={() =>
-                            setSelectDailyIngredient((s) => !s)
-                          }
+                          onClick={() => setSelectDailyIngredient((s) => !s)}
                         >
                           {selectDailyIngredient
                             ? 'Cancel ingredient feedback'

--- a/components/color-preset-picker.tsx
+++ b/components/color-preset-picker.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  DEFAULT_COLOR_PRESETS,
+  ColorPreset,
+  getUserColorPresets,
+  saveUserColorPresets,
+} from '@/lib/color-presets';
+import { useViewContext } from '@/lib/view-context';
+
+interface PickerProps {
+  userId: string;
+  onSelect: (p: { name: string; color: string }) => void;
+  onClose: () => void;
+}
+
+export default function ColorPresetPicker({
+  userId,
+  onSelect,
+  onClose,
+}: PickerProps) {
+  const { editable } = useViewContext();
+  const [custom, setCustom] = useState<ColorPreset[]>([]);
+  const [name, setName] = useState('');
+  const [color, setColor] = useState('#000000');
+
+  useEffect(() => {
+    setCustom(getUserColorPresets(userId));
+  }, [userId]);
+
+  function handleSave() {
+    if (!name.trim()) return;
+    const preset = { name: name.trim(), colors: [color] };
+    const next = [...custom, preset];
+    setCustom(next);
+    saveUserColorPresets(userId, next);
+    setName('');
+    onSelect({ name: preset.name, color: preset.colors[0] });
+  }
+
+  return (
+    <div className="w-64 rounded border bg-white p-2 text-sm shadow">
+      <div className="mb-2 font-semibold">Presets</div>
+      {DEFAULT_COLOR_PRESETS.map((p) => (
+        <button
+          key={p.name}
+          className="mb-1 flex w-full items-center gap-2 rounded px-1 py-0.5 text-left hover:bg-gray-100"
+          onClick={() => onSelect({ name: p.name, color: p.colors[0] })}
+        >
+          <span
+            className="h-4 w-4 rounded"
+            style={{ background: p.colors[0] }}
+          ></span>
+          <span>{p.name}</span>
+        </button>
+      ))}
+      {custom.length > 0 && (
+        <div className="mt-2 font-semibold">Your presets</div>
+      )}
+      {custom.map((p) => (
+        <button
+          key={p.name}
+          className="mb-1 flex w-full items-center gap-2 rounded px-1 py-0.5 text-left hover:bg-gray-100"
+          onClick={() => onSelect({ name: p.name, color: p.colors[0] })}
+        >
+          <span
+            className="h-4 w-4 rounded"
+            style={{ background: p.colors[0] }}
+          ></span>
+          <span>{p.name}</span>
+        </button>
+      ))}
+      {editable && (
+        <div className="mt-2 flex items-center gap-1">
+          <input
+            className="w-full border p-1 text-xs"
+            value={name}
+            placeholder="Title"
+            onChange={(e) => setName(e.target.value)}
+          />
+          <input
+            type="color"
+            className="h-8 w-8 border p-0"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+          />
+          <Button size="sm" onClick={handleSave} id="clr-pre-add">
+            Save
+          </Button>
+        </div>
+      )}
+      <div className="mt-2 text-right">
+        <Button size="sm" variant="outline" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/drizzle/0016_add_plan_block_color_preset.sql
+++ b/drizzle/0016_add_plan_block_color_preset.sql
@@ -1,0 +1,1 @@
+ALTER TABLE plan_blocks ADD COLUMN color_preset varchar(60);

--- a/lib/color-presets.ts
+++ b/lib/color-presets.ts
@@ -1,0 +1,97 @@
+export interface ColorPreset {
+  name: string;
+  colors: string[]; // primary, secondary, etc.
+}
+
+export const DEFAULT_COLOR_PRESETS: ColorPreset[] = [
+  {
+    name: 'Focused work',
+    colors: ['#2563EB', '#22D3EE', '#F1F5F9'],
+  },
+  {
+    name: 'Studying – detail/recall',
+    colors: ['#334155', '#EF4444', '#FAFAFA'],
+  },
+  {
+    name: 'Studying – concept building',
+    colors: ['#3B82F6', '#7C3AED', '#F0F9FF'],
+  },
+  {
+    name: 'Gym – HIIT & strength',
+    colors: ['#DC2626', '#F97316', '#0B0F19'],
+  },
+  {
+    name: 'Cardio & endurance',
+    colors: ['#22C55E', '#86EFAC', '#F0FDF4'],
+  },
+  {
+    name: 'Team sports / competition day',
+    colors: ['#B91C1C', '#F59E0B', '#0A0A0A'],
+  },
+  {
+    name: 'Planning / organizing',
+    colors: ['#14B8A6', '#F59E0B', '#F8FAFC'],
+  },
+  {
+    name: 'Admin / chores',
+    colors: ['#EAB308', '#22C55E', '#FFFBEB'],
+  },
+  {
+    name: 'Creative work',
+    colors: ['#0EA5E9', '#A78BFA', '#ECFEFF'],
+  },
+  {
+    name: 'Social / networking',
+    colors: ['#F97316', '#FB7185', '#FFF7ED'],
+  },
+  {
+    name: 'Relax / meditation',
+    colors: ['#38BDF8', '#86EFAC', '#E6FFFB'],
+  },
+  {
+    name: 'Sleep prep',
+    colors: ['#D97706', '#1F2937', '#FEF3C7'],
+  },
+  {
+    name: 'Finance / budgeting',
+    colors: ['#1D4ED8', '#93C5FD', '#EFF6FF'],
+  },
+];
+
+function storageKey(userId: string) {
+  return `color-presets-${userId}`;
+}
+
+export function getUserColorPresets(userId: string): ColorPreset[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(storageKey(userId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter(
+        (p) => typeof p?.name === 'string' && Array.isArray(p.colors),
+      );
+    }
+  } catch {
+    // ignore
+  }
+  return [];
+}
+
+export function saveUserColorPresets(userId: string, presets: ColorPreset[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(storageKey(userId), JSON.stringify(presets));
+  } catch {
+    // ignore
+  }
+}
+
+export function addUserColorPreset(userId: string, preset: ColorPreset) {
+  const existing = getUserColorPresets(userId);
+  if (!existing.find((p) => p.name === preset.name)) {
+    existing.push(preset);
+    saveUserColorPresets(userId, existing);
+  }
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -194,6 +194,7 @@ export const planBlocks = pgTable('plan_blocks', {
   title: varchar('title', { length: 60 }),
   description: text('description'),
   color: varchar('color', { length: 10 }),
+  colorPreset: varchar('color_preset', { length: 60 }),
   ingredientIds: integer('ingredient_ids').array(),
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),

--- a/lib/plans-store.ts
+++ b/lib/plans-store.ts
@@ -12,6 +12,7 @@ function toPlanBlock(row: typeof planBlocks.$inferSelect): PlanBlock {
     title: row.title ?? '',
     description: row.description ?? '',
     color: row.color ?? '#888888',
+    colorPreset: row.colorPreset ?? '',
     ingredientIds: row.ingredientIds ?? [],
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
     updatedAt: row.updatedAt?.toISOString() ?? new Date().toISOString(),
@@ -103,6 +104,7 @@ export async function getPlanAt(
       blocks: blocks.map((b) => ({
         ...b,
         ingredientIds: b.ingredientIds ?? [],
+        colorPreset: b.colorPreset ?? '',
       })),
       dailyAim: payload.dailyAim ?? '',
       dailyIngredientIds: payload.dailyIngredientIds ?? [],
@@ -157,6 +159,7 @@ export async function savePlan(
           title: blk.title.slice(0, 60),
           description: blk.description.slice(0, 500),
           color: blk.color,
+          colorPreset: blk.colorPreset || null,
           ingredientIds: blk.ingredientIds,
           updatedAt: now,
         })
@@ -176,6 +179,7 @@ export async function savePlan(
           title: blk.title.slice(0, 60),
           description: blk.description.slice(0, 500),
           color: blk.color,
+          colorPreset: blk.colorPreset || null,
           ingredientIds: blk.ingredientIds,
           createdAt: now,
           updatedAt: now,

--- a/types/plan.ts
+++ b/types/plan.ts
@@ -15,6 +15,7 @@ export interface PlanBlock {
   title: string;
   description: string;
   color: string;
+  colorPreset?: string;
   ingredientIds: number[];
   createdAt: string;
   updatedAt: string;
@@ -27,5 +28,6 @@ export interface PlanBlockInput {
   title: string;
   description: string;
   color: string;
+  colorPreset?: string;
   ingredientIds: number[];
 }


### PR DESCRIPTION
## Summary
- allow selecting color presets with defaults and personal saved options
- store preset name on plan blocks and let viewers copy presets
- support color preset persistence and migration

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c95d6fe0832aa7aedab6aa181240