### PR TITLE
feat: add progress overview and daily reports

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -197,3 +197,4 @@
 - 2025-10-27: Let recommendation agent auto-create ingredients via tool calls, skipped empty fields in context, and kept chat state until refresh.
 - 2025-10-27: Added resettable ingredient recommendation chat persisted in local storage and confirmed AI-created ingredients before saving.
 - 2025-10-27: Removed ingredient revisions on delete to prevent foreign key errors and added test coverage.
+- 2025-10-28: Introduced Progress section with daily report generation, overview pages, navigation link, and calendar highlight.

--- a/app/api/progress/daily/route.ts
+++ b/app/api/progress/daily/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { DEFAULT_LLM_SETUP, withOverrides } from '@/lib/llm/config';
+import { saveDailyReport, getDailyReport } from '@/lib/daily-reports';
+import { getTodayPlanContext } from '@/lib/progress-context';
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  const userId = Number(session?.user?.id);
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const todayIso = new Date().toLocaleDateString('en-CA');
+  const existing = await getDailyReport(userId, todayIso);
+  if (existing) {
+    return NextResponse.json(
+      { error: 'Report already exists', score: existing.score },
+      { status: 400 },
+    );
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Missing OpenAI API key' },
+      { status: 500 },
+    );
+  }
+
+  const context = await getTodayPlanContext(userId, todayIso);
+
+  const systemPrompt =
+    'You are a fair but strict assessment agent for the Piece of Cake framework. ' +
+    "Evaluate how the user's day aligned with their ethos, daily aim, and activities. " +
+    'Return JSON with keys good, bad, observations, planning, execution, and score (0-100).';
+
+  const messages = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: JSON.stringify(context) },
+  ];
+
+  console.log('daily report request', messages);
+
+  const setup = withOverrides(DEFAULT_LLM_SETUP, {});
+
+  const body = {
+    model: setup.model,
+    temperature: setup.temperature,
+    top_p: setup.top_p,
+    max_tokens: setup.maxTokens,
+    response_format: { type: 'json_object' },
+    messages,
+  } as any;
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+    const raw = await aiRes.text();
+    console.log('daily report raw response', raw);
+    if (!aiRes.ok) {
+      return NextResponse.json({ error: raw }, { status: aiRes.status });
+    }
+    const data = JSON.parse(raw);
+    const content = data.choices?.[0]?.message?.content ?? '{}';
+    let parsed: any;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid JSON from model' },
+        { status: 500 },
+      );
+    }
+    const score = Number(parsed.score ?? 0);
+    await saveDailyReport(userId, todayIso, score, parsed);
+    return NextResponse.json({ score, report: parsed });
+  } catch (e: any) {
+    console.error('daily report error', e);
+    return NextResponse.json(
+      { error: e.message || 'LLM request failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/progress/overview/daily/[date]/page.tsx
+++ b/app/progress/overview/daily/[date]/page.tsx
@@ -1,0 +1,45 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getDailyReport } from '@/lib/daily-reports';
+
+export default async function DailyReportPage({
+  params,
+}: {
+  params: { date: string };
+}) {
+  const session = await auth();
+  if (!session) return null;
+  const me = await ensureUser(session);
+  const report = await getDailyReport(me.id, params.date);
+  if (!report) {
+    return (
+      <main className="p-6">
+        <p>No report for this day.</p>
+      </main>
+    );
+  }
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Report for {params.date}</h1>
+      <p>Score: {report.score}</p>
+      <div>
+        <h2 className="font-semibold">What went well</h2>
+        <pre className="whitespace-pre-wrap">
+          {JSON.stringify((report.report as any).good, null, 2)}
+        </pre>
+      </div>
+      <div>
+        <h2 className="font-semibold">What went bad</h2>
+        <pre className="whitespace-pre-wrap">
+          {JSON.stringify((report.report as any).bad, null, 2)}
+        </pre>
+      </div>
+      <div>
+        <h2 className="font-semibold">Observations</h2>
+        <pre className="whitespace-pre-wrap">
+          {JSON.stringify((report.report as any).observations, null, 2)}
+        </pre>
+      </div>
+    </main>
+  );
+}

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { listDailyReports } from '@/lib/daily-reports';
+
+export default async function DailyOverviewPage() {
+  const session = await auth();
+  if (!session) {
+    return null;
+  }
+  const me = await ensureUser(session);
+  const reports = await listDailyReports(me.id);
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Daily Reports</h1>
+      <ul className="space-y-2">
+        {reports.map((r) => (
+          <li key={r.date}>
+            <Link
+              href={`/progress/overview/daily/${r.date}`}
+              className="text-orange-500 underline"
+            >
+              {r.date} - score {r.score}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/progress/overview/monthly/page.tsx
+++ b/app/progress/overview/monthly/page.tsx
@@ -1,0 +1,7 @@
+export default function MonthlyOverviewPage() {
+  return (
+    <main className="p-6">
+      <p>Monthly reports coming soon.</p>
+    </main>
+  );
+}

--- a/app/progress/overview/page.tsx
+++ b/app/progress/overview/page.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+
+export default function OverviewPage() {
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Progress Overview</h1>
+      <ul className="space-y-2">
+        <li>
+          <Link
+            href="/progress/overview/daily"
+            className="text-orange-500 underline"
+          >
+            Daily
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/progress/overview/weekly"
+            className="text-orange-500 underline"
+          >
+            Weekly
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/progress/overview/monthly"
+            className="text-orange-500 underline"
+          >
+            Monthly
+          </Link>
+        </li>
+        <li>
+          <Link
+            href="/progress/overview/yearly"
+            className="text-orange-500 underline"
+          >
+            Yearly
+          </Link>
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/app/progress/overview/weekly/page.tsx
+++ b/app/progress/overview/weekly/page.tsx
@@ -1,0 +1,7 @@
+export default function WeeklyOverviewPage() {
+  return (
+    <main className="p-6">
+      <p>Weekly reports coming soon.</p>
+    </main>
+  );
+}

--- a/app/progress/overview/yearly/page.tsx
+++ b/app/progress/overview/yearly/page.tsx
@@ -1,0 +1,7 @@
+export default function YearlyOverviewPage() {
+  return (
+    <main className="p-6">
+      <p>Yearly reports coming soon.</p>
+    </main>
+  );
+}

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -9,6 +9,12 @@ export default function ProgressPage() {
       >
         Chat with LLM
       </Link>
+      <Link
+        href="/progress/overview"
+        className="ml-4 bg-orange-500 text-white px-4 py-2 rounded"
+      >
+        Overview
+      </Link>
     </main>
   );
 }

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -14,6 +14,7 @@ const labels: Record<Section, string> = {
   review: 'Review',
   people: 'People',
   visibility: 'Visibility',
+  progress: 'Progress',
 };
 
 export function AppNav() {
@@ -30,6 +31,7 @@ export function AppNav() {
           'review',
           'people',
           'visibility',
+          'progress',
         ];
 
   return (

--- a/components/cake/cake-home.tsx
+++ b/components/cake/cake-home.tsx
@@ -1,13 +1,19 @@
 import { SideCalendar } from '@/components/calendar/side-calendar';
 import { CakeNavigation } from './cake-navigation';
 import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
+import { listDailyReportDates } from '@/lib/daily-reports';
+import { GenerateDailyReportButton } from '@/components/progress/generate-daily-report-button';
 
 export async function CakeHome({ ownerId }: { ownerId: number }) {
   const snapshotDates = await listProfileSnapshotDates(ownerId);
+  const reportDates = await listDailyReportDates(ownerId);
+  const todayIso = new Date().toLocaleDateString('en-CA');
+  const hasReportToday = reportDates.includes(todayIso);
   return (
-    <section className="w-full">
+    <section className="w-full space-y-4">
       <h1 className="sr-only">Cake</h1>
-      <SideCalendar snapshotDates={snapshotDates} />
+      <SideCalendar snapshotDates={snapshotDates} reportDates={reportDates} />
+      {!hasReportToday && <GenerateDailyReportButton />}
       <CakeNavigation />
     </section>
   );

--- a/components/calendar/side-calendar.tsx
+++ b/components/calendar/side-calendar.tsx
@@ -5,7 +5,13 @@ import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { useViewContext } from '@/lib/view-context';
 
-export function SideCalendar({ snapshotDates }: { snapshotDates: string[] }) {
+export function SideCalendar({
+  snapshotDates,
+  reportDates = [],
+}: {
+  snapshotDates: string[];
+  reportDates?: string[];
+}) {
   const [open, setOpen] = useState(false);
   const [monthOffset, setMonthOffset] = useState(0);
   const router = useRouter();
@@ -77,6 +83,7 @@ export function SideCalendar({ snapshotDates }: { snapshotDates: string[] }) {
               const isToday = date.toDateString() === today.toDateString();
               const iso = date.toLocaleDateString('en-CA');
               const hasSnap = snapshotDates.includes(iso);
+              const hasReport = reportDates.includes(iso);
               return (
                 <button
                   key={date.toISOString()}
@@ -96,7 +103,10 @@ export function SideCalendar({ snapshotDates }: { snapshotDates: string[] }) {
                     hasSnap
                       ? 'cursor-pointer hover:bg-orange-100'
                       : 'text-zinc-400 cursor-default',
-                    isToday && 'bg-orange-500 text-white font-bold',
+                    hasReport && 'bg-green-500 text-white font-bold',
+                    isToday &&
+                      !hasReport &&
+                      'bg-orange-500 text-white font-bold',
                   )}
                 >
                   {date.getDate()}

--- a/components/progress/generate-daily-report-button.tsx
+++ b/components/progress/generate-daily-report-button.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+export function GenerateDailyReportButton() {
+  const [loading, setLoading] = useState(false);
+  const [score, setScore] = useState<number | null>(null);
+  const router = useRouter();
+
+  async function handleClick() {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/progress/daily', { method: 'POST' });
+      if (res.ok) {
+        const data = await res.json();
+        setScore(data.score);
+        router.refresh();
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (score !== null) {
+    return <p>Daily report is created. Your score for today is: {score}</p>;
+  }
+
+  return (
+    <Button
+      onClick={handleClick}
+      disabled={loading}
+      title="You can only generate once a day"
+    >
+      {loading ? 'Generating…' : 'Generate daily report'}
+    </Button>
+  );
+}

--- a/lib/daily-reports.ts
+++ b/lib/daily-reports.ts
@@ -1,0 +1,40 @@
+import { db } from '@/lib/db';
+import { dailyReports } from '@/lib/db/schema';
+import { eq, and, desc } from 'drizzle-orm';
+
+export async function getDailyReport(userId: number, date: string) {
+  const rows = await db
+    .select()
+    .from(dailyReports)
+    .where(and(eq(dailyReports.userId, userId), eq(dailyReports.date, date)));
+  return rows[0] ?? null;
+}
+
+export async function saveDailyReport(
+  userId: number,
+  date: string,
+  score: number,
+  report: any,
+) {
+  await db
+    .insert(dailyReports)
+    .values({ userId, date, score, report })
+    .onConflictDoNothing();
+}
+
+export async function listDailyReports(userId: number) {
+  const rows = await db
+    .select({ date: dailyReports.date, score: dailyReports.score })
+    .from(dailyReports)
+    .where(eq(dailyReports.userId, userId))
+    .orderBy(desc(dailyReports.date));
+  return rows.map((r) => ({ date: String(r.date), score: r.score }));
+}
+
+export async function listDailyReportDates(userId: number) {
+  const rows = await db
+    .select({ date: dailyReports.date })
+    .from(dailyReports)
+    .where(eq(dailyReports.userId, userId));
+  return rows.map((r) => String(r.date));
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -212,6 +212,26 @@ export const planRevisions = pgTable('plan_revisions', {
   snapshotAt: timestamp('snapshot_at').defaultNow(),
 });
 
+export const dailyReports = pgTable(
+  'daily_reports',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    date: date('date').notNull(),
+    report: jsonb('report').notNull(),
+    score: integer('score').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserDate: uniqueIndex('daily_reports_user_date_unique').on(
+      table.userId,
+      table.date,
+    ),
+  }),
+);
+
 export const profileSnapshots = pgTable(
   'profile_snapshots',
   {

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -7,7 +7,8 @@ export type Section =
   | 'ingredients'
   | 'review'
   | 'people'
-  | 'visibility';
+  | 'visibility'
+  | 'progress';
 
 /**
  * Compute an href for a navigation target. Accepts either a known section name
@@ -56,6 +57,8 @@ export function hrefFor(
         return `${base}/people`;
       case 'visibility':
         return base; // no visibility route for viewers/historical
+      case 'progress':
+        return base; // no progress route for viewers/historical
     }
   }
   switch (sectionOrPath) {
@@ -74,5 +77,7 @@ export function hrefFor(
       return '/people';
     case 'visibility':
       return '/visibility';
+    case 'progress':
+      return '/progress';
   }
 }

--- a/lib/progress-context.ts
+++ b/lib/progress-context.ts
@@ -1,0 +1,31 @@
+import { db } from '@/lib/db';
+import { plans, planBlocks } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+
+export async function getTodayPlanContext(userId: number, isoDate: string) {
+  const planRows = await db
+    .select()
+    .from(plans)
+    .where(and(eq(plans.userId, userId), eq(plans.date, isoDate)))
+    .limit(1);
+  const plan = planRows[0];
+  if (!plan) {
+    return { date: isoDate, dailyAim: '', activities: [], reviews: {} };
+  }
+  const blocks = await db
+    .select()
+    .from(planBlocks)
+    .where(eq(planBlocks.planId, plan.id));
+  return {
+    date: isoDate,
+    dailyAim: plan.dailyAim ?? '',
+    activities: blocks.map((b) => ({
+      id: b.id,
+      title: b.title,
+      start: b.start,
+      end: b.end,
+      description: b.description,
+    })),
+    reviews: {}, // TODO: incorporate review data
+  };
+}


### PR DESCRIPTION
## Summary
- add Progress nav link and overview pages
- let users generate daily reports with LLM and store results
- highlight completed days on calendar and block repeat generations

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68adba72ae80832a91cdd9b7e04f8283