### PR TITLE
feat: add progress chat and logs overlay

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -187,3 +187,6 @@
 - 2025-10-27: Kept planner metadata open during autosave by matching blocks by id or time so typing doesn't close panels.
 - 2025-10-27: Improved planning block title visibility with contrast-based text color and responsive font sizing.
 - 2025-10-27: Added LLM integration guide (LLM.md) and updated Agents guidelines to reference it.
+- 2025-10-27: Added progress page with test chat and hidden logs overlay unlocked via marketing page.
+- 2025-10-27: Enabled logs unlock from sign-in page and wired test chat to GPT-4.1 with user-supplied API key.
+- 2025-10-27: Moved logs unlock to Settings with code prompt, removed secret "O" triggers, and switched test chat to env-based OpenAI key.

--- a/app/api/testchat/route.ts
+++ b/app/api/testchat/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { message } = await req.json();
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Missing OpenAI API key' },
+      { status: 500 },
+    );
+  }
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4.1',
+        messages: [{ role: 'user', content: message }],
+      }),
+    });
+    if (!aiRes.ok) {
+      const err = await aiRes.text();
+      return NextResponse.json({ error: err }, { status: aiRes.status });
+    }
+    const data = await aiRes.json();
+    const response = data.choices?.[0]?.message?.content ?? '';
+    return NextResponse.json({ response });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e.message || 'LLM request failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import './globals.css';
 import { cookies } from 'next/headers';
+import { LogsProvider } from '@/components/dev/logs-provider';
+import { LogsButton } from '@/components/dev/logs-button';
 
 export default async function RootLayout({
   children,
@@ -70,7 +72,12 @@ export default async function RootLayout({
           }}
         />
       </head>
-      <body>{children}</body>
+      <body>
+        <LogsProvider>
+          {children}
+          <LogsButton />
+        </LogsProvider>
+      </body>
     </html>
   );
 }

--- a/app/marketing/page.tsx
+++ b/app/marketing/page.tsx
@@ -1,12 +1,13 @@
-import Link from 'next/link';
+'use client';
 
+import Link from 'next/link';
 export default function MarketingPage() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-6">
-      <h1 className="text-4xl font-bold mb-4">A Piece of Cake</h1>
+      <h1 className="mb-4 text-4xl font-bold">A Piece Of Cake</h1>
       <Link
         href="/signin"
-        className="bg-orange-500 text-white px-4 py-2 rounded"
+        className="rounded bg-orange-500 px-4 py-2 text-white"
       >
         Enter app
       </Link>

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+
+export default function ProgressPage() {
+  return (
+    <main className="p-6">
+      <Link
+        href="/progress/testchat"
+        className="bg-orange-500 text-white px-4 py-2 rounded"
+      >
+        Chat with LLM
+      </Link>
+    </main>
+  );
+}

