### PR TITLE
feat: persist and reset ingredient chat

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -195,3 +195,4 @@
 - 2025-10-27: Added ingredient recommendation agent with chat modal in add ingredient flow.
 - 2025-10-27: Widened recommendation chat box, enabled scrolling, and logged chat messages.
 - 2025-10-27: Let recommendation agent auto-create ingredients via tool calls, skipped empty fields in context, and kept chat state until refresh.
+- 2025-10-27: Added resettable ingredient recommendation chat persisted in local storage and confirmed AI-created ingredients before saving.

--- a/app/(app)/ingredients/client.tsx
+++ b/app/(app)/ingredients/client.tsx
@@ -98,23 +98,45 @@ export default function IngredientsClient({
   );
   const [peopleSearch, setPeopleSearch] = useState('');
   const [recommendOpen, setRecommendOpen] = useState(false);
+  const CHAT_STORAGE_KEY = 'ingredient-recommend-chat';
   type ChatMessage = { role: 'user' | 'assistant'; content: string };
-  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([
+  const initialChat: ChatMessage[] = [
     {
       role: 'assistant',
       content: 'What kind of ingredient would you like to create?',
     },
-  ]);
+  ];
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>(initialChat);
   const [chatInput, setChatInput] = useState('');
   const chatIdRef = useRef<string>(
     typeof crypto !== 'undefined' && 'randomUUID' in crypto
       ? crypto.randomUUID()
       : Math.random().toString(36).slice(2),
   );
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const saved = localStorage.getItem(CHAT_STORAGE_KEY);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        if (parsed.chatId) chatIdRef.current = parsed.chatId;
+        if (parsed.messages) setChatMessages(parsed.messages);
+      } catch {
+        /* ignore */
+      }
+    }
+  }, []);
   const chatEndRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [chatMessages, recommendOpen]);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(
+      CHAT_STORAGE_KEY,
+      JSON.stringify({ chatId: chatIdRef.current, messages: chatMessages }),
+    );
+  }, [chatMessages]);
   const [form, setForm] = useState({
     title: '',
     shortDescription: '',
@@ -209,7 +231,8 @@ export default function IngredientsClient({
     return sortIngredients(list)
       .map((i) => {
         const parts = [`Title\n${i.title}`];
-        if (i.shortDescription) parts.push(`Short description\n${i.shortDescription}`);
+        if (i.shortDescription)
+          parts.push(`Short description\n${i.shortDescription}`);
         parts.push(`Usefulness (${i.usefulness})`);
         if (i.description) parts.push(`What it is\n${i.description}`);
         if (i.whyUsed) parts.push(`Why used\n${i.whyUsed}`);
@@ -218,6 +241,29 @@ export default function IngredientsClient({
         return parts.join('\n');
       })
       .join('\n\n');
+  }
+
+  function parseIngredient(str: string): Partial<IngredientInput> | null {
+    try {
+      return JSON.parse(str);
+    } catch {
+      try {
+        const m = str.match(/```json\s*([\s\S]*?)\s*```/i);
+        if (m) return JSON.parse(m[1]);
+      } catch {
+        return null;
+      }
+      return null;
+    }
+  }
+
+  function resetChat() {
+    const id =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : Math.random().toString(36).slice(2);
+    chatIdRef.current = id;
+    setChatMessages(initialChat);
   }
 
   async function sendChat() {
@@ -237,7 +283,7 @@ export default function IngredientsClient({
       {
         role: 'system',
         content:
-          'You are a helpful assistant in the Cake framework, a life-planning platform where users build a cake of goals with ingredients—habits or protocols that support their flavors. Recommend an ingredient to the user, grounding suggestions in cutting-edge science. Compare ideas with existing ingredients and, if the user is unsure, suggest one they may be missing. Always end responses with: "Should I create that ingredient for you?" If the user agrees, call the create_ingredient tool with the ingredient details (title, short description, usefulness score, what it is, why used, when used / situations, tips).',
+          'You are a helpful assistant in the Cake framework, a life-planning platform where users build a cake of goals with ingredients—habits or protocols that support their flavors. Recommend an ingredient to the user, grounding suggestions in cutting-edge science. Compare ideas with existing ingredients and, if the user is unsure, suggest one they may be missing. Always end responses with: "Should I create that ingredient for you?" If the user agrees, respond ONLY with a JSON object containing the fields title, shortDescription, usefulness, description, whyUsed, whenUsed, tips. Do not include any other text.',
       },
       ...newMessages,
     ];
@@ -251,15 +297,40 @@ export default function IngredientsClient({
       const data = await res.json();
       console.log('recommend response', data);
       if (data.response) {
-        setChatMessages([
-          ...newMessages,
-          { role: 'assistant', content: data.response as string },
-        ]);
-      }
-      if (data.ingredient) {
-        setIngredients((prev) =>
-          sortIngredients([...prev, data.ingredient as Ingredient]),
-        );
+        const parsed = parseIngredient(data.response as string);
+        if (parsed && parsed.title) {
+          const ok = confirm(
+            `Do you want to add this ingredient (${parsed.title})?`,
+          );
+          if (ok) {
+            const fd = new FormData();
+            Object.entries(parsed).forEach(([k, v]) => {
+              if (v !== null && v !== undefined) {
+                fd.append(k, String(v));
+              }
+            });
+            fd.append('icon', '🤖');
+            const created = await createMine(fd);
+            setIngredients((prev) => sortIngredients([...prev, created]));
+            setChatMessages([
+              ...newMessages,
+              {
+                role: 'assistant',
+                content: `Added ingredient "${created.title}".`,
+              },
+            ]);
+          } else {
+            setChatMessages([
+              ...newMessages,
+              { role: 'assistant', content: 'Okay, not adding it.' },
+            ]);
+          }
+        } else {
+          setChatMessages([
+            ...newMessages,
+            { role: 'assistant', content: data.response as string },
+          ]);
+        }
       }
     } catch {
       setChatMessages([
@@ -442,7 +513,14 @@ export default function IngredientsClient({
                 Send
               </button>
             </div>
-            <div className="mt-4 flex justify-end">
+            <div className="mt-4 flex justify-between">
+              <button
+                type="button"
+                className="rounded border px-3 py-1"
+                onClick={resetChat}
+              >
+                Reset
+              </button>
               <button
                 type="button"
                 className="rounded border px-3 py-1"

--- a/app/api/ingredients/recommend/route.ts
+++ b/app/api/ingredients/recommend/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { DEFAULT_LLM_SETUP, withOverrides } from '@/lib/llm/config';
-import { createIngredient } from '@/lib/ingredients-store';
 
 export async function POST(req: NextRequest) {
   const { messages, overrides, chatId } = await req.json();
@@ -23,38 +22,12 @@ export async function POST(req: NextRequest) {
 
   const setup = withOverrides(DEFAULT_LLM_SETUP, overrides);
 
-  const base = {
+  const body = {
     model: setup.model,
     temperature: setup.temperature,
     top_p: setup.top_p,
     max_tokens: setup.maxTokens,
-  };
-
-  const body = {
-    ...base,
     messages,
-    tools: [
-      {
-        type: 'function',
-        function: {
-          name: 'create_ingredient',
-          description: 'Create an ingredient for the user',
-          parameters: {
-            type: 'object',
-            properties: {
-              title: { type: 'string' },
-              shortDescription: { type: 'string' },
-              usefulness: { type: 'number' },
-              description: { type: 'string' },
-              whyUsed: { type: 'string' },
-              whenUsed: { type: 'string' },
-              tips: { type: 'string' },
-            },
-            required: ['title', 'shortDescription', 'usefulness'],
-          },
-        },
-      },
-    ],
   } as any;
 
   try {
@@ -79,60 +52,6 @@ export async function POST(req: NextRequest) {
     const data = JSON.parse(rawResponse);
     const choice = data.choices?.[0];
     const msg = choice?.message;
-
-    if (msg?.tool_calls?.length) {
-      const tc = msg.tool_calls[0];
-      if (tc.function?.name === 'create_ingredient') {
-        const args = JSON.parse(tc.function.arguments || '{}');
-        const ingredient = await createIngredient(String(userId), {
-          title: args.title,
-          shortDescription: args.shortDescription || '',
-          usefulness:
-            typeof args.usefulness === 'number' ? args.usefulness : 50,
-          description: args.description || '',
-          whyUsed: args.whyUsed || '',
-          whenUsed: args.whenUsed || '',
-          tips: args.tips || '',
-          imageUrl: null,
-          icon: '🤖',
-          tags: null,
-          visibility: 'private',
-        });
-        const toolMsg = {
-          role: 'tool',
-          tool_call_id: tc.id,
-          content: JSON.stringify({ status: 'created' }),
-        };
-        const followBody = {
-          ...base,
-          messages: [...messages, msg, toolMsg],
-        } as any;
-        const finalRes = await fetch(
-          'https://api.openai.com/v1/chat/completions',
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${apiKey}`,
-            },
-            body: JSON.stringify(followBody),
-          },
-        );
-        const finalRaw = await finalRes.text();
-        if (!finalRes.ok) {
-          return NextResponse.json(
-            { error: finalRaw },
-            { status: finalRes.status },
-          );
-        }
-        const finalData = JSON.parse(finalRaw);
-        const finalResponse =
-          finalData.choices?.[0]?.message?.content ?? '';
-        console.log('ingredient recommend response', finalResponse);
-        return NextResponse.json({ response: finalResponse, ingredient });
-      }
-    }
-
     const response = msg?.content ?? '';
     console.log('ingredient recommend response', response);
     return NextResponse.json({ response });


### PR DESCRIPTION
## Summary
- persist ingredient recommendation chat in localStorage and allow reset
- confirm structured ingredient suggestions before creating and add robot icon
- simplify recommendation API to return model response only

## Testing
- `npx prettier --write app/api/ingredients/recommend/route.ts "app/(app)/ingredients/client.tsx" UPDATE.md`
- `pnpm lint`
- `pnpm tsc` *(fails: Cannot find module 'jose' or '@panva/hkdf')*
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9ececa1c832a99786e6a9e7984fe