### PR TITLE
fix: persist viewer color presets

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -175,3 +175,4 @@
 - 2025-10-25: Fixed copying foreign color presets on older browsers by falling back to a generated ID when `crypto.randomUUID` isn't available.
 - 2025-10-26: Ensured presets copied in viewing mode save to the viewer's library like snapshot copies.
 - 2025-10-26: Fixed preset copying to target the viewer's ID reliably and display foreign palettes when viewing other profiles.
+- 2025-10-26: Corrected live-mode preset copying to always use the viewer's ID and alert anonymous users.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -65,9 +65,11 @@ export default function EditorClient({
 }: Props) {
   const { editable, viewId, viewerId } = useViewContext();
   // Viewer id is null when editing own plan; otherwise it represents the
-  // currently logged-in user. This helper simplifies targeting the correct
-  // storage key for color presets in both owner and viewer modes.
-  const currentUserId = viewerId !== null ? String(viewerId) : userId;
+  // currently logged-in user. Some browsers may provide `undefined` before the
+  // context hydrates, so fall back to the owner id only when a viewer id is not
+  // present. This ensures copied presets in viewer mode target the viewer's
+  // library instead of the plan owner's.
+  const currentUserId = viewerId != null ? String(viewerId) : userId;
   const mode = live ? 'live' : 'next';
   // Persist plans per-user and per-date. Live and review modes share the
   // same key while future planning uses its own so adjustments remain across
@@ -1377,8 +1379,12 @@ export default function EditorClient({
                               colorPreset: name,
                             });
                           } else {
-                            if (window.confirm('Copy to own presets?')) {
-                              addUserColorPreset(currentUserId, {
+                            if (viewerId == null) {
+                              alert('Please sign in to copy presets.');
+                            } else if (
+                              window.confirm('Copy to own presets?')
+                            ) {
+                              addUserColorPreset(String(viewerId), {
                                 id,
                                 name,
                                 colors: [color],


### PR DESCRIPTION
## Summary
- ensure viewer color presets save under the correct user and handle undefined viewer ids
- warn unauthenticated viewers when copying presets

## Testing
- `pnpm lint`
- `pnpm exec tsc --noEmit` *(fails: Cannot find module 'jose' / '@panva/hkdf')*
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0d23128c832a88dc3565d8a56b99