### PR TITLE
feat: tag plan blocks with flavors

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -104,6 +104,8 @@ Modal form IDs:
 - `p1an-meta-igrd-add-{blockId}-{ownerId}` → add ingredient button.
 - `p1an-meta-igrd-review-{blockId}-{ownerId}` → toggle ingredient feedback.
 - `p1an-meta-igrd-none-{blockId}-{ownerId}` → ingredient empty state text.
+- `p1an-meta-flav-{blockId}-{ownerId}` → flavor tags container.
+- `p1an-meta-flav-add-{blockId}-{ownerId}` → reasoning behind activity button.
 - `p1an-daily-aim-{ownerId}` → open Daily Aim modal.
 - `p1an-day-aim-{ownerId}` → Daily Aim textarea.
 - `p1an-day-feedback-{ownerId}` → overall day feedback textarea.
@@ -173,6 +175,8 @@ Modal form IDs:
 - `igrd-plan-list-back-{ownerId}` → ingredient picker back button.
 - `igrd-plan-back-{ingredientId}-{ownerId}` → ingredient detail back button.
 - `igrd-plan-none-{ownerId}` → empty state text when no ingredients exist.
+- `f7av-plan-back-{flavorId}-{ownerId}` → flavor detail back button.
+- `s7ub-plan-back-{subflavorId}-{ownerId}` → subflavor detail back button.
 
 ## History Pages
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -179,3 +179,5 @@
 - 2025-10-26: Generated fresh IDs when copying foreign color presets so they appear in My presets.
 - 2025-10-26: Merged copied presets into the viewer's library so they show up in My presets immediately.
 - 2025-10-26: Stored copied color presets under the viewer's ID in live view mode so they appear in My presets.
+- 2025-10-27: Added flavor and subflavor tagging for planning blocks with selection modal, detail pages, and ID catalog entries.
+- 2025-10-27: Polished flavor tagging UI with orange add button, visible selection rings, scrollable metadata panel, higher modal z-index, and proper rendering of custom icons.

--- a/app/(app)/flavor/[id]/page.tsx
+++ b/app/(app)/flavor/[id]/page.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable @next/next/no-img-element */
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getFlavor } from '@/lib/flavors-store';
+import { notFound } from 'next/navigation';
+import BackButton from '@/components/back-button';
+
+function iconSrc(ic: string) {
+  if (ic.startsWith('data:')) return ic;
+  if (/^[A-Za-z0-9+/=]+$/.test(ic)) return `data:image/png;base64,${ic}`;
+  return null;
+}
+
+export default async function FlavorViewPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const fl = await getFlavor(String(me.id), id, me.id);
+  if (!fl) notFound();
+  return (
+    <div className="mx-auto max-w-xl space-y-2 p-4">
+      <BackButton id={`f7av-plan-back-${id}-${me.id}`} />
+      <h1 className="text-xl font-semibold">Flavor info</h1>
+      <div className="flex items-center gap-2">
+        {iconSrc(fl.icon) ? (
+          <img src={iconSrc(fl.icon) as string} alt="" className="h-6 w-6" />
+        ) : (
+          <span className="text-2xl">{fl.icon}</span>
+        )}
+        <span className="font-medium">{fl.name}</span>
+      </div>
+      <p className="text-sm">{fl.description}</p>
+      <p>Importance ({fl.importance})</p>
+      <p>Target % ({fl.targetMix})</p>
+      <p>Color: {fl.color}</p>
+      <p>Visibility: {fl.visibility}</p>
+    </div>
+  );
+}

