### PR TITLE
fix: cascade delete ingredient revisions

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -196,3 +196,4 @@
 - 2025-10-27: Widened recommendation chat box, enabled scrolling, and logged chat messages.
 - 2025-10-27: Let recommendation agent auto-create ingredients via tool calls, skipped empty fields in context, and kept chat state until refresh.
 - 2025-10-27: Added resettable ingredient recommendation chat persisted in local storage and confirmed AI-created ingredients before saving.
+- 2025-10-27: Removed ingredient revisions on delete to prevent foreign key errors and added test coverage.

--- a/lib/ingredients-store.ts
+++ b/lib/ingredients-store.ts
@@ -208,11 +208,21 @@ export async function deleteIngredient(
   userId: string,
   id: number,
 ): Promise<boolean> {
-  const rows = await db
-    .delete(ingredients)
-    .where(and(eq(ingredients.userId, Number(userId)), eq(ingredients.id, id)))
-    .returning();
-  return rows.length > 0;
+  return db.transaction(async (tx) => {
+    const [exists] = await tx
+      .select({ id: ingredients.id })
+      .from(ingredients)
+      .where(and(eq(ingredients.userId, Number(userId)), eq(ingredients.id, id)))
+      .limit(1);
+    if (!exists) return false;
+    await tx
+      .delete(ingredientRevisions)
+      .where(eq(ingredientRevisions.ingredientId, id));
+    await tx
+      .delete(ingredients)
+      .where(and(eq(ingredients.userId, Number(userId)), eq(ingredients.id, id)));
+    return true;
+  });
 }
 
 function clamp(n: number) {

--- a/tests/ingredients.spec.ts
+++ b/tests/ingredients.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+test('ingredient CRUD delete removes revisions', async ({ page }) => {
+  const handle = `user${Date.now()}`;
+  const email = `${handle}@example.com`;
+  const password = 'pass1234';
+
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Tester');
+  await page.fill('input[placeholder="Handle"]', handle);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.goto('/ingredients');
+
+  await page.click('button[id^="1ngred-add"]');
+  await page.click('button[id^="1ngred-add-own"]');
+  await page.fill('input[id^="1ngred-t1tle"]', 'Test ingredient');
+  await page.fill('input[id^="1ngred-sh0rt"]', 'desc');
+  await page.click('button:has-text("Save")');
+  const row = page.locator('div[id^="1ngred-card-"]:has-text("Test ingredient")');
+  await expect(row).toBeVisible();
+  await row.click();
+  page.on('dialog', (d) => d.accept());
+  await page.click('button:has-text("Delete")');
+  await expect(row).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- remove ingredient revisions before deleting ingredient to avoid FK constraint errors
- add Playwright test covering ingredient delete flow
- log update entry

## Testing
- `command -v pnpm || echo pnpm-not-found`


------
https://chatgpt.com/codex/tasks/task_e_68ada2324d28832a8fdc9afecd88f12a