### PR TITLE
fix: keep planning metadata open

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -181,3 +181,5 @@
 - 2025-10-26: Stored copied color presets under the viewer's ID in live view mode so they appear in My presets.
 - 2025-10-27: Added flavor and subflavor tagging for planning blocks with selection modal, detail pages, and ID catalog entries.
 - 2025-10-27: Polished flavor tagging UI with orange add button, visible selection rings, scrollable metadata panel, higher modal z-index, and proper rendering of custom icons.
+- 2025-10-27: Prevented planner metadata from auto-closing; panels now stay open until manually dismissed or the page unloads.
+- 2025-10-27: Removed outside-click auto-close and reset drag state so metadata opens on single clicks and stays open until closed.


### PR DESCRIPTION
## Summary
- keep planning metadata panel open until closed
- remove outside-click handler and reset drag flag for responsive metadata

## Testing
- `pnpm lint`
- `pnpm tsc` *(fails: Cannot find module 'jose' or '@panva/hkdf')*
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68ac61f4d0bc832a9fc4df1fd1dc393a