### PR TITLE
feat: add ingredient recommendation agent

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -192,3 +192,6 @@
 - 2025-10-27: Moved logs unlock to Settings with code prompt, removed secret "O" triggers, and switched test chat to env-based OpenAI key.
 - 2025-10-27: Logged raw OpenAI request and response in test chat route for debugging.
 - 2025-10-27: Fixed logs overlay hydration mismatch by loading unlock state on the client.
+- 2025-10-27: Added ingredient recommendation agent with chat modal in add ingredient flow.
+- 2025-10-27: Widened recommendation chat box, enabled scrolling, and logged chat messages.
+- 2025-10-27: Let recommendation agent auto-create ingredients via tool calls, skipped empty fields in context, and kept chat state until refresh.

--- a/app/(app)/ingredients/client.tsx
+++ b/app/(app)/ingredients/client.tsx
@@ -1,7 +1,7 @@
 'use client';
 /* eslint-disable @next/next/no-img-element */
 
-import { useState, useMemo, useRef } from 'react';
+import { useState, useMemo, useRef, useEffect } from 'react';
 import Link from 'next/link';
 import IconPicker from '@/components/icon-picker';
 import type {
@@ -97,6 +97,24 @@ export default function IngredientsClient({
     'choice',
   );
   const [peopleSearch, setPeopleSearch] = useState('');
+  const [recommendOpen, setRecommendOpen] = useState(false);
+  type ChatMessage = { role: 'user' | 'assistant'; content: string };
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([
+    {
+      role: 'assistant',
+      content: 'What kind of ingredient would you like to create?',
+    },
+  ]);
+  const [chatInput, setChatInput] = useState('');
+  const chatIdRef = useRef<string>(
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2),
+  );
+  const chatEndRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [chatMessages, recommendOpen]);
   const [form, setForm] = useState({
     title: '',
     shortDescription: '',
@@ -185,6 +203,70 @@ export default function IngredientsClient({
     if (n >= 70) return 'bg-green-200';
     if (n >= 40) return 'bg-yellow-200';
     return 'bg-gray-200';
+  }
+
+  function buildIngredientContext(list: Ingredient[]) {
+    return sortIngredients(list)
+      .map((i) => {
+        const parts = [`Title\n${i.title}`];
+        if (i.shortDescription) parts.push(`Short description\n${i.shortDescription}`);
+        parts.push(`Usefulness (${i.usefulness})`);
+        if (i.description) parts.push(`What it is\n${i.description}`);
+        if (i.whyUsed) parts.push(`Why used\n${i.whyUsed}`);
+        if (i.whenUsed) parts.push(`When used / situations\n${i.whenUsed}`);
+        if (i.tips) parts.push(`Tips\n${i.tips}`);
+        return parts.join('\n');
+      })
+      .join('\n\n');
+  }
+
+  async function sendChat() {
+    if (!chatInput.trim()) return;
+    const isFirst =
+      chatMessages.length === 1 && chatMessages[0].role === 'assistant';
+    const userContent = isFirst
+      ? `${chatInput}\n\nHere is the context of the ingredients the user currently has:\n<${buildIngredientContext(ingredients)}>`
+      : chatInput;
+    const newMessages: ChatMessage[] = [
+      ...chatMessages,
+      { role: 'user', content: userContent },
+    ];
+    setChatMessages(newMessages);
+    setChatInput('');
+    const payload = [
+      {
+        role: 'system',
+        content:
+          'You are a helpful assistant in the Cake framework, a life-planning platform where users build a cake of goals with ingredients—habits or protocols that support their flavors. Recommend an ingredient to the user, grounding suggestions in cutting-edge science. Compare ideas with existing ingredients and, if the user is unsure, suggest one they may be missing. Always end responses with: "Should I create that ingredient for you?" If the user agrees, call the create_ingredient tool with the ingredient details (title, short description, usefulness score, what it is, why used, when used / situations, tips).',
+      },
+      ...newMessages,
+    ];
+    try {
+      console.log('recommend request', payload);
+      const res = await fetch('/api/ingredients/recommend', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chatId: chatIdRef.current, messages: payload }),
+      });
+      const data = await res.json();
+      console.log('recommend response', data);
+      if (data.response) {
+        setChatMessages([
+          ...newMessages,
+          { role: 'assistant', content: data.response as string },
+        ]);
+      }
+      if (data.ingredient) {
+        setIngredients((prev) =>
+          sortIngredients([...prev, data.ingredient as Ingredient]),
+        );
+      }
+    } catch {
+      setChatMessages([
+        ...newMessages,
+        { role: 'assistant', content: 'Sorry, something went wrong.' },
+      ]);
+    }
   }
 
   async function importPreset(p: IngredientInput) {
@@ -297,6 +379,16 @@ export default function IngredientsClient({
               >
                 Import ingredient
               </button>
+              <button
+                id={`1ngred-add-recommend-${userId}`}
+                className="rounded bg-orange-500 px-3 py-1 text-white"
+                onClick={() => {
+                  setChoiceOpen(false);
+                  setRecommendOpen(true);
+                }}
+              >
+                Recommend ingredient
+              </button>
             </div>
             <div className="mt-4 flex justify-end">
               <button
@@ -305,6 +397,60 @@ export default function IngredientsClient({
                 onClick={() => setChoiceOpen(false)}
               >
                 Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {recommendOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div className="flex w-[90%] max-w-2xl max-h-[90vh] flex-col rounded bg-white p-6 shadow-lg">
+            <div className="mb-4 flex-1 overflow-y-auto space-y-2">
+              {chatMessages.map((m, i) => (
+                <div
+                  key={i}
+                  className={m.role === 'user' ? 'text-right' : 'text-left'}
+                >
+                  <span
+                    className={
+                      m.role === 'user'
+                        ? 'inline-block rounded bg-orange-100 px-2 py-1'
+                        : 'inline-block rounded bg-gray-200 px-2 py-1'
+                    }
+                  >
+                    {m.content}
+                  </span>
+                </div>
+              ))}
+              <div ref={chatEndRef} />
+            </div>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={chatInput}
+                onChange={(e) => setChatInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') sendChat();
+                }}
+                placeholder="Type your answer..."
+                className="flex-1 rounded border px-2 py-1"
+              />
+              <button
+                onClick={sendChat}
+                className="rounded bg-orange-500 px-3 py-1 text-white"
+              >
+                Send
+              </button>
+            </div>
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                className="rounded border px-3 py-1"
+                onClick={() => {
+                  setRecommendOpen(false);
+                }}
+              >
+                Close
               </button>
             </div>
           </div>
@@ -465,9 +611,7 @@ export default function IngredientsClient({
               </h2>
               <button onClick={() => setOpen(false)}>✕</button>
             </div>
-            <div
-              className="mb-4"
-            >
+            <div className="mb-4">
               <label className="block text-sm font-medium">Icon</label>
               <IconPicker
                 value={form.icon}

--- a/app/api/ingredients/recommend/route.ts
+++ b/app/api/ingredients/recommend/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { DEFAULT_LLM_SETUP, withOverrides } from '@/lib/llm/config';
+import { createIngredient } from '@/lib/ingredients-store';
+
+export async function POST(req: NextRequest) {
+  const { messages, overrides, chatId } = await req.json();
+  console.log('ingredient recommend request', chatId, messages);
+
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Missing OpenAI API key' },
+      { status: 500 },
+    );
+  }
+
+  const setup = withOverrides(DEFAULT_LLM_SETUP, overrides);
+
+  const base = {
+    model: setup.model,
+    temperature: setup.temperature,
+    top_p: setup.top_p,
+    max_tokens: setup.maxTokens,
+  };
+
+  const body = {
+    ...base,
+    messages,
+    tools: [
+      {
+        type: 'function',
+        function: {
+          name: 'create_ingredient',
+          description: 'Create an ingredient for the user',
+          parameters: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              shortDescription: { type: 'string' },
+              usefulness: { type: 'number' },
+              description: { type: 'string' },
+              whyUsed: { type: 'string' },
+              whenUsed: { type: 'string' },
+              tips: { type: 'string' },
+            },
+            required: ['title', 'shortDescription', 'usefulness'],
+          },
+        },
+      },
+    ],
+  } as any;
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const rawResponse = await aiRes.text();
+
+    if (!aiRes.ok) {
+      return NextResponse.json(
+        { error: rawResponse },
+        { status: aiRes.status },
+      );
+    }
+
+    const data = JSON.parse(rawResponse);
+    const choice = data.choices?.[0];
+    const msg = choice?.message;
+
+    if (msg?.tool_calls?.length) {
+      const tc = msg.tool_calls[0];
+      if (tc.function?.name === 'create_ingredient') {
+        const args = JSON.parse(tc.function.arguments || '{}');
+        const ingredient = await createIngredient(String(userId), {
+          title: args.title,
+          shortDescription: args.shortDescription || '',
+          usefulness:
+            typeof args.usefulness === 'number' ? args.usefulness : 50,
+          description: args.description || '',
+          whyUsed: args.whyUsed || '',
+          whenUsed: args.whenUsed || '',
+          tips: args.tips || '',
+          imageUrl: null,
+          icon: '🤖',
+          tags: null,
+          visibility: 'private',
+        });
+        const toolMsg = {
+          role: 'tool',
+          tool_call_id: tc.id,
+          content: JSON.stringify({ status: 'created' }),
+        };
+        const followBody = {
+          ...base,
+          messages: [...messages, msg, toolMsg],
+        } as any;
+        const finalRes = await fetch(
+          'https://api.openai.com/v1/chat/completions',
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify(followBody),
+          },
+        );
+        const finalRaw = await finalRes.text();
+        if (!finalRes.ok) {
+          return NextResponse.json(
+            { error: finalRaw },
+            { status: finalRes.status },
+          );
+        }
+        const finalData = JSON.parse(finalRaw);
+        const finalResponse =
+          finalData.choices?.[0]?.message?.content ?? '';
+        console.log('ingredient recommend response', finalResponse);
+        return NextResponse.json({ response: finalResponse, ingredient });
+      }
+    }
+
+    const response = msg?.content ?? '';
+    console.log('ingredient recommend response', response);
+    return NextResponse.json({ response });
+  } catch (e: any) {
+    console.error('ingredient recommend error', e);
+    return NextResponse.json(
+      { error: e.message || 'LLM request failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/llm/config.ts
+++ b/lib/llm/config.ts
@@ -1,0 +1,22 @@
+export interface LlmSetup {
+  provider: 'openai';
+  model: string;
+  temperature: number;
+  top_p: number;
+  maxTokens: number;
+}
+
+export const DEFAULT_LLM_SETUP: LlmSetup = {
+  provider: 'openai',
+  model: 'gpt-4.1',
+  temperature: 0.2,
+  top_p: 1,
+  maxTokens: 800,
+};
+
+export function withOverrides(
+  base: LlmSetup,
+  overrides?: Partial<LlmSetup>,
+): LlmSetup {
+  return { ...base, ...overrides };
+}


### PR DESCRIPTION
## Summary
- allow recommendation agent to automatically create ingredients via tool calls (robot icon)
- omit empty ingredient fields from prompt and persist chat session until page refresh
- document update

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68ad91c7faac832a8d8f985065907235