### PR TITLE
fix: keep planning metadata open

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -181,3 +181,7 @@
 - 2025-10-26: Stored copied color presets under the viewer's ID in live view mode so they appear in My presets.
 - 2025-10-27: Added flavor and subflavor tagging for planning blocks with selection modal, detail pages, and ID catalog entries.
 - 2025-10-27: Polished flavor tagging UI with orange add button, visible selection rings, scrollable metadata panel, higher modal z-index, and proper rendering of custom icons.
+- 2025-10-27: Prevented planner metadata from auto-closing; panels now stay open until manually dismissed or the page unloads.
+- 2025-10-27: Removed outside-click auto-close and reset drag state so metadata opens on single clicks and stays open until closed.
+- 2025-10-27: Preserved open metadata after autosave by remapping temporary timeslot IDs to server-issued IDs.
+- 2025-10-27: Kept planner metadata open during autosave by matching blocks by id or time so typing doesn't close panels.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -69,8 +69,14 @@ export default function EditorClient({
   review = false,
   initialShowDailyAim = false,
 }: Props) {
-  const { editable, viewId, viewerId, mode: viewMode, snapshotDate, ownerId } =
-    useViewContext();
+  const {
+    editable,
+    viewId,
+    viewerId,
+    mode: viewMode,
+    snapshotDate,
+    ownerId,
+  } = useViewContext();
   // Viewer id is null when editing own plan; otherwise it represents the
   // currently logged-in user. Some browsers may provide `undefined` before the
   // context hydrates, so fall back to the owner id only when a viewer id is not
@@ -190,6 +196,15 @@ export default function EditorClient({
   });
   const [showPresetPicker, setShowPresetPicker] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [metaPinned, setMetaPinned] = useState(false);
+  const openMeta = useCallback((id: string) => {
+    setSelectedId(id);
+    setMetaPinned(true);
+  }, []);
+  const closeMeta = useCallback(() => {
+    setSelectedId(null);
+    setMetaPinned(false);
+  }, []);
   const selected = useMemo(
     () => blocks.find((b) => b.id === selectedId) || null,
     [blocks, selectedId],
@@ -223,6 +238,19 @@ export default function EditorClient({
     const reviewed = reviews['day']?.ingredients || {};
     return dailyIngredientIds.filter((iid) => !(iid in reviewed));
   }, [dailyIngredientIds, reviews]);
+  useEffect(() => {
+    const handler = () => closeMeta();
+    if (typeof window !== 'undefined') {
+      window.addEventListener('pagehide', handler);
+      window.addEventListener('beforeunload', handler);
+    }
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('pagehide', handler);
+        window.removeEventListener('beforeunload', handler);
+      }
+    };
+  }, [closeMeta]);
   const draggingRef = useRef(false);
   const [startMinute, setStartMinute] = useState(DEFAULT_START);
   const [endMinute, setEndMinute] = useState(DEFAULT_END);
@@ -491,7 +519,7 @@ export default function EditorClient({
       updatedAt: new Date().toISOString(),
     };
     setBlocks((b) => [...b, newBlock]);
-    setSelectedId(id);
+    openMeta(id);
   }
 
   const lastSaved = useRef(
@@ -584,28 +612,41 @@ export default function EditorClient({
         subflavorIds: b.subflavorIds,
       }));
       const presetsSnapshot = getUserColorPresets(userId);
