### PR TITLE
feat: add ingredient recommendation agent

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -192,3 +192,4 @@
 - 2025-10-27: Moved logs unlock to Settings with code prompt, removed secret "O" triggers, and switched test chat to env-based OpenAI key.
 - 2025-10-27: Logged raw OpenAI request and response in test chat route for debugging.
 - 2025-10-27: Fixed logs overlay hydration mismatch by loading unlock state on the client.
+- 2025-10-27: Added ingredient recommendation agent with chat modal in add ingredient flow.

--- a/app/(app)/ingredients/client.tsx
+++ b/app/(app)/ingredients/client.tsx
@@ -97,6 +97,15 @@ export default function IngredientsClient({
     'choice',
   );
   const [peopleSearch, setPeopleSearch] = useState('');
+  const [recommendOpen, setRecommendOpen] = useState(false);
+  type ChatMessage = { role: 'user' | 'assistant'; content: string };
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([
+    {
+      role: 'assistant',
+      content: 'What kind of ingredient would you like to create?',
+    },
+  ]);
+  const [chatInput, setChatInput] = useState('');
   const [form, setForm] = useState({
     title: '',
     shortDescription: '',
@@ -185,6 +194,57 @@ export default function IngredientsClient({
     if (n >= 70) return 'bg-green-200';
     if (n >= 40) return 'bg-yellow-200';
     return 'bg-gray-200';
+  }
+
+  function buildIngredientContext(list: Ingredient[]) {
+    return sortIngredients(list)
+      .map(
+        (i) =>
+          `Title\n${i.title}\nShort description\n${i.shortDescription}\nUsefulness (${i.usefulness})\nWhat it is\n${i.description}\nWhy used\n${i.whyUsed}\nWhen used / situations\n${i.whenUsed}\nTips\n${i.tips}`,
+      )
+      .join('\n\n');
+  }
+
+  async function sendChat() {
+    if (!chatInput.trim()) return;
+    const isFirst =
+      chatMessages.length === 1 && chatMessages[0].role === 'assistant';
+    const userContent = isFirst
+      ? `${chatInput}\n\nHere is the context of the ingredients the user currently has:\n<${buildIngredientContext(ingredients)}>`
+      : chatInput;
+    const newMessages: ChatMessage[] = [
+      ...chatMessages,
+      { role: 'user', content: userContent },
+    ];
+    setChatMessages(newMessages);
+    setChatInput('');
+    const payload = [
+      {
+        role: 'system',
+        content:
+          'You are a helpful assistant in the Cake framework, a life-planning platform where users build a cake of goals with ingredients—habits or protocols that support their flavors. Recommend an ingredient to the user, grounding suggestions in cutting-edge science. Compare ideas with existing ingredients and, if the user is unsure, suggest one they may be missing. Always end responses with: "Should I create that ingredient for you?" If they agree, explain the tool calls needed, including title, short description, usefulness score, description, why used, when used, and tips.',
+      },
+      ...newMessages,
+    ];
+    try {
+      const res = await fetch('/api/ingredients/recommend', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: payload }),
+      });
+      const data = await res.json();
+      if (data.response) {
+        setChatMessages([
+          ...newMessages,
+          { role: 'assistant', content: data.response as string },
+        ]);
+      }
+    } catch {
+      setChatMessages([
+        ...newMessages,
+        { role: 'assistant', content: 'Sorry, something went wrong.' },
+      ]);
+    }
   }
 
   async function importPreset(p: IngredientInput) {
@@ -297,6 +357,16 @@ export default function IngredientsClient({
               >
                 Import ingredient
               </button>
+              <button
+                id={`1ngred-add-recommend-${userId}`}
+                className="rounded bg-orange-500 px-3 py-1 text-white"
+                onClick={() => {
+                  setChoiceOpen(false);
+                  setRecommendOpen(true);
+                }}
+              >
+                Recommend ingredient
+              </button>
             </div>
             <div className="mt-4 flex justify-end">
               <button
@@ -305,6 +375,67 @@ export default function IngredientsClient({
                 onClick={() => setChoiceOpen(false)}
               >
                 Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {recommendOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div className="flex w-full max-w-md flex-col rounded bg-white p-6 shadow-lg">
+            <div className="mb-4 h-64 overflow-y-auto space-y-2">
+              {chatMessages.map((m, i) => (
+                <div
+                  key={i}
+                  className={m.role === 'user' ? 'text-right' : 'text-left'}
+                >
+                  <span
+                    className={
+                      m.role === 'user'
+                        ? 'inline-block rounded bg-orange-100 px-2 py-1'
+                        : 'inline-block rounded bg-gray-200 px-2 py-1'
+                    }
+                  >
+                    {m.content}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={chatInput}
+                onChange={(e) => setChatInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') sendChat();
+                }}
+                placeholder="Type your answer..."
+                className="flex-1 rounded border px-2 py-1"
+              />
+              <button
+                onClick={sendChat}
+                className="rounded bg-orange-500 px-3 py-1 text-white"
+              >
+                Send
+              </button>
+            </div>
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                className="rounded border px-3 py-1"
+                onClick={() => {
+                  setRecommendOpen(false);
+                  setChatMessages([
+                    {
+                      role: 'assistant',
+                      content:
+                        'What kind of ingredient would you like to create?',
+                    },
+                  ]);
+                  setChatInput('');
+                }}
+              >
+                Close
               </button>
             </div>
           </div>
@@ -465,9 +596,7 @@ export default function IngredientsClient({
               </h2>
               <button onClick={() => setOpen(false)}>✕</button>
             </div>
-            <div
-              className="mb-4"
-            >
+            <div className="mb-4">
               <label className="block text-sm font-medium">Icon</label>
               <IconPicker
                 value={form.icon}

--- a/app/api/ingredients/recommend/route.ts
+++ b/app/api/ingredients/recommend/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { DEFAULT_LLM_SETUP, withOverrides } from '@/lib/llm/config';
+
+export async function POST(req: NextRequest) {
+  const { messages, overrides } = await req.json();
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Missing OpenAI API key' },
+      { status: 500 },
+    );
+  }
+
+  const setup = withOverrides(DEFAULT_LLM_SETUP, overrides);
+
+  const body = {
+    model: setup.model,
+    messages,
+    temperature: setup.temperature,
+    top_p: setup.top_p,
+    max_tokens: setup.maxTokens,
+  };
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const rawResponse = await aiRes.text();
+
+    if (!aiRes.ok) {
+      return NextResponse.json(
+        { error: rawResponse },
+        { status: aiRes.status },
+      );
+    }
+
+    const data = JSON.parse(rawResponse);
+    const response = data.choices?.[0]?.message?.content ?? '';
+    return NextResponse.json({ response });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e.message || 'LLM request failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/llm/config.ts
+++ b/lib/llm/config.ts
@@ -1,0 +1,22 @@
+export interface LlmSetup {
+  provider: 'openai';
+  model: string;
+  temperature: number;
+  top_p: number;
+  maxTokens: number;
+}
+
+export const DEFAULT_LLM_SETUP: LlmSetup = {
+  provider: 'openai',
+  model: 'gpt-4.1',
+  temperature: 0.2,
+  top_p: 1,
+  maxTokens: 800,
+};
+
+export function withOverrides(
+  base: LlmSetup,
+  overrides?: Partial<LlmSetup>,
+): LlmSetup {
+  return { ...base, ...overrides };
+}


### PR DESCRIPTION
## Summary
- add ingredient recommendation agent chat modal when adding ingredients
- support OpenAI calls with basic LLM config and API route
- document update

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68ad91c7faac832a8d8f985065907235