--- a/app/progress/testchat/page.tsx
+++ b/app/progress/testchat/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState } from 'react';
+import { useLogs } from '@/components/dev/logs-provider';
+
+type Message = { role: 'user' | 'assistant'; content: string };
+
+export default function TestChatPage() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const { addLog } = useLogs();
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const text = input;
+    setMessages((prev) => [...prev, { role: 'user', content: text }]);
+    const res = await fetch('/api/testchat', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ message: text }),
+    });
+    const data = await res.json();
+    setMessages((prev) => [
+      ...prev,
+      { role: 'assistant', content: data.response },
+    ]);
+    addLog({ request: text, response: data.response });
+    setInput('');
+  };
+
+  const reset = () => setMessages([]);
+
+  return (
+    <div className="p-4">
+      <div className="mb-4 space-y-2">
+        {messages.map((m, i) => (
+          <div
+            key={i}
+            className={m.role === 'user' ? 'text-right' : 'text-left'}
+          >
+            <span
+              className={
+                m.role === 'user'
+                  ? 'bg-orange-100 p-2 rounded inline-block'
+                  : 'bg-gray-200 p-2 rounded inline-block'
+              }
+            >
+              {m.content}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="flex-1 border rounded px-2"
+        />
+        <button
+          onClick={sendMessage}
+          className="bg-orange-500 text-white px-4 rounded"
+        >
+          Send
+        </button>
+        <button onClick={reset} className="bg-gray-500 text-white px-4 rounded">
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -12,6 +12,7 @@ export default function SignInPage() {
   return (
     <main className="flex min-h-screen items-center justify-center p-6">
       <div className="w-full max-w-sm">
+        <h1 className="mb-6 text-center text-2xl font-bold">A Piece Of Cake</h1>
         <form
           onSubmit={async (e) => {
             e.preventDefault();

--- a/components/cake/settings-button.tsx
+++ b/components/cake/settings-button.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { signOut } from 'next-auth/react';
+import { useLogs } from '@/components/dev/logs-provider';
 
 function GearIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
@@ -25,6 +26,7 @@ export function SettingsButton() {
   const [open, setOpen] = useState(false);
   const [dark, setDark] = useState(false);
   const [followers, setFollowers] = useState(0);
+  const { unlock, unlocked } = useLogs();
 
   useEffect(() => {
     const storedTheme = localStorage.getItem('color-mode');
@@ -87,6 +89,19 @@ export function SettingsButton() {
           >
             Account settings
           </Link>
+          {!unlocked && (
+            <button
+              className="mb-2 w-full rounded bg-[var(--surface)] px-3 py-1 text-center hover:bg-[var(--accent)] hover:text-white"
+              onClick={() => {
+                const code = window.prompt('Enter code');
+                if (code === '123Yergush123') {
+                  unlock();
+                }
+              }}
+            >
+              LLM-logs
+            </button>
+          )}
           <button
             className="mt-2 w-full rounded bg-[var(--accent)] px-3 py-1 text-white hover:opacity-90"
             onClick={() => signOut()}

--- a/components/dev/logs-button.tsx
+++ b/components/dev/logs-button.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState } from 'react';
+import { useLogs } from './logs-provider';
+
+export function LogsButton() {
+  const { logs, unlocked } = useLogs();
+  const [open, setOpen] = useState(false);
+
+  if (!unlocked) return null;
+
+  return (
+    <>
+      <button
+        className="fixed top-4 right-4 bg-orange-500 text-white px-3 py-2 rounded"
+        onClick={() => setOpen(true)}
+      >
+        Logs
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+          <div className="bg-white p-4 rounded max-h-[80vh] w-[90vw] max-w-lg overflow-auto">
+            <button
+              className="mb-2 text-sm text-gray-500"
+              onClick={() => setOpen(false)}
+            >
+              Close
+            </button>
+            <ul className="space-y-2">
+              {logs.map((l, i) => (
+                <li key={i} className="border p-2 rounded">
+                  <div>
+                    <strong>Request:</strong> {l.request}
+                  </div>
+                  <div>
+                    <strong>Response:</strong> {l.response}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/components/dev/logs-provider.tsx
+++ b/components/dev/logs-provider.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { createContext, useContext, useState } from 'react';
+
+interface LogEntry {
+  request: string;
+  response: string;
+}
+
+interface LogsContextType {
+  logs: LogEntry[];
+  addLog: (entry: LogEntry) => void;
+  unlocked: boolean;
+  unlock: () => void;
+}
+
+const LogsContext = createContext<LogsContextType | undefined>(undefined);
+
+export function LogsProvider({ children }: { children: React.ReactNode }) {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [unlocked, setUnlocked] = useState<boolean>(
+    () =>
+      typeof window !== 'undefined' &&
+      localStorage.getItem('logsUnlocked') === 'true',
+  );
+
+  const addLog = (entry: LogEntry) => setLogs((prev) => [...prev, entry]);
+
+  const unlock = () => {
+    setUnlocked(true);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('logsUnlocked', 'true');
+    }
+  };
+
+  return (
+    <LogsContext.Provider value={{ logs, addLog, unlocked, unlock }}>
+      {children}
+    </LogsContext.Provider>
+  );
+}
+
+export function useLogs() {
+  const ctx = useContext(LogsContext);
+  if (!ctx) throw new Error('useLogs must be used within LogsProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add progress page with link to test chat
- create stub LLM chat interface and API
- introduce hidden logs overlay unlocked via code in Settings
- switch test chat to env-based OpenAI key and remove secret 'O' triggers

## Testing
- `pnpm lint`
- `pnpm tsc` *(fails: Cannot find module 'jose' or '@panva/hkdf')*
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68ad77bff234832a8a4ed64e6c840ec0