### PR TITLE
feat: add color preset picker for planning

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -164,3 +164,11 @@
 - 2025-10-24: Extended NextAuth session tolerance to prevent JWT expiry when overriding the site clock.
 - 2025-10-25: Enabled viewing mode access to Review Today’s Planning, documented new IDs, and added viewer review test.
 - 2025-10-25: Show ingredient names in viewer modes, link public ingredients to detail pages, and label private ones as Secret.
+- 2025-10-25: Added color preset picker with default palettes and personal presets; viewers can copy presets from plans.
+- 2025-10-25: Showed custom presets above defaults and allowed copying presets via picker in viewer and snapshot modes.
+- 2025-10-25: Exposed plan owner's presets in viewer picker and ensured copying adds them to My presets.
+- 2025-10-25: Captured preset libraries in plan snapshots, surfaced historical presets in snapshot mode, and added remove buttons for custom presets.
+- 2025-10-25: Synced copied color presets to My presets across viewer and owner pages using storage events.
+- 2025-10-25: Hid personal presets on foreign profiles so viewers only see the plan owner's palettes.
+- 2025-10-25: Fixed copying presets so selections reliably persist to My presets via local storage events.
+- 2025-10-25: Assigned unique IDs to color presets so copies remain available after returning to your own planning page.

--- a/app/(app)/planning/next/actions.ts
+++ b/app/(app)/planning/next/actions.ts
@@ -5,6 +5,7 @@ import { ensureUser } from '@/lib/users';
 import { assertOwner } from '@/lib/profile';
 import { savePlan, getPlanStrict } from '@/lib/plans-store';
 import type { PlanBlockInput } from '@/types/plan';
