### PR TITLE
feat: add progress chat and logs viewer

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -187,3 +187,4 @@
 - 2025-10-27: Kept planner metadata open during autosave by matching blocks by id or time so typing doesn't close panels.
 - 2025-10-27: Improved planning block title visibility with contrast-based text color and responsive font sizing.
 - 2025-10-27: Added LLM integration guide (LLM.md) and updated Agents guidelines to reference it.
+- 2025-10-27: Added progress test chat with mock LLM, hidden logs viewer unlock via repeated logo click, and global AI request logging.

--- a/app/api/testchat/route.ts
+++ b/app/api/testchat/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { message } = await req.json();
+  return NextResponse.json({ reply: `Echo: ${message}` });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import { cookies } from 'next/headers';
+import { LogsProvider } from '@/components/logs-provider';
 
 export default async function RootLayout({
   children,
@@ -70,7 +71,9 @@ export default async function RootLayout({
           }}
         />
       </head>
-      <body>{children}</body>
+      <body>
+        <LogsProvider>{children}</LogsProvider>
+      </body>
     </html>
   );
 }

--- a/app/marketing/page.tsx
+++ b/app/marketing/page.tsx
@@ -1,9 +1,34 @@
+'use client';
 import Link from 'next/link';
+import { useState } from 'react';
+import { useLogs } from '@/components/logs-provider';
 
 export default function MarketingPage() {
+  const [clicks, setClicks] = useState(0);
+  const { enableLogs } = useLogs();
+
+  function handleSecretClick() {
+    setClicks((c) => {
+      const next = c + 1;
+      if (next === 5) {
+        const code = prompt('Enter access code');
+        if (code === '123Yergush123') {
+          enableLogs();
+        }
+      }
+      return next;
+    });
+  }
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-6">
-      <h1 className="text-4xl font-bold mb-4">A Piece of Cake</h1>
+      <h1 className="text-4xl font-bold mb-4">
+        A Piece{' '}
+        <span onClick={handleSecretClick} className="cursor-pointer">
+          O
+        </span>
+        f Cake
+      </h1>
       <Link
         href="/signin"
         className="bg-orange-500 text-white px-4 py-2 rounded"

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+export default function ProgressPage() {
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl mb-4">Progress</h1>
+      <Link
+        href="/progress/testchat"
+        className="bg-orange-500 text-white px-4 py-2 rounded"
+      >
+        Chat with llm
+      </Link>
+    </main>
+  );
+}

--- a/app/progress/testchat/page.tsx
+++ b/app/progress/testchat/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+import { useState } from 'react';
+import { useLogs } from '@/components/logs-provider';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export default function TestChatPage() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const { addLog } = useLogs();
+
+  async function sendMessage() {
+    if (!input.trim()) return;
+    const userMsg: Message = { role: 'user', content: input };
+    setMessages((prev) => [...prev, userMsg]);
+    const res = await fetch('/api/testchat', {
+      method: 'POST',
+      body: JSON.stringify({ message: input }),
+    });
+    const data = await res.json();
+    const reply = data.reply as string;
+    const aiMsg: Message = { role: 'assistant', content: reply };
+    setMessages((prev) => [...prev, aiMsg]);
+    addLog({ request: input, response: reply });
+    setInput('');
+  }
+
+  function reset() {
+    setMessages([]);
+  }
+
+  return (
+    <div className="p-4">
+      <div className="mb-4 space-y-2">
+        {messages.map((m, i) => (
+          <div
+            key={i}
+            className={m.role === 'user' ? 'text-right' : 'text-left'}
+          >
+            <span className="inline-block rounded px-2 py-1 bg-gray-200">
+              {m.content}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="flex-grow border px-2 py-1"
+        />
+        <button
+          onClick={sendMessage}
+          className="bg-blue-500 text-white px-4 py-1 rounded"
+        >
+          Send
+        </button>
+        <button
+          onClick={reset}
+          className="bg-gray-500 text-white px-4 py-1 rounded"
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/logs-provider.tsx
+++ b/components/logs-provider.tsx
@@ -1,0 +1,66 @@
+'use client';
+import { createContext, useContext, useState } from 'react';
+
+interface LogEntry {
+  request: string;
+  response: string;
+}
+
+interface LogsContextType {
+  logs: LogEntry[];
+  addLog: (entry: LogEntry) => void;
+  enableLogs: () => void;
+}
+
+const LogsContext = createContext<LogsContextType | undefined>(undefined);
+
+export function LogsProvider({ children }: { children: React.ReactNode }) {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [enabled, setEnabled] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  const addLog = (entry: LogEntry) => setLogs((prev) => [...prev, entry]);
+  const enableLogs = () => setEnabled(true);
+
+  return (
+    <LogsContext.Provider value={{ logs, addLog, enableLogs }}>
+      {children}
+      {enabled && (
+        <>
+          <button
+            className="fixed top-2 right-2 z-50 bg-gray-800 text-white px-2 py-1 rounded"
+            onClick={() => setOpen(!open)}
+          >
+            Logs
+          </button>
+          {open && (
+            <div className="fixed top-10 right-2 z-50 w-80 h-96 overflow-y-auto bg-white border shadow-lg p-2 text-sm">
+              {logs.length === 0 && <p>No logs yet.</p>}
+              {logs.map((l, i) => (
+                <div key={i} className="mb-2">
+                  <div className="font-semibold">Request:</div>
+                  <pre className="whitespace-pre-wrap break-words">
+                    {l.request}
+                  </pre>
+                  <div className="font-semibold mt-1">Response:</div>
+                  <pre className="whitespace-pre-wrap break-words">
+                    {l.response}
+                  </pre>
+                  <hr className="my-2" />
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </LogsContext.Provider>
+  );
+}
+
+export function useLogs() {
+  const ctx = useContext(LogsContext);
+  if (!ctx) {
+    throw new Error('useLogs must be used within LogsProvider');
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add progress page linking to test chat
- create mock LLM chat with reset and request logging
- enable hidden Logs button unlocked by clicking the home logo five times and entering a code

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68ad77bff234832a8a4ed64e6c840ec0