### PR TITLE
Log raw LLM requests and responses in test chat

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -190,3 +190,5 @@
 - 2025-10-27: Added progress page with test chat and hidden logs overlay unlocked via marketing page.
 - 2025-10-27: Enabled logs unlock from sign-in page and wired test chat to GPT-4.1 with user-supplied API key.
 - 2025-10-27: Moved logs unlock to Settings with code prompt, removed secret "O" triggers, and switched test chat to env-based OpenAI key.
+- 2025-10-27: Logged raw OpenAI request and response in test chat route for debugging.
+- 2025-10-27: Fixed logs overlay hydration mismatch by loading unlock state on the client.

--- a/app/api/testchat/route.ts
+++ b/app/api/testchat/route.ts
@@ -10,22 +10,33 @@ export async function POST(req: NextRequest) {
     );
   }
   try {
+    const requestBody = {
+      model: 'gpt-4.1',
+      messages: [{ role: 'user', content: message }],
+    };
+
+    console.log('LLM raw request:', JSON.stringify(requestBody));
+
     const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${apiKey}`,
       },
-      body: JSON.stringify({
-        model: 'gpt-4.1',
-        messages: [{ role: 'user', content: message }],
-      }),
+      body: JSON.stringify(requestBody),
     });
+
+    const rawResponse = await aiRes.text();
+    console.log('LLM raw response:', rawResponse);
+
     if (!aiRes.ok) {
-      const err = await aiRes.text();
-      return NextResponse.json({ error: err }, { status: aiRes.status });
+      return NextResponse.json(
+        { error: rawResponse },
+        { status: aiRes.status },
+      );
     }
-    const data = await aiRes.json();
+
+    const data = JSON.parse(rawResponse);
     const response = data.choices?.[0]?.message?.content ?? '';
     return NextResponse.json({ response });
   } catch (e: any) {

--- a/components/dev/logs-provider.tsx
+++ b/components/dev/logs-provider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 interface LogEntry {
   request: string;
@@ -18,19 +18,19 @@ const LogsContext = createContext<LogsContextType | undefined>(undefined);
 
 export function LogsProvider({ children }: { children: React.ReactNode }) {
   const [logs, setLogs] = useState<LogEntry[]>([]);
-  const [unlocked, setUnlocked] = useState<boolean>(
-    () =>
-      typeof window !== 'undefined' &&
-      localStorage.getItem('logsUnlocked') === 'true',
-  );
+  const [unlocked, setUnlocked] = useState(false);
+
+  useEffect(() => {
+    if (localStorage.getItem('logsUnlocked') === 'true') {
+      setUnlocked(true);
+    }
+  }, []);
 
   const addLog = (entry: LogEntry) => setLogs((prev) => [...prev, entry]);
 
   const unlock = () => {
     setUnlocked(true);
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('logsUnlocked', 'true');
-    }
+    localStorage.setItem('logsUnlocked', 'true');
   };
 
   return (


### PR DESCRIPTION
## Summary
- log serialized request payloads and raw responses in `/api/testchat` for easier debugging
- document change in project update log
- load logs unlock state on the client to prevent hydration mismatch

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Error: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8193fba4832aae9189c8e649514c