-      savePlanAction(
-        date,
-        payload,
-        dailyAim,
-        dailyIngredientIds,
-        presetsSnapshot,
-      ).then((plan) => {
-        setBlocks(plan.blocks);
-        setDailyAim(plan.dailyAim);
-        setDailyIngredientIds(plan.dailyIngredientIds);
-        const ser = JSON.stringify({
-          blocks: plan.blocks,
-          dailyAim: plan.dailyAim,
-          dailyIngredientIds: plan.dailyIngredientIds,
+        savePlanAction(
+          date,
+          payload,
+          dailyAim,
+          dailyIngredientIds,
+          presetsSnapshot,
+        ).then((plan) => {
+          const prevSelected =
+            metaPinned && selectedId
+              ? blocksRef.current.find((b) => b.id === selectedId)
+              : null;
+          setBlocks(plan.blocks);
+          setDailyAim(plan.dailyAim);
+          setDailyIngredientIds(plan.dailyIngredientIds);
+          if (prevSelected) {
+            const match =
+              plan.blocks.find((b) => b.id === prevSelected.id) ??
+              plan.blocks.find(
+                (b) => b.start === prevSelected.start && b.end === prevSelected.end,
+              );
+            if (match) setSelectedId(match.id);
+            else closeMeta();
+          }
+          const ser = JSON.stringify({
+            blocks: plan.blocks,
+            dailyAim: plan.dailyAim,
+            dailyIngredientIds: plan.dailyIngredientIds,
+          });
+          lastSaved.current = ser;
+          try {
+            window.localStorage.setItem(storageKey, ser);
+          } catch {
+            // ignore write errors
+          }
         });
-        lastSaved.current = ser;
-        try {
-          window.localStorage.setItem(storageKey, ser);
-        } catch {
-          // ignore write errors
-        }
-      });
       saveTimer.current = null;
     }, 500);
   }, [
@@ -618,6 +659,9 @@ export default function EditorClient({
     storageKey,
     review,
     userId,
+    metaPinned,
+    selectedId,
+    closeMeta,
   ]);
 
   useEffect(() => {
@@ -749,6 +793,7 @@ export default function EditorClient({
     function onUp() {
       window.removeEventListener('pointermove', onMove);
       window.removeEventListener('pointerup', onUp);
+      dragRef.current = false;
     }
     window.addEventListener('pointermove', onMove);
     window.addEventListener('pointerup', onUp);
@@ -798,10 +843,10 @@ export default function EditorClient({
   }, [liveBlocks, minutesFromIso]);
 
   useEffect(() => {
-    if (!live) return;
+    if (!live || metaPinned) return;
     if (currentBlock) setSelectedId(currentBlock.id);
     else setSelectedId(null);
-  }, [live, currentBlock]);
+  }, [live, currentBlock, metaPinned]);
 
   const lineColor = useMemo(() => {
     if (!live) return '#FF0000';
@@ -819,7 +864,6 @@ export default function EditorClient({
         <div
           className={`relative overflow-y-hidden ${selected ? 'w-1/2' : 'w-full'}`}
           id={`p1an-timecol-${userId}`}
-          onPointerDown={() => setSelectedId(null)}
         >
           <div
             className="sticky top-0 z-10 flex flex-wrap items-end gap-2 bg-gray-100 p-2 text-sm"
@@ -1037,7 +1081,7 @@ export default function EditorClient({
                       if (draggingRef.current) return;
                       if (review && live && nowMinute < minutesFromIso(b.end))
                         return;
-                      setSelectedId(b.id);
+                      openMeta(b.id);
                     }}
                   >
                     <span className="pointer-events-none block truncate">
@@ -1313,7 +1357,7 @@ export default function EditorClient({
                   <Button
                     variant="outline"
                     id={`p1an-meta-close-${userId}`}
-                    onClick={() => setSelectedId(null)}
+                    onClick={closeMeta}
                   >
                     X
                   </Button>
@@ -1556,9 +1600,7 @@ export default function EditorClient({
                   </div>
                 </div>
                 <div>
-                  <label className="block text-sm font-medium">
-                    Flavors
-                  </label>
+                  <label className="block text-sm font-medium">Flavors</label>
                   <div
                     id={`p1an-meta-flav-${selected.id}-${userId}`}
                     className="mb-2 flex flex-wrap gap-2"
@@ -1702,7 +1744,7 @@ export default function EditorClient({
                         setBlocks((prev) =>
                           prev.filter((blk) => blk.id !== selected.id),
                         );
-                        setSelectedId(null);
+                        closeMeta();
                       }}
                     >
                       Delete
@@ -1721,7 +1763,7 @@ export default function EditorClient({
                   <Button
                     variant="outline"
                     id={`p1an-meta-close-${userId}`}
-                    onClick={() => setSelectedId(null)}
+                    onClick={closeMeta}
                   >
                     X
                   </Button>
@@ -2182,10 +2224,16 @@ export default function EditorClient({
                   onClick={() => {
                     updateBlock(selected.id, {
                       flavorIds: Array.from(
-                        new Set([...(selected.flavorIds || []), ...tempFlavors]),
+                        new Set([
+                          ...(selected.flavorIds || []),
+                          ...tempFlavors,
+                        ]),
                       ),
                       subflavorIds: Array.from(
-                        new Set([...(selected.subflavorIds || []), ...tempSubs]),
+                        new Set([
+                          ...(selected.subflavorIds || []),
+                          ...tempSubs,
+                        ]),
                       ),
                     });
                     setSelectFlavor(false);


### PR DESCRIPTION
## Summary
- prevent autosave updates from closing planner metadata by matching blocks by id or time
- document behavior in UPDATE log

## Testing
- `pnpm lint`
- `pnpm tsc` *(fails: Cannot find module 'jose' or '@panva/hkdf')*
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*


------
https://chatgpt.com/codex/tasks/task_e_68ac61f4d0bc832a9fc4df1fd1dc393a