### PR TITLE
fix: ensure copied presets save to viewer library

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -178,3 +178,4 @@
 - 2025-10-26: Corrected live-mode preset copying to always use the viewer's ID and alert anonymous users.
 - 2025-10-26: Generated fresh IDs when copying foreign color presets so they appear in My presets.
 - 2025-10-26: Merged copied presets into the viewer's library so they show up in My presets immediately.
+- 2025-10-26: Stored copied color presets under the viewer's ID in live view mode so they appear in My presets.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -549,24 +549,22 @@ export default function EditorClient({
         dailyAim,
         dailyIngredientIds,
         presetsSnapshot,
-      ).then(
-        (plan) => {
-          setBlocks(plan.blocks);
-          setDailyAim(plan.dailyAim);
-          setDailyIngredientIds(plan.dailyIngredientIds);
-          const ser = JSON.stringify({
-            blocks: plan.blocks,
-            dailyAim: plan.dailyAim,
-            dailyIngredientIds: plan.dailyIngredientIds,
-          });
-          lastSaved.current = ser;
-          try {
-            window.localStorage.setItem(storageKey, ser);
-          } catch {
-            // ignore write errors
-          }
-        },
-      );
+      ).then((plan) => {
+        setBlocks(plan.blocks);
+        setDailyAim(plan.dailyAim);
+        setDailyIngredientIds(plan.dailyIngredientIds);
+        const ser = JSON.stringify({
+          blocks: plan.blocks,
+          dailyAim: plan.dailyAim,
+          dailyIngredientIds: plan.dailyIngredientIds,
+        });
+        lastSaved.current = ser;
+        try {
+          window.localStorage.setItem(storageKey, ser);
+        } catch {
+          // ignore write errors
+        }
+      });
       saveTimer.current = null;
     }, 500);
   }, [
@@ -1379,15 +1377,16 @@ export default function EditorClient({
                               colorPreset: name,
                             });
                           } else {
-                            const targetId =
-                              viewerId != null ? String(viewerId) : userId;
                             if (viewerId == null) {
+                              // Viewer isn't signed in, so copying would save to
+                              // the plan owner's library. Block the action and
+                              // prompt them to log in first.
                               alert('Please sign in to copy presets.');
                             } else if (window.confirm('Copy to own presets?')) {
-                              // Generate a fresh ID to avoid clashes with the
-                              // original owner's preset and ensure it appears
-                              // in the viewer's library.
-                              addUserColorPreset(targetId, {
+                              // Save the preset under the viewer's ID so it
+                              // appears in their personal library regardless
+                              // of which plan/date they copied it from.
+                              addUserColorPreset(currentUserId, {
                                 name,
                                 colors: [color],
                               });


### PR DESCRIPTION
## Summary
- store copied color presets under the viewer's ID in live/view mode so they appear in My presets
- document the change in the update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68aabe2f5e78832a8c93aecd6a0582f5