### PR TITLE
feat: add daily progress reports

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -197,3 +197,5 @@
 - 2025-10-27: Let recommendation agent auto-create ingredients via tool calls, skipped empty fields in context, and kept chat state until refresh.
 - 2025-10-27: Added resettable ingredient recommendation chat persisted in local storage and confirmed AI-created ingredients before saving.
 - 2025-10-27: Removed ingredient revisions on delete to prevent foreign key errors and added test coverage.
+- 2025-10-27: Added progress overview with daily report generation, navigation link, and calendar highlighting of completed reports.
+- 2025-10-27: Expanded daily report generation with detailed context, improved system prompt, and ability to regenerate reports for testing.

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { createDailyReport } from '@/lib/daily-report-store';
+import { getPlanStrict } from '@/lib/plans-store';
+import { DEFAULT_LLM_SETUP } from '@/lib/llm/config';
+import { getIngredient } from '@/lib/ingredients-store';
+import { getFlavor } from '@/lib/flavors-store';
+
+const SYSTEM_PROMPT = `You are a helpful assessment agent in the Piece of Cake framework. Actions add constructive "flavors" (life domains) through "ingredients" (rules, rituals, habits). The user's Cake—their ethos or life thesis—guides direction without fixing a destination.
+Compare the day's plan and daily aim against execution feedback. Be fair yet candid: praise wins, call out self-sabotage, and scale strictness with the user's ambition and the day's difficulty.
+Return a JSON object with keys: summary, good (array), bad (array), observations (array), score (0-100).`;
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  const userId = Number(session?.user?.id);
+  if (!userId)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  let bodyJson: any = {};
+  try {
+    bodyJson = await req.json();
+  } catch {
+    // ignore
+  }
+  const targetDate = (bodyJson.date as string) || new Date().toISOString().slice(0, 10);
+  const reviews = (bodyJson.reviews as any) || {};
+  const rational = (bodyJson.rational as string) || '';
+
+  const plan = await getPlanStrict(userId, targetDate);
+
+  const ingredientIds = new Set<number>();
+  for (const id of plan.dailyIngredientIds) ingredientIds.add(id);
+  for (const blk of plan.blocks) {
+    for (const id of blk.ingredientIds || []) ingredientIds.add(id);
+  }
+  const ingredientMap: Record<number, any> = {};
+  for (const id of ingredientIds) {
+    const ing = await getIngredient(String(userId), id);
+    if (ing) ingredientMap[id] = ing;
+  }
+  const flavorIds = new Set<string>();
+  for (const blk of plan.blocks) {
+    for (const fid of blk.flavorIds || []) flavorIds.add(fid);
+  }
+  const flavorMap: Record<string, any> = {};
+  for (const fid of flavorIds) {
+    const fl = await getFlavor(String(userId), fid);
+    if (fl) flavorMap[fid] = fl;
+  }
+
+  function formatIngredient(i: any) {
+    return `Title: ${i.title}\nShort description: ${i.shortDescription}\nUsefulness: ${i.usefulness}\nWhat it is: ${i.description}\nWhy used: ${i.whyUsed}\nWhen used / situations: ${i.whenUsed}\nTips: ${i.tips}`;
+  }
+
+  const dailyAimIng = plan.dailyIngredientIds
+    .map((id) => ingredientMap[id])
+    .filter(Boolean)
+    .map((i) => formatIngredient(i))
+    .join('\n');
+
+  let context = `The Ethos / Life Thesis / Telos/rational that the user is trying to achieve in his life (his cake) is: ${rational || 'not provided'}. for today ${targetDate} the users daily aim was ${plan.dailyAim || 'not filled in'}`;
+  if (dailyAimIng) context += `\nIngredients:\n${dailyAimIng}`;
+  context += `\n-------------------------------\n`;
+  context += `the activities the user had inputted for today:\n`;
+  const blocks = [...plan.blocks].sort(
+    (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+  );
+  for (const blk of blocks) {
+    const ingDetails = (blk.ingredientIds || [])
+      .map((id) => ingredientMap[id])
+      .filter(Boolean)
+      .map((i) => formatIngredient(i))
+      .join('\n');
+    const flavorDetails = (blk.flavorIds || [])
+      .map((id) => flavorMap[id])
+      .filter(Boolean)
+      .map((f) => `${f.name}: ${f.description}`)
+      .join('\n');
+    context += `Activity ${blk.id}\nTitle: ${blk.title}\nDescription: ${blk.description}\nTime: ${blk.start} to ${blk.end}\nIngredients:\n${ingDetails || 'none'}\nFlavors:\n${flavorDetails || 'none'}\n`;
+  }
+  context += `--------------------------\n`;
+  const dayReview = reviews['day'] || {};
+  context += `in this part the review of the user are provided:\n`;
+  context += `Daily aim review:\n  what went good: ${dayReview.good || 'user did not leave feedback'}\n  what went bad: ${dayReview.bad || 'user did not leave feedback'}\n  ingredient reviews:\n`;
+  for (const id of plan.dailyIngredientIds) {
+    const ing = ingredientMap[id];
+    if (ing) {
+      context += `   ${ing.title}: ${dayReview.ingredients?.[id] || 'user did not leave feedback'}\n`;
+    }
+  }
+  context += `Activity reviews:\n`;
+  for (const blk of blocks) {
+    const r = reviews[blk.id] || {};
+    context += `  Activity ${blk.id} ${blk.title} (${blk.start} to ${blk.end})\n    what went good: ${r.good || 'user did not leave feedback'}\n    what went bad: ${r.bad || 'user did not leave feedback'}\n`;
+    for (const id of blk.ingredientIds || []) {
+      const ing = ingredientMap[id];
+      if (ing) {
+        context += `    ingredient ${ing.title}: ${r.ingredients?.[id] || 'user did not leave feedback'}\n`;
+      }
+    }
+  }
+  context += `------------------------------`;
+
+  const setup = DEFAULT_LLM_SETUP;
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Missing OpenAI API key' },
+      { status: 500 },
+    );
+  }
+
+  const body = {
+    model: setup.model,
+    temperature: setup.temperature,
+    top_p: setup.top_p,
+    max_tokens: setup.maxTokens,
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user', content: context },
+    ],
+    response_format: { type: 'json_object' },
+  } as any;
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+    const raw = await aiRes.text();
+    if (!aiRes.ok) {
+      return NextResponse.json({ error: raw }, { status: aiRes.status });
+    }
+    const data = JSON.parse(raw);
+    const msg = data.choices?.[0]?.message?.content ?? '{}';
+    let parsed: any = {};
+    try {
+      parsed = JSON.parse(msg);
+    } catch {
+      parsed = { summary: msg, good: [], bad: [], observations: [], score: 0 };
+    }
+    const score = Number(parsed.score) || 0;
+    await createDailyReport(userId, targetDate, JSON.stringify(parsed), score);
+    return NextResponse.json({ report: parsed, score });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e.message || 'LLM request failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/progress/overview/daily/[date]/page.tsx
+++ b/app/progress/overview/daily/[date]/page.tsx
@@ -1,0 +1,59 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getDailyReport } from '@/lib/daily-report-store';
+import { redirect, notFound } from 'next/navigation';
+
+export default async function DailyReportDetail({
+  params,
+}: {
+  params: { date: string };
+}) {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  const report = await getDailyReport(me.id, params.date);
+  if (!report) notFound();
+  let parsed: any = {};
+  try {
+    parsed = JSON.parse(report.content);
+  } catch {
+    parsed.summary = report.content;
+  }
+  return (
+    <main className="p-6">
+      <h1 className="mb-4 text-2xl font-bold">Report for {params.date}</h1>
+      <p className="mb-4 font-semibold">Score: {report.score}</p>
+      <pre className="whitespace-pre-wrap">{parsed.summary ?? ''}</pre>
+      {parsed.good && (
+        <div className="mt-4">
+          <h2 className="font-semibold">What went well</h2>
+          <ul className="list-disc pl-4">
+            {parsed.good.map((g: string, i: number) => (
+              <li key={i}>{g}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {parsed.bad && (
+        <div className="mt-4">
+          <h2 className="font-semibold">What went bad</h2>
+          <ul className="list-disc pl-4">
+            {parsed.bad.map((g: string, i: number) => (
+              <li key={i}>{g}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {parsed.observations && (
+        <div className="mt-4">
+          <h2 className="font-semibold">Observations</h2>
+          <ul className="list-disc pl-4">
+            {parsed.observations.map((g: string, i: number) => (
+              <li key={i}>{g}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { redirect } from 'next/navigation';
+import { listDailyReports } from '@/lib/daily-report-store';
+
+export default async function DailyReportsPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  const reports = await listDailyReports(me.id);
+  return (
+    <main className="p-6">
+      <h1 className="mb-4 text-2xl font-bold">Daily Reports</h1>
+      <ul className="space-y-2">
+        {reports.map((r) => (
+          <li key={r.date}>
+            <Link
+              href={`/progress/overview/daily/${r.date}`}
+              className="flex justify-between rounded border p-4 hover:bg-orange-50"
+            >
+              <span>{r.date}</span>
+              <span>{r.score}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/progress/overview/page.tsx
+++ b/app/progress/overview/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+
+const items = [
+  { href: '/progress/overview/daily', label: 'Daily' },
+  { href: '/progress/overview/weekly', label: 'Weekly' },
+  { href: '/progress/overview/monthly', label: 'Monthly' },
+  { href: '/progress/overview/yearly', label: 'Yearly' },
+];
+
+export default function ProgressOverviewPage() {
+  return (
+    <main className="p-6">
+      <ul className="space-y-2">
+        {items.map((i) => (
+          <li key={i.href}>
+            <Link
+              href={i.href}
+              className="block rounded border p-4 hover:bg-orange-50"
+            >
+              {i.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -2,12 +2,18 @@ import Link from 'next/link';
 
 export default function ProgressPage() {
   return (
-    <main className="p-6">
+    <main className="p-6 space-x-4">
       <Link
         href="/progress/testchat"
         className="bg-orange-500 text-white px-4 py-2 rounded"
       >
         Chat with LLM
+      </Link>
+      <Link
+        href="/progress/overview"
+        className="bg-orange-500 text-white px-4 py-2 rounded"
+      >
+        Overview
       </Link>
     </main>
   );

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -14,6 +14,7 @@ const labels: Record<Section, string> = {
   review: 'Review',
   people: 'People',
   visibility: 'Visibility',
+  progress: 'Progress',
 };
 
 export function AppNav() {
@@ -30,6 +31,7 @@ export function AppNav() {
           'review',
           'people',
           'visibility',
+          'progress',
         ];
 
   return (

--- a/components/cake/cake-home.tsx
+++ b/components/cake/cake-home.tsx
@@ -1,14 +1,23 @@
 import { SideCalendar } from '@/components/calendar/side-calendar';
 import { CakeNavigation } from './cake-navigation';
 import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
+import { listDailyReportDates } from '@/lib/daily-report-store';
+import { GenerateDailyReportButton } from '@/components/progress/generate-daily-report-button';
+import { cookies } from 'next/headers';
+import { getNow, toYMD } from '@/lib/clock';
 
 export async function CakeHome({ ownerId }: { ownerId: number }) {
   const snapshotDates = await listProfileSnapshotDates(ownerId);
+  const reportDates = await listDailyReportDates(ownerId);
+  const cookieStore = await cookies();
+  const { now } = getNow('UTC', { cookies: cookieStore });
+  const todayIso = toYMD(now, 'UTC');
   return (
     <section className="w-full">
       <h1 className="sr-only">Cake</h1>
-      <SideCalendar snapshotDates={snapshotDates} />
+      <SideCalendar snapshotDates={snapshotDates} reportDates={reportDates} />
       <CakeNavigation />
+      <GenerateDailyReportButton userId={ownerId} date={todayIso} />
     </section>
   );
 }

--- a/components/calendar/side-calendar.tsx
+++ b/components/calendar/side-calendar.tsx
@@ -5,7 +5,13 @@ import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { useViewContext } from '@/lib/view-context';
 
-export function SideCalendar({ snapshotDates }: { snapshotDates: string[] }) {
+export function SideCalendar({
+  snapshotDates,
+  reportDates = [],
+}: {
+  snapshotDates: string[];
+  reportDates?: string[];
+}) {
   const [open, setOpen] = useState(false);
   const [monthOffset, setMonthOffset] = useState(0);
   const router = useRouter();
@@ -77,6 +83,7 @@ export function SideCalendar({ snapshotDates }: { snapshotDates: string[] }) {
               const isToday = date.toDateString() === today.toDateString();
               const iso = date.toLocaleDateString('en-CA');
               const hasSnap = snapshotDates.includes(iso);
+              const hasReport = reportDates.includes(iso);
               return (
                 <button
                   key={date.toISOString()}
@@ -96,7 +103,9 @@ export function SideCalendar({ snapshotDates }: { snapshotDates: string[] }) {
                     hasSnap
                       ? 'cursor-pointer hover:bg-orange-100'
                       : 'text-zinc-400 cursor-default',
-                    isToday && 'bg-orange-500 text-white font-bold',
+                    hasReport
+                      ? 'bg-green-500 text-white'
+                      : isToday && 'bg-orange-500 text-white font-bold',
                   )}
                 >
                   {date.getDate()}

--- a/components/progress/generate-daily-report-button.tsx
+++ b/components/progress/generate-daily-report-button.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useLogs } from '@/components/dev/logs-provider';
+import { useRouter } from 'next/navigation';
+
+export function GenerateDailyReportButton({
+  userId,
+  date,
+}: {
+  userId: number;
+  date: string;
+}) {
+  const [loading, setLoading] = useState(false);
+  const { addLog } = useLogs();
+  const router = useRouter();
+  const [message, setMessage] = useState<string | null>(null);
+
+  const onClick = async () => {
+    setLoading(true);
+    let reviews: Record<string, any> = {};
+    try {
+      const raw = window.localStorage.getItem(`review-${userId}-${date}`);
+      if (raw) reviews = JSON.parse(raw);
+    } catch {
+      // ignore malformed data
+    }
+    const rational = window.localStorage.getItem(`rational-${userId}`) || '';
+    const payload = { date, reviews, rational };
+    const res = await fetch('/api/progress/daily-report', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json();
+    addLog({ request: JSON.stringify(payload), response: JSON.stringify(data) });
+    setLoading(false);
+    if (data.error) {
+      setMessage(data.error);
+    } else {
+      setMessage(
+        `Daily rapport is created. Your score for today is: ${data.score}`,
+      );
+      router.refresh();
+    }
+  };
+
+  if (message) {
+    return <p className="mt-4 text-sm">{message}</p>;
+  }
+
+  return (
+    <Button onClick={onClick} disabled={loading} className="mt-4">
+      {loading ? 'Generating…' : 'Generate daily report'}
+    </Button>
+  );
+}

--- a/drizzle/0018_create_daily_reports.sql
+++ b/drizzle/0018_create_daily_reports.sql
@@ -1,0 +1,9 @@
+CREATE TABLE daily_reports (
+  id serial PRIMARY KEY,
+  user_id integer NOT NULL REFERENCES users(id),
+  date date NOT NULL,
+  content text NOT NULL,
+  score integer NOT NULL,
+  created_at timestamp DEFAULT now(),
+  CONSTRAINT daily_reports_user_date_unique UNIQUE (user_id, date)
+);

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -1,0 +1,61 @@
+import { db } from './db';
+import { dailyReports } from './db/schema';
+import { eq, and, asc } from 'drizzle-orm';
+import type { DailyReport } from '@/types/report';
+
+export async function listDailyReportDates(userId: number): Promise<string[]> {
+  const rows = await db
+    .select({ date: dailyReports.date })
+    .from(dailyReports)
+    .where(eq(dailyReports.userId, userId));
+  return rows.map((r) => r.date?.toString().slice(0, 10) ?? '');
+}
+
+export async function listDailyReports(
+  userId: number,
+): Promise<Array<{ date: string; score: number }>> {
+  const rows = await db
+    .select({ date: dailyReports.date, score: dailyReports.score })
+    .from(dailyReports)
+    .where(eq(dailyReports.userId, userId))
+    .orderBy(asc(dailyReports.date));
+  return rows.map((r) => ({
+    date: r.date?.toString().slice(0, 10) ?? '',
+    score: r.score ?? 0,
+  }));
+}
+
+export async function getDailyReport(
+  userId: number,
+  date: string,
+): Promise<DailyReport | null> {
+  const [row] = await db
+    .select()
+    .from(dailyReports)
+    .where(and(eq(dailyReports.userId, userId), eq(dailyReports.date, date)));
+  if (!row) return null;
+  return {
+    id: row.id,
+    userId: row.userId ?? 0,
+    date: row.date?.toString().slice(0, 10) ?? date,
+    content: row.content ?? '',
+    score: row.score ?? 0,
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+export async function createDailyReport(
+  userId: number,
+  date: string,
+  content: string,
+  score: number,
+) {
+  const now = new Date();
+  await db
+    .insert(dailyReports)
+    .values({ userId, date, content, score, createdAt: now })
+    .onConflictDoUpdate({
+      target: [dailyReports.userId, dailyReports.date],
+      set: { content, score, createdAt: now },
+    });
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -230,3 +230,23 @@ export const profileSnapshots = pgTable(
     ),
   }),
 );
+
+export const dailyReports = pgTable(
+  'daily_reports',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    date: date('date').notNull(),
+    content: text('content').notNull(),
+    score: integer('score').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserDate: uniqueIndex('daily_reports_user_date_unique').on(
+      table.userId,
+      table.date,
+    ),
+  }),
+);

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -7,7 +7,8 @@ export type Section =
   | 'ingredients'
   | 'review'
   | 'people'
-  | 'visibility';
+  | 'visibility'
+  | 'progress';
 
 /**
  * Compute an href for a navigation target. Accepts either a known section name
@@ -56,6 +57,8 @@ export function hrefFor(
         return `${base}/people`;
       case 'visibility':
         return base; // no visibility route for viewers/historical
+      case 'progress':
+        return base; // progress hidden in viewer/historical
     }
   }
   switch (sectionOrPath) {
@@ -74,5 +77,7 @@ export function hrefFor(
       return '/people';
     case 'visibility':
       return '/visibility';
+    case 'progress':
+      return '/progress';
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@panva/hkdf':
+        specifier: ^1.2.1
+        version: 1.2.1
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.21(postcss@8.5.6)
@@ -20,6 +23,9 @@ importers:
       drizzle-orm:
         specifier: ^0.44.4
         version: 0.44.4(pg@8.16.3)
+      jose:
+        specifier: ^4.15.9
+        version: 4.15.9
       next:
         specifier: 15.1.4
         version: 15.1.4(@playwright/test@1.54.2)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -44,12 +50,6 @@ importers:
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.17
-      jose:
-        specifier: ^4.15.9
-        version: 4.15.9
-      '@panva/hkdf':
-        specifier: ^1.2.1
-        version: 1.2.1
     devDependencies:
       '@playwright/test':
         specifier: ^1.44.0

--- a/tests/progress.spec.ts
+++ b/tests/progress.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('progress link and overview', async ({ page }) => {
+  const handle = `user${Date.now()}`;
+  const email = `${handle}@example.com`;
+  const password = 'pass1234';
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Tester');
+  await page.fill('input[placeholder="Handle"]', handle);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.click('text=Progress');
+  await expect(page.getByRole('link', { name: 'Chat with LLM' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Overview' })).toBeVisible();
+});

--- a/types/report.ts
+++ b/types/report.ts
@@ -1,0 +1,8 @@
+export interface DailyReport {
+  id: number;
+  userId: number;
+  date: string; // YYYY-MM-DD
+  content: string; // JSON string of report
+  score: number;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- enable regenerating daily reports with upserted storage
- capture date, reviews, and rational to build detailed report context
- surface daily report button with site time awareness

## Testing
- `pnpm lint`
- `npx tsc --noEmit`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68adba72ae80832a91cdd9b7e04f8283