--- a/app/(app)/flavors/[flavorId]/subflavors/actions.ts
+++ b/app/(app)/flavors/[flavorId]/subflavors/actions.ts
@@ -103,7 +103,7 @@ export async function copySubflavor(
   const session = await auth();
   const user = await ensureUser(session);
   await assertOwner(user.id, user.id);
-  const sub = await getSubflavor(fromUserId, subflavorId);
+    const sub = await getSubflavor(fromUserId, subflavorId, Number(user.id));
   if (!sub) throw new Error('Not found');
   const created = await createSubflavorStore(String(user.id), targetFlavorId, {
     flavorId: targetFlavorId,
@@ -128,7 +128,7 @@ export async function copySubflavorAsFlavor(
   const session = await auth();
   const user = await ensureUser(session);
   await assertOwner(user.id, user.id);
-  const sub = await getSubflavor(fromUserId, subflavorId);
+    const sub = await getSubflavor(fromUserId, subflavorId, Number(user.id));
   if (!sub) throw new Error('Not found');
   const created = await createFlavorStore(String(user.id), {
     name: sub.name,

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -90,7 +90,7 @@ export async function copyFlavor(
 ) {
   const session = await auth();
   const self = await ensureUser(session);
-  const source = await getFlavor(fromUserId, flavorId);
+    const source = await getFlavor(fromUserId, flavorId, Number(self.id));
   if (!source) throw new Error('Not found');
   const created = await createFlavorStore(String(self.id), {
     name: source.name,

--- a/app/(app)/planning/live/page.tsx
+++ b/app/(app)/planning/live/page.tsx
@@ -7,6 +7,8 @@ import { getOrCreatePlan } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from '../next/client';
 import { listIngredients } from '@/lib/ingredients-store';
+import { listFlavors } from '@/lib/flavors-store';
+import { listAllSubflavors } from '@/lib/subflavors-store';
 
 export const revalidate = 0;
 
@@ -29,6 +31,8 @@ export default async function PlanningLivePage({
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getOrCreatePlan(me.id, dateStr);
   const ingredients = await listIngredients(String(me.id), me.id);
+  const flavors = await listFlavors(String(me.id));
+  const subflavors = await listAllSubflavors(String(me.id));
   const overrideLabel = info.override
     ? `${info.now.toLocaleString('en-US', { timeZone: info.tz })} (tz: ${info.tz})`
     : null;
@@ -44,6 +48,8 @@ export default async function PlanningLivePage({
         initialPlan={plan}
         live
         ingredients={ingredients}
+        flavors={flavors}
+        subflavors={subflavors}
         initialShowDailyAim={showDailyAim}
       />
     </>

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -8,6 +8,8 @@ import { useViewContext } from '@/lib/view-context';
 import PlanningDateNav from './date-nav';
 import type { Plan, PlanBlock, PlanBlockInput } from '@/types/plan';
 import type { Ingredient } from '@/types/ingredient';
+import type { Flavor } from '@/types/flavor';
+import type { Subflavor } from '@/types/subflavor';
 import { savePlanAction } from './actions';
 import { cn } from '@/lib/utils';
 import ColorPresetPicker from '@/components/color-preset-picker';
@@ -47,6 +49,8 @@ interface Props {
   tz: string;
   initialPlan: Plan | null;
   ingredients?: Ingredient[];
+  flavors?: Flavor[];
+  subflavors?: Subflavor[];
   live?: boolean;
   review?: boolean;
   initialShowDailyAim?: boolean;
@@ -59,11 +63,14 @@ export default function EditorClient({
   tz,
   initialPlan,
   ingredients: initialIngredients = [],
+  flavors: initialFlavors = [],
+  subflavors: initialSubflavors = [],
   live = false,
   review = false,
   initialShowDailyAim = false,
 }: Props) {
-  const { editable, viewId, viewerId } = useViewContext();
+  const { editable, viewId, viewerId, mode: viewMode, snapshotDate, ownerId } =
+    useViewContext();
   // Viewer id is null when editing own plan; otherwise it represents the
   // currently logged-in user. Some browsers may provide `undefined` before the
   // context hydrates, so fall back to the owner id only when a viewer id is not
@@ -84,6 +91,8 @@ export default function EditorClient({
           return (JSON.parse(raw) as PlanBlock[]).map((b) => ({
             ...b,
             ingredientIds: b.ingredientIds ?? [],
+            flavorIds: b.flavorIds ?? [],
+            subflavorIds: b.subflavorIds ?? [],
             colorPreset: b.colorPreset ?? '',
           }));
       } catch {
@@ -93,6 +102,8 @@ export default function EditorClient({
     return (initialPlan?.blocks ?? []).map((b) => ({
       ...b,
       ingredientIds: b.ingredientIds ?? [],
+      flavorIds: b.flavorIds ?? [],
+      subflavorIds: b.subflavorIds ?? [],
       colorPreset: b.colorPreset ?? '',
     }));
   });
@@ -119,6 +130,13 @@ export default function EditorClient({
   const [dailyIngredientIds, setDailyIngredientIds] = useState<number[]>(
     () => initialPlan?.dailyIngredientIds ?? [],
   );
+  const [flavors] = useState(initialFlavors);
+  const [subflavors] = useState(initialSubflavors);
+  const [selectFlavor, setSelectFlavor] = useState(false);
+  const [flavorTab, setFlavorTab] = useState<'flavor' | 'subflavor'>('flavor');
+  const [flavorSearch, setFlavorSearch] = useState('');
+  const [tempFlavors, setTempFlavors] = useState<string[]>([]);
+  const [tempSubs, setTempSubs] = useState<string[]>([]);
   const [showDailyAim, setShowDailyAim] = useState(initialShowDailyAim);
   const hasDailyAim = useMemo(
     () => dailyAim.trim().length > 0 || dailyIngredientIds.length > 0,
@@ -179,6 +197,9 @@ export default function EditorClient({
   const [selectIngredient, setSelectIngredient] = useState(false);
   useEffect(() => {
     setSelectIngredient(false);
+  }, [selectedId]);
+  useEffect(() => {
+    setSelectFlavor(false);
   }, [selectedId]);
   const unreviewedIngredientIds = useMemo(() => {
     if (!selected) return [] as number[];
@@ -356,6 +377,22 @@ export default function EditorClient({
     });
   }
 
+  function removeFlavor(blockId: string, flavorId: string) {
+    const blk = blocks.find((b) => b.id === blockId);
+    if (!blk) return;
+    updateBlock(blockId, {
+      flavorIds: (blk.flavorIds || []).filter((id) => id !== flavorId),
+    });
+  }
+
+  function removeSubflavor(blockId: string, subId: string) {
+    const blk = blocks.find((b) => b.id === blockId);
+    if (!blk) return;
+    updateBlock(blockId, {
+      subflavorIds: (blk.subflavorIds || []).filter((id) => id !== subId),
+    });
+  }
+
   function removeDailyIngredient(ingredientId: number) {
     setDailyIngredientIds((ids) => ids.filter((id) => id !== ingredientId));
   }
@@ -448,6 +485,8 @@ export default function EditorClient({
       color: COLORS[0],
       colorPreset: '',
       ingredientIds: [],
+      flavorIds: [],
+      subflavorIds: [],
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
@@ -541,6 +580,8 @@ export default function EditorClient({
         color: b.color,
         colorPreset: b.colorPreset,
         ingredientIds: b.ingredientIds,
+        flavorIds: b.flavorIds,
+        subflavorIds: b.subflavorIds,
       }));
       const presetsSnapshot = getUserColorPresets(userId);
       savePlanAction(
@@ -593,6 +634,8 @@ export default function EditorClient({
           color: b.color,
           colorPreset: b.colorPreset,
           ingredientIds: b.ingredientIds,
+          flavorIds: b.flavorIds,
+          subflavorIds: b.subflavorIds,
         }));
         const presetsSnapshot = getUserColorPresets(userId);
         void savePlanAction(
@@ -1047,7 +1090,7 @@ export default function EditorClient({
         </div>
         {selected ? (
           <div
-            className="w-1/2 border-l p-4"
+            className="w-1/2 max-h-[90vh] overflow-y-auto border-l p-4"
             id={`p1an-meta-${selected.id}-${userId}`}
           >
             {review ? (
@@ -1512,6 +1555,143 @@ export default function EditorClient({
                     )}
                   </div>
                 </div>
+                <div>
+                  <label className="block text-sm font-medium">
+                    Flavors
+                  </label>
+                  <div
+                    id={`p1an-meta-flav-${selected.id}-${userId}`}
+                    className="mb-2 flex flex-wrap gap-2"
+                  >
+                    {(selected.flavorIds ?? []).length === 0 &&
+                      (selected.subflavorIds ?? []).length === 0 && (
+                        <span className="text-sm text-gray-500">
+                          No flavor selected
+                        </span>
+                      )}
+                    {(selected.flavorIds ?? []).map((fid) => {
+                      const fl = flavors.find((f) => f.id === fid);
+                      const src = fl?.icon ? iconSrc(fl.icon) : null;
+                      const content = (
+                        <>
+                          {src ? (
+                            <img src={src} alt="" className="h-4 w-4" />
+                          ) : (
+                            <span>{fl?.icon ?? '❓'}</span>
+                          )}
+                          <span className="text-sm">
+                            {fl?.name ?? 'Secret 🔒'}
+                          </span>
+                          {editable && fl && (
+                            <span
+                              className="ml-1 cursor-pointer"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                removeFlavor(selected.id, fid);
+                              }}
+                            >
+                              ×
+                            </span>
+                          )}
+                        </>
+                      );
+                      const link =
+                        fl &&
+                        (viewMode === 'historical'
+                          ? viewerId === ownerId
+                            ? `/history/self/${snapshotDate}/flavors/${fl.id}`
+                            : viewId
+                              ? `/history/${viewId}/${snapshotDate}/flavors/${fl.id}`
+                              : null
+                          : viewId
+                            ? `/view/${viewId}/flavor/${fl.id}`
+                            : `/flavor/${fl.id}`);
+                      return link ? (
+                        <Link
+                          key={fid}
+                          href={link}
+                          className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 shadow"
+                        >
+                          {content}
+                        </Link>
+                      ) : (
+                        <span
+                          key={fid}
+                          className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 shadow"
+                        >
+                          {content}
+                        </span>
+                      );
+                    })}
+                    {(selected.subflavorIds ?? []).map((sid) => {
+                      const sub = subflavors.find((s) => s.id === sid);
+                      const src = sub?.icon ? iconSrc(sub.icon) : null;
+                      const content = (
+                        <>
+                          {src ? (
+                            <img src={src} alt="" className="h-4 w-4" />
+                          ) : (
+                            <span>{sub?.icon ?? '❓'}</span>
+                          )}
+                          <span className="text-sm">
+                            {sub?.name ?? 'Secret 🔒'}
+                          </span>
+                          {editable && sub && (
+                            <span
+                              className="ml-1 cursor-pointer"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                removeSubflavor(selected.id, sid);
+                              }}
+                            >
+                              ×
+                            </span>
+                          )}
+                        </>
+                      );
+                      const link =
+                        sub &&
+                        (viewMode === 'historical'
+                          ? viewerId === ownerId
+                            ? `/history/self/${snapshotDate}/flavors/${sub.flavorId}/subflavors#s7ubflavourrow${sub.id}-${ownerId}`
+                            : viewId
+                              ? `/history/${viewId}/${snapshotDate}/flavors/${sub.flavorId}/subflavors#s7ubflavourrow${sub.id}-${ownerId}`
+                              : null
+                          : viewId
+                            ? `/view/${viewId}/subflavor/${sub.id}`
+                            : `/subflavor/${sub.id}`);
+                      return link ? (
+                        <Link
+                          key={sid}
+                          href={link}
+                          className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 shadow"
+                        >
+                          {content}
+                        </Link>
+                      ) : (
+                        <span
+                          key={sid}
+                          className="flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 shadow"
+                        >
+                          {content}
+                        </span>
+                      );
+                    })}
+                    {editable && (
+                      <button
+                        id={`p1an-meta-flav-add-${selected.id}-${userId}`}
+                        type="button"
+                        className="flex items-center gap-1 rounded-full bg-orange-200 px-3 py-1 text-orange-800 shadow"
+                        onClick={() => setSelectFlavor(true)}
+                      >
+                        <span>+</span>
+                        <span>Reasoning behind activity</span>
+                      </button>
+                    )}
+                  </div>
+                </div>
                 <div className="mt-4 flex gap-2">
                   {editable ? (
                     <Button
@@ -1900,6 +2080,123 @@ export default function EditorClient({
                   </Button>
                 </div>
               </>
+            )}
+          </div>
+        </div>
+      )}
+      {selectFlavor && selected && (
+        <div
+          className="fixed inset-0 z-[1000000] flex items-center justify-center bg-black/20 backdrop-blur"
+          onClick={() => setSelectFlavor(false)}
+        >
+          <div
+            className="w-96 max-h-[80vh] overflow-y-auto rounded bg-white p-4 shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-2 flex justify-between">
+              <div className="flex gap-2">
+                <button
+                  className={`px-2 py-1 ${flavorTab === 'flavor' ? 'border-b-2 border-black' : ''}`}
+                  onClick={() => setFlavorTab('flavor')}
+                >
+                  Main flavor
+                </button>
+                <button
+                  className={`px-2 py-1 ${flavorTab === 'subflavor' ? 'border-b-2 border-black' : ''}`}
+                  onClick={() => setFlavorTab('subflavor')}
+                >
+                  Subflavor
+                </button>
+              </div>
+              <button onClick={() => setSelectFlavor(false)}>×</button>
+            </div>
+            <input
+              type="text"
+              placeholder="Search"
+              value={flavorSearch}
+              onChange={(e) => setFlavorSearch(e.target.value)}
+              className="mb-2 w-full rounded border p-1"
+            />
+            <div className="max-h-60 overflow-y-auto">
+              {flavorTab === 'flavor'
+                ? flavors
+                    .filter((f) =>
+                      f.name.toLowerCase().includes(flavorSearch.toLowerCase()),
+                    )
+                    .map((f) => {
+                      const src = f.icon ? iconSrc(f.icon) : null;
+                      const selected = tempFlavors.includes(f.id);
+                      return (
+                        <div
+                          key={f.id}
+                          className={`flex cursor-pointer items-center gap-2 rounded p-1 ${selected ? 'ring-2 ring-orange-400 bg-orange-50' : ''}`}
+                          onClick={() =>
+                            setTempFlavors((prev) =>
+                              prev.includes(f.id)
+                                ? prev.filter((id) => id !== f.id)
+                                : [...prev, f.id],
+                            )
+                          }
+                        >
+                          {src ? (
+                            <img src={src} alt="" className="h-4 w-4" />
+                          ) : (
+                            <span>{f.icon}</span>
+                          )}
+                          <span>{f.name}</span>
+                        </div>
+                      );
+                    })
+                : subflavors
+                    .filter((s) =>
+                      s.name.toLowerCase().includes(flavorSearch.toLowerCase()),
+                    )
+                    .map((s) => {
+                      const src = s.icon ? iconSrc(s.icon) : null;
+                      const selected = tempSubs.includes(s.id);
+                      return (
+                        <div
+                          key={s.id}
+                          className={`flex cursor-pointer items-center gap-2 rounded p-1 ${selected ? 'ring-2 ring-orange-400 bg-orange-50' : ''}`}
+                          onClick={() =>
+                            setTempSubs((prev) =>
+                              prev.includes(s.id)
+                                ? prev.filter((id) => id !== s.id)
+                                : [...prev, s.id],
+                            )
+                          }
+                        >
+                          {src ? (
+                            <img src={src} alt="" className="h-4 w-4" />
+                          ) : (
+                            <span>{s.icon}</span>
+                          )}
+                          <span>{s.name}</span>
+                        </div>
+                      );
+                    })}
+            </div>
+            {(tempFlavors.length > 0 || tempSubs.length > 0) && (
+              <div className="mt-4 text-right">
+                <Button
+                  onClick={() => {
+                    updateBlock(selected.id, {
+                      flavorIds: Array.from(
+                        new Set([...(selected.flavorIds || []), ...tempFlavors]),
+                      ),
+                      subflavorIds: Array.from(
+                        new Set([...(selected.subflavorIds || []), ...tempSubs]),
+                      ),
+                    });
+                    setSelectFlavor(false);
+                    setTempFlavors([]);
+                    setTempSubs([]);
+                    setFlavorSearch('');
+                  }}
+                >
+                  Add
+                </Button>
+              </div>
             )}
           </div>
         </div>

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -7,6 +7,8 @@ import { getOrCreatePlan } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from './client';
 import { listIngredients } from '@/lib/ingredients-store';
+import { listFlavors } from '@/lib/flavors-store';
+import { listAllSubflavors } from '@/lib/subflavors-store';
 
 export const revalidate = 0;
 
@@ -33,6 +35,8 @@ export default async function PlanningNextPage({
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getOrCreatePlan(me.id, dateStr);
   const ingredients = await listIngredients(String(me.id), me.id);
+  const flavors = await listFlavors(String(me.id));
+  const subflavors = await listAllSubflavors(String(me.id));
   const overrideLabel = info.override
     ? `${info.now.toLocaleString('en-US', { timeZone: info.tz })} (tz: ${info.tz})`
     : null;
@@ -47,6 +51,8 @@ export default async function PlanningNextPage({
         tz={info.tz}
         initialPlan={plan}
         ingredients={ingredients}
+        flavors={flavors}
+        subflavors={subflavors}
         initialShowDailyAim={showDailyAim}
       />
     </>

--- a/app/(app)/planning/review/page.tsx
+++ b/app/(app)/planning/review/page.tsx
@@ -7,6 +7,8 @@ import { getPlanStrict } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from '../next/client';
 import { listIngredients } from '@/lib/ingredients-store';
+import { listFlavors } from '@/lib/flavors-store';
+import { listAllSubflavors } from '@/lib/subflavors-store';
 
 export const revalidate = 0;
 
@@ -29,6 +31,8 @@ export default async function PlanningReviewPage({
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getPlanStrict(me.id, dateStr);
   const ingredients = await listIngredients(String(me.id), me.id);
+  const flavors = await listFlavors(String(me.id));
+  const subflavors = await listAllSubflavors(String(me.id));
   const overrideLabel = info.override
     ? `${info.now.toLocaleString('en-US', { timeZone: info.tz })} (tz: ${info.tz})`
     : null;
@@ -45,6 +49,8 @@ export default async function PlanningReviewPage({
         live
         review
         ingredients={ingredients}
+        flavors={flavors}
+        subflavors={subflavors}
         initialShowDailyAim={showDailyAim}
       />
     </>

--- a/app/(app)/subflavor/[id]/page.tsx
+++ b/app/(app)/subflavor/[id]/page.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable @next/next/no-img-element */
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getSubflavor } from '@/lib/subflavors-store';
+import { notFound } from 'next/navigation';
+import BackButton from '@/components/back-button';
+
+function iconSrc(ic: string) {
+  if (ic.startsWith('data:')) return ic;
+  if (/^[A-Za-z0-9+/=]+$/.test(ic)) return `data:image/png;base64,${ic}`;
+  return null;
+}
+
+export default async function SubflavorViewPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const sub = await getSubflavor(String(me.id), id, me.id);
+  if (!sub) notFound();
+  return (
+    <div className="mx-auto max-w-xl space-y-2 p-4">
+      <BackButton id={`s7ub-plan-back-${id}-${me.id}`} />
+      <h1 className="text-xl font-semibold">Subflavor info</h1>
+      <div className="flex items-center gap-2">
+        {iconSrc(sub.icon) ? (
+          <img src={iconSrc(sub.icon) as string} alt="" className="h-6 w-6" />
+        ) : (
+          <span className="text-2xl">{sub.icon}</span>
+        )}
+        <span className="font-medium">{sub.name}</span>
+      </div>
+      <p className="text-sm">{sub.description}</p>
+      <p>Importance ({sub.importance})</p>
+      <p>Target % ({sub.targetMix})</p>
+      <p>Color: {sub.color}</p>
+      <p>Visibility: {sub.visibility}</p>
+    </div>
+  );
+}

--- a/app/(view)/view/[viewId]/flavor/[id]/page.tsx
+++ b/app/(view)/view/[viewId]/flavor/[id]/page.tsx
@@ -1,0 +1,45 @@
+/* eslint-disable @next/next/no-img-element */
+import { auth } from '@/lib/auth';
+import { ensureUser, getUserByViewId } from '@/lib/users';
+import { getFlavor } from '@/lib/flavors-store';
+import { notFound } from 'next/navigation';
+import BackButton from '@/components/back-button';
+
+function iconSrc(ic: string) {
+  if (ic.startsWith('data:')) return ic;
+  if (/^[A-Za-z0-9+/=]+$/.test(ic)) return `data:image/png;base64,${ic}`;
+  return null;
+}
+
+export default async function ViewFlavorPage({
+  params,
+}: {
+  params: Promise<{ viewId: string; id: string }>;
+}) {
+  const { viewId, id } = await params;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const fl = await getFlavor(String(owner.id), id, viewer?.id || null);
+  if (!fl) notFound();
+  return (
+    <div className="mx-auto max-w-xl space-y-2 p-4">
+      <BackButton id={`f7av-plan-back-${id}-${owner.id}`} />
+      <h1 className="text-xl font-semibold">Flavor info</h1>
+      <div className="flex items-center gap-2">
+        {iconSrc(fl.icon) ? (
+          <img src={iconSrc(fl.icon) as string} alt="" className="h-6 w-6" />
+        ) : (
+          <span className="text-2xl">{fl.icon}</span>
+        )}
+        <span className="font-medium">{fl.name}</span>
+      </div>
+      <p className="text-sm">{fl.description}</p>
+      <p>Importance ({fl.importance})</p>
+      <p>Target % ({fl.targetMix})</p>
+      <p>Color: {fl.color}</p>
+      <p>Visibility: {fl.visibility}</p>
+    </div>
+  );
+}

--- a/app/(view)/view/[viewId]/flavors/[flavorId]/subflavors/page.tsx
+++ b/app/(view)/view/[viewId]/flavors/[flavorId]/subflavors/page.tsx
@@ -19,7 +19,7 @@ export default async function ViewSubflavorsPage({
   const session = await auth();
   const viewer = session ? await ensureUser(session) : null;
   const subflavors = await listSubflavors(String(user.id), flavorId);
-  const flavor = await getFlavor(String(user.id), flavorId);
+  const flavor = await getFlavor(String(user.id), flavorId, viewer?.id || null);
   if (!flavor) notFound();
   const viewerFlavors = viewer ? await listFlavors(String(viewer.id)) : [];
   return (

--- a/app/(view)/view/[viewId]/subflavor/[id]/page.tsx
+++ b/app/(view)/view/[viewId]/subflavor/[id]/page.tsx
@@ -1,0 +1,45 @@
+/* eslint-disable @next/next/no-img-element */
+import { auth } from '@/lib/auth';
+import { ensureUser, getUserByViewId } from '@/lib/users';
+import { getSubflavor } from '@/lib/subflavors-store';
+import { notFound } from 'next/navigation';
+import BackButton from '@/components/back-button';
+
+function iconSrc(ic: string) {
+  if (ic.startsWith('data:')) return ic;
+  if (/^[A-Za-z0-9+/=]+$/.test(ic)) return `data:image/png;base64,${ic}`;
+  return null;
+}
+
+export default async function ViewSubflavorPage({
+  params,
+}: {
+  params: Promise<{ viewId: string; id: string }>;
+}) {
+  const { viewId, id } = await params;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const sub = await getSubflavor(String(owner.id), id, viewer?.id || null);
+  if (!sub) notFound();
+  return (
+    <div className="mx-auto max-w-xl space-y-2 p-4">
+      <BackButton id={`s7ub-plan-back-${id}-${owner.id}`} />
+      <h1 className="text-xl font-semibold">Subflavor info</h1>
+      <div className="flex items-center gap-2">
+        {iconSrc(sub.icon) ? (
+          <img src={iconSrc(sub.icon) as string} alt="" className="h-6 w-6" />
+        ) : (
+          <span className="text-2xl">{sub.icon}</span>
+        )}
+        <span className="font-medium">{sub.name}</span>
+      </div>
+      <p className="text-sm">{sub.description}</p>
+      <p>Importance ({sub.importance})</p>
+      <p>Target % ({sub.targetMix})</p>
+      <p>Color: {sub.color}</p>
+      <p>Visibility: {sub.visibility}</p>
+    </div>
+  );
+}

--- a/app/(view)/view/[viewId]/subflavors/client.tsx
+++ b/app/(view)/view/[viewId]/subflavors/client.tsx
@@ -9,6 +9,12 @@ import {
 import { useViewContext } from '@/lib/view-context';
 import { useState } from 'react';
 
+function iconSrc(ic: string) {
+  if (ic.startsWith('data:')) return ic;
+  if (/^[A-Za-z0-9+/=]+$/.test(ic)) return `data:image/png;base64,${ic}`;
+  return null;
+}
+
 export default function AllSubflavorsClient({
   userId,
   selfId,
@@ -55,13 +61,21 @@ export default function AllSubflavorsClient({
                   className="flex items-center justify-between rounded border p-2"
                 >
                   <div className="flex items-center gap-2">
-                    <span
-                      aria-label={s.name}
-                      className="text-2xl"
-                      style={{ color: s.color }}
-                    >
-                      {s.icon}
-                    </span>
+                    {iconSrc(s.icon) ? (
+                      <img
+                        src={iconSrc(s.icon) as string}
+                        alt=""
+                        className="h-6 w-6"
+                      />
+                    ) : (
+                      <span
+                        aria-label={s.name}
+                        className="text-2xl"
+                        style={{ color: s.color }}
+                      >
+                        {s.icon}
+                      </span>
+                    )}
                     <div className="min-w-0">
                       <div className="font-semibold">{s.name}</div>
                       <div className="truncate text-sm text-gray-600">

--- a/app/api/flavors/[id]/route.ts
+++ b/app/api/flavors/[id]/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: Request, context: any) {
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const flavor = await getFlavor(userId, params.id);
+  const flavor = await getFlavor(userId, params.id, Number(userId));
   if (!flavor) return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json(flavor);
 }

--- a/app/api/subflavors/[id]/route.ts
+++ b/app/api/subflavors/[id]/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: Request, context: any) {
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const subflavor = await getSubflavor(userId, params.id);
+  const subflavor = await getSubflavor(userId, params.id, Number(userId));
   if (!subflavor)
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   return NextResponse.json(subflavor);

--- a/drizzle/0017_add_plan_block_flavors.sql
+++ b/drizzle/0017_add_plan_block_flavors.sql
@@ -1,0 +1,2 @@
+ALTER TABLE plan_blocks ADD COLUMN flavor_ids text[];
+ALTER TABLE plan_blocks ADD COLUMN subflavor_ids text[];

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -196,6 +196,8 @@ export const planBlocks = pgTable('plan_blocks', {
   color: varchar('color', { length: 10 }),
   colorPreset: varchar('color_preset', { length: 60 }),
   ingredientIds: integer('ingredient_ids').array(),
+  flavorIds: text('flavor_ids').array(),
+  subflavorIds: text('subflavor_ids').array(),
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),
 });

--- a/lib/plans-store.ts
+++ b/lib/plans-store.ts
@@ -16,6 +16,8 @@ function toPlanBlock(row: typeof planBlocks.$inferSelect): PlanBlock {
     color: row.color ?? '#888888',
     colorPreset: row.colorPreset ?? '',
     ingredientIds: row.ingredientIds ?? [],
+    flavorIds: row.flavorIds ?? [],
+    subflavorIds: row.subflavorIds ?? [],
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
     updatedAt: row.updatedAt?.toISOString() ?? new Date().toISOString(),
   };
@@ -109,6 +111,8 @@ export async function getPlanAt(
       blocks: blocks.map((b) => ({
         ...b,
         ingredientIds: b.ingredientIds ?? [],
+        flavorIds: b.flavorIds ?? [],
+        subflavorIds: b.subflavorIds ?? [],
         colorPreset: b.colorPreset ?? '',
       })),
       dailyAim: payload.dailyAim ?? '',
@@ -169,13 +173,15 @@ export async function savePlan(
         .set({
           start: new Date(blk.start),
           end: new Date(blk.end),
-          title: blk.title.slice(0, 60),
-          description: blk.description.slice(0, 500),
-          color: blk.color,
-          colorPreset: blk.colorPreset || null,
-          ingredientIds: blk.ingredientIds,
-          updatedAt: now,
-        })
+        title: blk.title.slice(0, 60),
+        description: blk.description.slice(0, 500),
+        color: blk.color,
+        colorPreset: blk.colorPreset || null,
+        ingredientIds: blk.ingredientIds,
+        flavorIds: blk.flavorIds,
+        subflavorIds: blk.subflavorIds,
+        updatedAt: now,
+      })
         .where(eq(planBlocks.id, blk.id))
         .returning();
       results.push(toPlanBlock(row));
@@ -189,14 +195,16 @@ export async function savePlan(
           planId: Number(planRow.id),
           start: new Date(blk.start),
           end: new Date(blk.end),
-          title: blk.title.slice(0, 60),
-          description: blk.description.slice(0, 500),
-          color: blk.color,
-          colorPreset: blk.colorPreset || null,
-          ingredientIds: blk.ingredientIds,
-          createdAt: now,
-          updatedAt: now,
-        })
+        title: blk.title.slice(0, 60),
+        description: blk.description.slice(0, 500),
+        color: blk.color,
+        colorPreset: blk.colorPreset || null,
+        ingredientIds: blk.ingredientIds,
+        flavorIds: blk.flavorIds,
+        subflavorIds: blk.subflavorIds,
+        createdAt: now,
+        updatedAt: now,
+      })
         .returning();
       results.push(toPlanBlock(row));
     }

--- a/tests/history-plans.spec.ts
+++ b/tests/history-plans.spec.ts
@@ -41,14 +41,16 @@ test('historical plans keep past versions', async ({ page }) => {
 
   const user = await getUserByHandle(handle);
   const blocksA = [
-    {
-      start: iso(future, 9),
-      end: iso(future, 10),
-      title: 'Old',
-      description: '',
-      color: '#F87171',
-      ingredientIds: [],
-    },
+      {
+        start: iso(future, 9),
+        end: iso(future, 10),
+        title: 'Old',
+        description: '',
+        color: '#F87171',
+        ingredientIds: [],
+        flavorIds: [],
+        subflavorIds: [],
+      },
   ];
   await savePlan(String(user.id), future, blocksA);
   await createProfileSnapshot(user.id, todayStr);
@@ -56,14 +58,16 @@ test('historical plans keep past versions', async ({ page }) => {
   if (!snap) throw new Error('missing snapshot');
   await new Promise((r) => setTimeout(r, 1000));
   const blocksB = [
-    {
-      start: iso(future, 9),
-      end: iso(future, 10),
-      title: 'New',
-      description: '',
-      color: '#34D399',
-      ingredientIds: [],
-    },
+      {
+        start: iso(future, 9),
+        end: iso(future, 10),
+        title: 'New',
+        description: '',
+        color: '#34D399',
+        ingredientIds: [],
+        flavorIds: [],
+        subflavorIds: [],
+      },
   ];
   await savePlan(String(user.id), future, blocksB);
 
@@ -91,14 +95,16 @@ test('plans added after snapshot are hidden from past snapshots', async ({
   await createProfileSnapshot(user.id, todayStr);
 
   const blocks = [
-    {
-      start: iso(future, 9),
-      end: iso(future, 10),
-      title: 'Future',
-      description: '',
-      color: '#FBBF24',
-      ingredientIds: [],
-    },
+      {
+        start: iso(future, 9),
+        end: iso(future, 10),
+        title: 'Future',
+        description: '',
+        color: '#FBBF24',
+        ingredientIds: [],
+        flavorIds: [],
+        subflavorIds: [],
+      },
   ];
   await savePlan(String(user.id), future, blocks);
 

--- a/types/plan.ts
+++ b/types/plan.ts
@@ -20,6 +20,8 @@ export interface PlanBlock {
   color: string;
   colorPreset?: string;
   ingredientIds: number[];
+  flavorIds: string[];
+  subflavorIds: string[];
   createdAt: string;
   updatedAt: string;
 }
@@ -33,4 +35,6 @@ export interface PlanBlockInput {
   color: string;
   colorPreset?: string;
   ingredientIds: number[];
+  flavorIds: string[];
+  subflavorIds: string[];
 }


### PR DESCRIPTION
## Summary
- allow selecting flavors and subflavors for planning blocks
- add flavor and subflavor detail pages
- document new planning flavor IDs
- polish flavor picker with orange add button, scrollable panel, selection highlighting, and custom icon rendering

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0e85f8c4832ab40b60bb2f11726e