+import type { ColorPreset } from '@/lib/color-presets';
 import { revalidatePath } from 'next/cache';
 
 export async function savePlanAction(
@@ -12,6 +13,7 @@ export async function savePlanAction(
   blocks: PlanBlockInput[],
   dailyAim: string,
   dailyIngredientIds: number[],
+  colorPresets: ColorPreset[],
 ) {
   const session = await auth();
   const self = await ensureUser(session);
@@ -22,6 +24,7 @@ export async function savePlanAction(
     blocks,
     dailyAim,
     dailyIngredientIds,
+    colorPresets,
   );
   revalidatePath('/planning');
   return plan;
@@ -48,6 +51,7 @@ export async function addIngredientAction(
       plan.blocks,
       plan.dailyAim,
       dailyIngredientIds,
+      plan.colorPresets ?? [],
     );
   } else {
     const blocks = plan.blocks.map((b) =>
@@ -66,6 +70,7 @@ export async function addIngredientAction(
       blocks,
       plan.dailyAim,
       plan.dailyIngredientIds,
+      plan.colorPresets ?? [],
     );
   }
   revalidatePath('/planning/next');

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -10,6 +10,8 @@ import type { Plan, PlanBlock, PlanBlockInput } from '@/types/plan';
 import type { Ingredient } from '@/types/ingredient';
 import { savePlanAction } from './actions';
 import { cn } from '@/lib/utils';
+import ColorPresetPicker from '@/components/color-preset-picker';
+import { addUserColorPreset, getUserColorPresets } from '@/lib/color-presets';
 
 const COLORS = [
   '#F87171',
@@ -61,7 +63,7 @@ export default function EditorClient({
   review = false,
   initialShowDailyAim = false,
 }: Props) {
-  const { editable, viewId } = useViewContext();
+  const { editable, viewId, viewerId } = useViewContext();
   const mode = live ? 'live' : 'next';
   // Persist plans per-user and per-date. Live and review modes share the
   // same key while future planning uses its own so adjustments remain across
@@ -76,6 +78,7 @@ export default function EditorClient({
           return (JSON.parse(raw) as PlanBlock[]).map((b) => ({
             ...b,
             ingredientIds: b.ingredientIds ?? [],
+            colorPreset: b.colorPreset ?? '',
           }));
       } catch {
         // ignore malformed data
@@ -84,8 +87,28 @@ export default function EditorClient({
     return (initialPlan?.blocks ?? []).map((b) => ({
       ...b,
       ingredientIds: b.ingredientIds ?? [],
+      colorPreset: b.colorPreset ?? '',
     }));
   });
+  const foreignPresets = useMemo(() => {
+    if (initialPlan?.colorPresets && initialPlan.colorPresets.length > 0) {
+      return initialPlan.colorPresets.map((p) => ({
+        id: p.id,
+        name: p.name,
+        color: p.colors[0],
+      }));
+    }
+    const map = new Map<string, string>();
+    for (const b of blocks) {
+      if (b.colorPreset && b.color && !map.has(b.colorPreset)) {
+        map.set(b.colorPreset, b.color);
+      }
+    }
+    return Array.from(map.entries()).map(([name, color]) => ({
+      name,
+      color,
+    }));
+  }, [blocks, initialPlan?.colorPresets]);
   const [dailyAim, setDailyAim] = useState(() => initialPlan?.dailyAim ?? '');
   const [dailyIngredientIds, setDailyIngredientIds] = useState<number[]>(
     () => initialPlan?.dailyIngredientIds ?? [],
@@ -141,6 +164,7 @@ export default function EditorClient({
     }
     return {};
   });
+  const [showPresetPicker, setShowPresetPicker] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const selected = useMemo(
     () => blocks.find((b) => b.id === selectedId) || null,
@@ -416,6 +440,7 @@ export default function EditorClient({
       title: '',
       description: '',
       color: COLORS[0],
+      colorPreset: '',
       ingredientIds: [],
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
@@ -461,7 +486,13 @@ export default function EditorClient({
         // ignore malformed data
       }
     }
-    const nextBlocks = fromStorage?.blocks ?? initialPlan?.blocks ?? [];
+    const nextBlocks = (fromStorage?.blocks ?? initialPlan?.blocks ?? []).map(
+      (b) => ({
+        ...b,
+        ingredientIds: b.ingredientIds ?? [],
+        colorPreset: b.colorPreset ?? '',
+      }),
+    );
     const nextAim = fromStorage?.dailyAim ?? initialPlan?.dailyAim ?? '';
     const nextIng =
       fromStorage?.dailyIngredientIds ?? initialPlan?.dailyIngredientIds ?? [];
@@ -502,9 +533,17 @@ export default function EditorClient({
         title: b.title,
         description: b.description,
         color: b.color,
+        colorPreset: b.colorPreset,
         ingredientIds: b.ingredientIds,
       }));
-      savePlanAction(date, payload, dailyAim, dailyIngredientIds).then(
+      const presetsSnapshot = getUserColorPresets(userId);
+      savePlanAction(
+        date,
+        payload,
+        dailyAim,
+        dailyIngredientIds,
+        presetsSnapshot,
+      ).then(
         (plan) => {
           setBlocks(plan.blocks);
           setDailyAim(plan.dailyAim);
@@ -533,6 +572,7 @@ export default function EditorClient({
     live,
     storageKey,
     review,
+    userId,
   ]);
 
   useEffect(() => {
@@ -547,13 +587,16 @@ export default function EditorClient({
           title: b.title,
           description: b.description,
           color: b.color,
+          colorPreset: b.colorPreset,
           ingredientIds: b.ingredientIds,
         }));
+        const presetsSnapshot = getUserColorPresets(userId);
         void savePlanAction(
           date,
           payload,
           dailyAimRef.current,
           dailyIngredientIdsRef.current,
+          presetsSnapshot,
         ).then((plan) => {
           const ser = JSON.stringify({
             blocks: plan.blocks,
@@ -569,7 +612,7 @@ export default function EditorClient({
         });
       }
     };
-  }, [date, editable, storageKey, review]);
+  }, [date, editable, storageKey, review, userId]);
 
   function handleTimeChange(id: string, field: 'start' | 'end', value: string) {
     if (review) return;
@@ -735,8 +778,8 @@ export default function EditorClient({
             className="sticky top-0 z-10 flex flex-wrap items-end gap-2 bg-gray-100 p-2 text-sm"
             onClick={(e) => e.stopPropagation()}
           >
-            {!review && (
-              editable ? (
+            {!review &&
+              (editable ? (
                 <button
                   id={`p1an-add-top-${userId}`}
                   onClick={() => addBlock()}
@@ -754,8 +797,7 @@ export default function EditorClient({
                 >
                   + Add timeslot
                 </button>
-              )
-            )}
+              ))}
             <button
               id={`p1an-range-btn-${userId}`}
               className="rounded border px-2 py-1"
@@ -1077,7 +1119,10 @@ export default function EditorClient({
                       <div key={iid} className="mb-2">
                         <div className="mb-1 flex items-center justify-between">
                           {link ? (
-                            <Link href={link} className="flex items-center gap-1">
+                            <Link
+                              href={link}
+                              className="flex items-center gap-1"
+                            >
                               {src ? (
                                 <img src={src} alt="" className="h-4 w-4" />
                               ) : (
@@ -1212,7 +1257,7 @@ export default function EditorClient({
                       : 'Write feedback on ingredient'}
                   </Button>
                 )}
-                  {selectIngredient && (
+                {selectIngredient && (
                   <div className="mb-2 text-sm text-gray-500">
                     Select an ingredient above
                   </div>
@@ -1276,12 +1321,75 @@ export default function EditorClient({
                       className="h-6 w-6 rounded"
                       style={{ background: c }}
                       onClick={() =>
-                        editable && updateBlock(selected.id, { color: c })
+                        editable &&
+                        updateBlock(selected.id, { color: c, colorPreset: '' })
                       }
                       disabled={!editable}
                     />
                   ))}
                 </div>
+                {selected.colorPreset && (
+                  <div className="mb-2 flex items-center gap-1 text-xs text-gray-500">
+                    <span>Preset: {selected.colorPreset}</span>
+                    {editable && (
+                      <button
+                        aria-label="Remove preset"
+                        className="rounded px-1 hover:bg-gray-200"
+                        onClick={() =>
+                          updateBlock(selected.id, { colorPreset: '' })
+                        }
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
+                )}
+                {(editable || viewerId) && (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="mb-2"
+                      id={`p1an-meta-col-pre-${selected.id}-${userId}`}
+                      onClick={() => setShowPresetPicker((s) => !s)}
+                    >
+                      Presets
+                    </Button>
+                    {showPresetPicker && (
+                      <ColorPresetPicker
+                        userId={String(viewerId ?? userId)}
+                        foreignPresets={
+                          viewerId && viewerId !== Number(userId)
+                            ? foreignPresets
+                            : undefined
+                        }
+                        initialCustom={
+                          !editable && viewerId === null
+                            ? initialPlan?.colorPresets
+                            : undefined
+                        }
+                        onSelect={({ id, name, color }) => {
+                          if (editable) {
+                            updateBlock(selected.id, {
+                              color,
+                              colorPreset: name,
+                            });
+                          } else if (viewerId) {
+                            if (window.confirm('Copy to own presets?')) {
+                              addUserColorPreset(String(viewerId), {
+                                id: id ?? crypto.randomUUID(),
+                                name,
+                                colors: [color],
+                              });
+                            }
+                          }
+                          setShowPresetPicker(false);
+                        }}
+                        onClose={() => setShowPresetPicker(false)}
+                      />
+                    )}
+                  </>
+                )}
                 <div className="mb-2 flex gap-2">
                   <div>
                     <label
@@ -1514,7 +1622,9 @@ export default function EditorClient({
                           </span>
                         )}
                         {dailyIngredientIds.map((iid) => {
-                          const ing = initialIngredients.find((i) => i.id === iid);
+                          const ing = initialIngredients.find(
+                            (i) => i.id === iid,
+                          );
                           const src = ing?.icon ? iconSrc(ing.icon) : null;
                           const selectable = selectDailyIngredient && editable;
                           const content = (
@@ -1537,7 +1647,9 @@ export default function EditorClient({
                               : `/ingredient/${ing.id}`);
                           const cls = cn(
                             'flex items-center gap-1 rounded border px-2 py-1',
-                            selectable ? 'cursor-pointer bg-gray-100 hover:bg-gray-200' : '',
+                            selectable
+                              ? 'cursor-pointer bg-gray-100 hover:bg-gray-200'
+                              : '',
                           );
                           if (link) {
                             return (
@@ -1565,7 +1677,9 @@ export default function EditorClient({
                       {Object.entries(reviews['day']?.ingredients ?? {}).map(
                         ([iidStr, text]) => {
                           const iid = Number(iidStr);
-                          const ing = initialIngredients.find((i) => i.id === iid);
+                          const ing = initialIngredients.find(
+                            (i) => i.id === iid,
+                          );
                           const src = ing?.icon ? iconSrc(ing.icon) : null;
                           const link =
                             ing &&
@@ -1653,9 +1767,7 @@ export default function EditorClient({
                           variant="outline"
                           size="sm"
                           className="mb-2"
-                          onClick={() =>
-                            setSelectDailyIngredient((s) => !s)
-                          }
+                          onClick={() => setSelectDailyIngredient((s) => !s)}
                         >
                           {selectDailyIngredient
                             ? 'Cancel ingredient feedback'

--- a/components/color-preset-picker.tsx
+++ b/components/color-preset-picker.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  DEFAULT_COLOR_PRESETS,
+  ColorPreset,
+  getUserColorPresets,
+  saveUserColorPresets,
+  removeUserColorPreset,
+  userColorPresetsKey,
+} from '@/lib/color-presets';
+import { useViewContext } from '@/lib/view-context';
+
+interface PickerProps {
+  userId: string;
+  foreignPresets?: { id?: string; name: string; color: string }[];
+  initialCustom?: ColorPreset[];
+  onSelect: (p: { id?: string; name: string; color: string }) => void;
+  onClose: () => void;
+}
+
+export default function ColorPresetPicker({
+  userId,
+  foreignPresets = [],
+  initialCustom,
+  onSelect,
+  onClose,
+}: PickerProps) {
+  const { editable, viewerId, ownerId } = useViewContext();
+  const viewingOther = viewerId !== null && viewerId !== ownerId;
+  const [custom, setCustom] = useState<ColorPreset[]>([]);
+  const [name, setName] = useState('');
+  const [color, setColor] = useState('#000000');
+
+  useEffect(() => {
+    if (viewingOther) return;
+    if (initialCustom) {
+      setCustom(initialCustom);
+    } else {
+      setCustom(getUserColorPresets(userId));
+    }
+  }, [userId, initialCustom, viewingOther]);
+
+  useEffect(() => {
+    if (viewingOther) return;
+    function handleStorage(e: StorageEvent) {
+      if (e.key === userColorPresetsKey(userId)) {
+        setCustom(getUserColorPresets(userId));
+      }
+    }
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [userId, viewingOther]);
+
+  function handleSave() {
+    if (!name.trim()) return;
+    const preset: ColorPreset = {
+      id: crypto.randomUUID(),
+      name: name.trim(),
+      colors: [color],
+    };
+    const next = [...custom, preset];
+    setCustom(next);
+    saveUserColorPresets(userId, next);
+    setName('');
+    onSelect({ id: preset.id, name: preset.name, color: preset.colors[0] });
+  }
+
+  return (
+    <div className="w-64 rounded border bg-white p-2 text-sm shadow">
+      {!viewingOther && (
+        <>
+          <div className="mb-2 font-semibold">Your presets</div>
+          {custom.length > 0 ? (
+            custom.map((p) => (
+              <div key={p.id} className="mb-1 flex items-center">
+                <button
+                  className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left hover:bg-gray-100"
+                  onClick={() => onSelect({ id: p.id, name: p.name, color: p.colors[0] })}
+                >
+                  <span
+                    className="h-4 w-4 rounded"
+                    style={{ background: p.colors[0] }}
+                  ></span>
+                  <span>{p.name}</span>
+                </button>
+                {editable && (
+                  <button
+                    aria-label="Remove preset"
+                    className="ml-1 text-gray-400 hover:text-gray-700"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      removeUserColorPreset(userId, p.id);
+                      setCustom((cs) => cs.filter((c) => c.id !== p.id));
+                    }}
+                  >
+                    ×
+                  </button>
+                )}
+              </div>
+            ))
+          ) : (
+            <div className="mb-2 text-gray-500">No presets yet</div>
+          )}
+        </>
+      )}
+      {foreignPresets.length > 0 && (
+        <>
+          <div className="mt-2 mb-2 font-semibold">Their presets</div>
+          {foreignPresets.map((p) => (
+            <button
+              key={`foreign-${p.id ?? p.name}`}
+              className="mb-1 flex w-full items-center gap-2 rounded px-1 py-0.5 text-left hover:bg-gray-100"
+              onClick={() => onSelect(p)}
+            >
+              <span
+                className="h-4 w-4 rounded"
+                style={{ background: p.color }}
+              ></span>
+              <span>{p.name}</span>
+            </button>
+          ))}
+        </>
+      )}
+      <div className="mt-2 mb-2 font-semibold">Presets</div>
+      {DEFAULT_COLOR_PRESETS.map((p) => (
+        <button
+          key={p.id}
+          className="mb-1 flex w-full items-center gap-2 rounded px-1 py-0.5 text-left hover:bg-gray-100"
+          onClick={() => onSelect({ id: p.id, name: p.name, color: p.colors[0] })}
+        >
+          <span
+            className="h-4 w-4 rounded"
+            style={{ background: p.colors[0] }}
+          ></span>
+          <span>{p.name}</span>
+        </button>
+      ))}
+      {editable && (
+        <div className="mt-2 flex items-center gap-1">
+          <input
+            className="w-full border p-1 text-xs"
+            value={name}
+            placeholder="Title"
+            onChange={(e) => setName(e.target.value)}
+          />
+          <input
+            type="color"
+            className="h-8 w-8 border p-0"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+          />
+          <Button size="sm" onClick={handleSave} id="clr-pre-add">
+            Save
+          </Button>
+        </div>
+      )}
+      <div className="mt-2 text-right">
+        <Button size="sm" variant="outline" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/drizzle/0016_add_plan_block_color_preset.sql
+++ b/drizzle/0016_add_plan_block_color_preset.sql
@@ -1,0 +1,1 @@
+ALTER TABLE plan_blocks ADD COLUMN color_preset varchar(60);

--- a/lib/color-presets.ts
+++ b/lib/color-presets.ts
@@ -1,0 +1,139 @@
+export interface ColorPreset {
+  id: string;
+  name: string;
+  colors: string[]; // primary, secondary, etc.
+}
+
+function slug(name: string) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+export const DEFAULT_COLOR_PRESETS: ColorPreset[] = [
+  {
+    id: slug('Focused work'),
+    name: 'Focused work',
+    colors: ['#2563EB', '#22D3EE', '#F1F5F9'],
+  },
+  {
+    id: slug('Studying – detail/recall'),
+    name: 'Studying – detail/recall',
+    colors: ['#334155', '#EF4444', '#FAFAFA'],
+  },
+  {
+    id: slug('Studying – concept building'),
+    name: 'Studying – concept building',
+    colors: ['#3B82F6', '#7C3AED', '#F0F9FF'],
+  },
+  {
+    id: slug('Gym – HIIT & strength'),
+    name: 'Gym – HIIT & strength',
+    colors: ['#DC2626', '#F97316', '#0B0F19'],
+  },
+  {
+    id: slug('Cardio & endurance'),
+    name: 'Cardio & endurance',
+    colors: ['#22C55E', '#86EFAC', '#F0FDF4'],
+  },
+  {
+    id: slug('Team sports / competition day'),
+    name: 'Team sports / competition day',
+    colors: ['#B91C1C', '#F59E0B', '#0A0A0A'],
+  },
+  {
+    id: slug('Planning / organizing'),
+    name: 'Planning / organizing',
+    colors: ['#14B8A6', '#F59E0B', '#F8FAFC'],
+  },
+  {
+    id: slug('Admin / chores'),
+    name: 'Admin / chores',
+    colors: ['#EAB308', '#22C55E', '#FFFBEB'],
+  },
+  {
+    id: slug('Creative work'),
+    name: 'Creative work',
+    colors: ['#0EA5E9', '#A78BFA', '#ECFEFF'],
+  },
+  {
+    id: slug('Social / networking'),
+    name: 'Social / networking',
+    colors: ['#F97316', '#FB7185', '#FFF7ED'],
+  },
+  {
+    id: slug('Relax / meditation'),
+    name: 'Relax / meditation',
+    colors: ['#38BDF8', '#86EFAC', '#E6FFFB'],
+  },
+  {
+    id: slug('Sleep prep'),
+    name: 'Sleep prep',
+    colors: ['#D97706', '#1F2937', '#FEF3C7'],
+  },
+  {
+    id: slug('Finance / budgeting'),
+    name: 'Finance / budgeting',
+    colors: ['#1D4ED8', '#93C5FD', '#EFF6FF'],
+  },
+];
+
+export function userColorPresetsKey(userId: string) {
+  return `color-presets-${userId}`;
+}
+
+export function getUserColorPresets(userId: string): ColorPreset[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(userColorPresetsKey(userId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter(
+        (p) =>
+          typeof p?.id === 'string' &&
+          typeof p?.name === 'string' &&
+          Array.isArray(p.colors),
+      );
+    }
+  } catch {
+    // ignore
+  }
+  return [];
+}
+
+export function saveUserColorPresets(userId: string, presets: ColorPreset[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(
+      userColorPresetsKey(userId),
+      JSON.stringify(presets),
+    );
+  } catch {
+    // ignore
+  }
+}
+
+export function addUserColorPreset(userId: string, preset: ColorPreset) {
+  const existing = getUserColorPresets(userId);
+  existing.push(preset);
+  saveUserColorPresets(userId, existing);
+  // Manually dispatch a storage event so open pages update immediately
+  try {
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: userColorPresetsKey(userId),
+        newValue: JSON.stringify(existing),
+      }),
+    );
+  } catch {
+    // ignore
+  }
+}
+
+export function removeUserColorPreset(userId: string, id: string) {
+  const existing = getUserColorPresets(userId);
+  const next = existing.filter((p) => p.id !== id);
+  saveUserColorPresets(userId, next);
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -194,6 +194,7 @@ export const planBlocks = pgTable('plan_blocks', {
   title: varchar('title', { length: 60 }),
   description: text('description'),
   color: varchar('color', { length: 10 }),
+  colorPreset: varchar('color_preset', { length: 60 }),
   ingredientIds: integer('ingredient_ids').array(),
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),

--- a/lib/plans-store.ts
+++ b/lib/plans-store.ts
@@ -2,6 +2,7 @@ import { db } from './db';
 import { plans, planBlocks, planRevisions } from './db/schema';
 import { eq, and, inArray, lte, desc } from 'drizzle-orm';
 import type { Plan, PlanBlock, PlanBlockInput } from '@/types/plan';
+import type { ColorPreset } from '@/lib/color-presets';
 
 function toPlanBlock(row: typeof planBlocks.$inferSelect): PlanBlock {
   return {
@@ -12,6 +13,7 @@ function toPlanBlock(row: typeof planBlocks.$inferSelect): PlanBlock {
     title: row.title ?? '',
     description: row.description ?? '',
     color: row.color ?? '#888888',
+    colorPreset: row.colorPreset ?? '',
     ingredientIds: row.ingredientIds ?? [],
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
     updatedAt: row.updatedAt?.toISOString() ?? new Date().toISOString(),
@@ -35,6 +37,7 @@ async function fetchPlan(userId: number, date: string): Promise<Plan | null> {
     blocks: blockRows.map(toPlanBlock),
     dailyAim: planRow.dailyAim ?? '',
     dailyIngredientIds: planRow.dailyIngredientIds ?? [],
+    colorPresets: [],
   };
 }
 
@@ -55,6 +58,7 @@ export async function getOrCreatePlan(
       blocks: [],
       dailyAim: '',
       dailyIngredientIds: [],
+      colorPresets: [],
     };
   }
   return plan;
@@ -73,6 +77,7 @@ export async function getPlanStrict(
     blocks: [],
     dailyAim: '',
     dailyIngredientIds: [],
+    colorPresets: [],
   };
 }
 
@@ -103,9 +108,11 @@ export async function getPlanAt(
       blocks: blocks.map((b) => ({
         ...b,
         ingredientIds: b.ingredientIds ?? [],
+        colorPreset: b.colorPreset ?? '',
       })),
       dailyAim: payload.dailyAim ?? '',
       dailyIngredientIds: payload.dailyIngredientIds ?? [],
+      colorPresets: (payload.colorPresets as ColorPreset[]) || [],
     };
   }
   // When no revision exists at or before the requested time, the user had not
@@ -119,6 +126,7 @@ export async function getPlanAt(
     blocks: [],
     dailyAim: '',
     dailyIngredientIds: [],
+    colorPresets: [],
   };
 }
 
@@ -128,6 +136,7 @@ export async function savePlan(
   blocks: PlanBlockInput[],
   dailyAim = '',
   dailyIngredientIds: number[] = [],
+  colorPresets: ColorPreset[] = [],
 ): Promise<Plan> {
   let planRow = await fetchPlan(Number(userId), date);
   if (!planRow) {
@@ -157,6 +166,7 @@ export async function savePlan(
           title: blk.title.slice(0, 60),
           description: blk.description.slice(0, 500),
           color: blk.color,
+          colorPreset: blk.colorPreset || null,
           ingredientIds: blk.ingredientIds,
           updatedAt: now,
         })
@@ -176,6 +186,7 @@ export async function savePlan(
           title: blk.title.slice(0, 60),
           description: blk.description.slice(0, 500),
           color: blk.color,
+          colorPreset: blk.colorPreset || null,
           ingredientIds: blk.ingredientIds,
           createdAt: now,
           updatedAt: now,
@@ -195,7 +206,7 @@ export async function savePlan(
   await db.insert(planRevisions).values({
     userId: Number(userId),
     planDate: date,
-    payload: { blocks: results, dailyAim, dailyIngredientIds },
+    payload: { blocks: results, dailyAim, dailyIngredientIds, colorPresets },
   });
   return {
     id: String(planRow.id),
@@ -204,5 +215,6 @@ export async function savePlan(
     blocks: results,
     dailyAim,
     dailyIngredientIds,
+    colorPresets,
   };
 }

--- a/types/plan.ts
+++ b/types/plan.ts
@@ -1,3 +1,5 @@
+import type { ColorPreset } from '@/lib/color-presets';
+
 export interface Plan {
   id: string;
   userId: string;
@@ -5,6 +7,7 @@ export interface Plan {
   blocks: PlanBlock[];
   dailyAim: string;
   dailyIngredientIds: number[];
+  colorPresets?: ColorPreset[];
 }
 
 export interface PlanBlock {
@@ -15,6 +18,7 @@ export interface PlanBlock {
   title: string;
   description: string;
   color: string;
+  colorPreset?: string;
   ingredientIds: number[];
   createdAt: string;
   updatedAt: string;
@@ -27,5 +31,6 @@ export interface PlanBlockInput {
   title: string;
   description: string;
   color: string;
+  colorPreset?: string;
   ingredientIds: number[];
 }


### PR DESCRIPTION
## Summary
- capture preset library snapshots with plans and show historical presets in viewer and snapshot modes
- allow removing presets and clearing applied presets via an "×" button
- sync copied color presets to "My presets" across viewer and owner pages using storage events
- hide personal presets on foreign profiles so viewers only see the owner's palettes
- ensure copying a preset reliably stores it in "My presets" by dispatching a storage event
- assign unique IDs to color presets so copied palettes remain available when returning to your own planning page

## Testing
- `pnpm lint`
- `pnpm tsc` *(fails: Cannot find module 'jose' or '@panva/hkdf')*
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c95d6fe0832aa7aedab6aa181240