### PR TITLE
feat: add daily progress reports

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -192,3 +192,7 @@ Modal form IDs:
 - `hist-cake-{ownerId}-{date}` → historical cake page.
 - `hist-flav-{ownerId}-{date}` → historical flavors page.
 - `hist-subflav-{ownerId}-{flavorId}-{date}` → historical subflavors page.
+
+## Progress
+
+- `pr0g-gen-{ownerId}` → generate daily report button.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -197,3 +197,7 @@
 - 2025-10-27: Let recommendation agent auto-create ingredients via tool calls, skipped empty fields in context, and kept chat state until refresh.
 - 2025-10-27: Added resettable ingredient recommendation chat persisted in local storage and confirmed AI-created ingredients before saving.
 - 2025-10-27: Removed ingredient revisions on delete to prevent foreign key errors and added test coverage.
+- 2025-10-27: Added progress overview with daily report generation, navigation link, and calendar highlighting of completed reports.
+- 2025-10-27: Improved daily report agent with richer context, site-time handling, and replaceable report generation for testing.
+- 2025-10-27: Structured daily report input with ethos, daily aim, activities, and reviews; logged LLM requests and responses.
+- 2025-10-27: Matched daily report context to exact user-specified structure and added spinner-equipped generator button with ID.

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -1,0 +1,222 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { createDailyReport } from '@/lib/daily-report-store';
+import { getPlanStrict } from '@/lib/plans-store';
+import { getIngredient } from '@/lib/ingredients-store';
+import { getFlavor } from '@/lib/flavors-store';
+import { getSubflavor } from '@/lib/subflavors-store';
+import { resolvePlanDate, toYMD } from '@/lib/plan-date';
+import { DEFAULT_LLM_SETUP } from '@/lib/llm/config';
+
+// Assessment agent prompt summarised from user instructions
+const SYSTEM_PROMPT = `You are a helpful assistant in the Piece of Cake framework: actions add \"flavors\" (life domains) through \"ingredients\" (habits/rules). The Cake is the user's guiding ethos, offering direction without a fixed destination. Compare the user's plan with their execution, highlighting positive contributions, trade-offs, and imbalance.
+
+Be wise, strict yet fair. Ambitious goals warrant tougher grading; acknowledge wins, call out self-sabotage, and consider planning difficulty versus execution quality.
+
+Respond ONLY with JSON containing: summary (string), good (string[]), bad (string[]), observations (string[]), score (number 0-100).`;
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  const userId = Number(session?.user?.id);
+  if (!userId)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  let body: any = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const reviews = body.reviews || {};
+  const ethos = body.ethos || body.rational || '';
+
+  const { date: dateObj, tz } = resolvePlanDate(
+    'live',
+    session?.user as any,
+    { cookies: req.cookies, searchParams: Object.fromEntries(req.nextUrl.searchParams) },
+  );
+  const today = toYMD(dateObj, tz);
+
+  const plan = await getPlanStrict(userId, today);
+
+  // helper to fetch ingredient details once
+  const ingredientCache = new Map<number, any>();
+  async function loadIngredient(id: number) {
+    if (!ingredientCache.has(id)) {
+      const ing = await getIngredient(String(userId), id, userId);
+      if (ing) ingredientCache.set(id, ing);
+    }
+    return ingredientCache.get(id);
+  }
+
+  const dailyIngredients = await Promise.all(
+    plan.dailyIngredientIds.map((id) => loadIngredient(id)),
+  );
+
+  const activities = [] as any[];
+  const sorted = [...plan.blocks].sort((a, b) => a.start.localeCompare(b.start));
+  for (const blk of sorted) {
+    const ings = await Promise.all(blk.ingredientIds.map((id) => loadIngredient(id)));
+    const flavors = await Promise.all(
+      blk.flavorIds.map((fid) => getFlavor(String(userId), fid, userId)),
+    );
+    const subflavors = await Promise.all(
+      blk.subflavorIds.map((sid) => getSubflavor(String(userId), sid, userId)),
+    );
+    activities.push({
+      id: blk.id,
+      title: blk.title,
+      description: blk.description,
+      start: blk.start,
+      end: blk.end,
+      ingredients: ings.filter(Boolean),
+      flavors: flavors.filter(Boolean),
+      subflavors: subflavors.filter(Boolean),
+    });
+  }
+
+  // --- reviews ---
+  const dailyAimReview = reviews['day'] || {};
+
+  const activityReviews = new Map<string, any>();
+  for (const act of activities) {
+    const r = reviews[act.id] || {};
+    activityReviews.set(act.id, r);
+  }
+
+  // --- build context string ---
+  function formatIngredient(ing: any): string {
+    return `- ${ing.title}\n  Short description: ${ing.shortDescription}\n  Usefulness (1-100): ${ing.usefulness}\n  What it is: ${ing.description}\n  Why used: ${ing.whyUsed}\n  When used / situations: ${ing.whenUsed}\n  Tips: ${ing.tips}`;
+  }
+
+  const lines: string[] = [];
+  lines.push(
+    `The Ethos / Life Thesis / Telos/rational that the user is trying to achieve in his life (his cake) is: ${
+      ethos || 'not provided'
+    } . for today ${today} the users daily aim was ${
+      plan.dailyAim || 'not filled in'
+    }${
+      dailyIngredients.length
+        ? ' including the information of which ingredients the user added for that day so the Title\nShort description\nUsefulness (scale 1-100)\n\nWhat it is\nWhy used\nWhen used / situations\nTips.  for that ingredient.'
+        : ''
+    }`,
+  );
+  for (const ing of dailyIngredients.filter(Boolean)) {
+    lines.push(formatIngredient(ing));
+  }
+  lines.push('-------------------------------');
+  lines.push(
+    'the activities the user had inputted for today: (here the activities are going to be sorted with the earlies ones starting first)',
+  );
+  if (activities.length === 0) lines.push('no activities planned.');
+  for (const act of activities) {
+    lines.push(`activity id p1an-blk-${act.id}-${userId}`);
+    lines.push(`Activity: ${act.title}`);
+    lines.push(`Description: ${act.description}`);
+    lines.push(`Time start till end: ${act.start} till ${act.end}`);
+    if (act.ingredients.length) {
+      lines.push('Ingredients:');
+      for (const ing of act.ingredients) lines.push(formatIngredient(ing));
+    }
+    if (act.flavors.length || act.subflavors.length) {
+      lines.push('Flavours added by the user (so the info of them):');
+      for (const fl of act.flavors)
+        lines.push(`- ${fl.name}: ${fl.description} (importance ${fl.importance})`);
+      for (const sf of act.subflavors)
+        lines.push(`- ${sf.name}: ${sf.description} (importance ${sf.importance})`);
+    }
+  }
+  lines.push('--------------------------');
+  lines.push('in this part the review of the user are provided:');
+  lines.push(
+    "start by the review of the daily aim, and the review of the ingredients (if filled in, if not filled in it will say everywhere, user didn't leave feedback)",
+  );
+  lines.push(`- what went good: ${dailyAimReview.good || 'user did not leave feedback'}`);
+  lines.push(`- what went bad: ${dailyAimReview.bad || 'user did not leave feedback'}`);
+  lines.push('- ingredient review:');
+  const aimIngReviews = dailyAimReview.ingredients || {};
+  if (Object.keys(aimIngReviews).length === 0) {
+    lines.push('  user did not leave feedback');
+  } else {
+    for (const [iid, fb] of Object.entries(aimIngReviews)) {
+      const ing = await loadIngredient(Number(iid));
+      const name = ing?.title || `ingredient ${iid}`;
+      lines.push(`  - ${name}: ${fb || 'user did not leave feedback'}`);
+    }
+  }
+  lines.push('and here is the review for every activitity the user did:');
+  for (const act of activities) {
+    const r = activityReviews.get(act.id) || {};
+    lines.push(`activity id p1an-blk-${act.id}-${userId} and time ${act.start}-${act.end} and title ${act.title}`);
+    lines.push(`- what went good: ${r.good || 'user did not leave feedback'}`);
+    lines.push(`- what went bad: ${r.bad || 'user did not leave feedback'}`);
+    lines.push('- ingredient review:');
+    const ingReviews = r.ingredients || {};
+    if (Object.keys(ingReviews).length === 0) {
+      lines.push('  user did not leave feedback');
+    } else {
+      for (const [iid, fb] of Object.entries(ingReviews)) {
+        const ing = await loadIngredient(Number(iid));
+        const name = ing?.title || `ingredient ${iid}`;
+        lines.push(`  - ${name}: ${fb || 'user did not leave feedback'}`);
+      }
+    }
+  }
+  lines.push('------------------------------');
+  lines.push(
+    'youre goal is to now write the report in the structured output and take everything into consideration.',
+  );
+
+  const context = lines.join('\n');
+
+  const setup = DEFAULT_LLM_SETUP;
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Missing OpenAI API key' },
+      { status: 500 },
+    );
+  }
+
+  const reqBody = {
+    model: setup.model,
+    temperature: setup.temperature,
+    top_p: setup.top_p,
+    max_tokens: setup.maxTokens,
+    messages: [
+      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'user', content: context },
+    ],
+    response_format: { type: 'json_object' },
+  } as any;
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(reqBody),
+    });
+    const raw = await aiRes.text();
+    if (!aiRes.ok) {
+      return NextResponse.json({ error: raw }, { status: aiRes.status });
+    }
+    const data = JSON.parse(raw);
+    const msg = data.choices?.[0]?.message?.content ?? '{}';
+    let parsed: any = {};
+    try {
+      parsed = JSON.parse(msg);
+    } catch {
+      parsed = { summary: msg, good: [], bad: [], observations: [], score: 0 };
+    }
+    const score = Number(parsed.score) || 0;
+    await createDailyReport(userId, today, JSON.stringify(parsed), score);
+    return NextResponse.json({ report: parsed, score, context });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e.message || 'LLM request failed' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/progress/overview/daily/[date]/page.tsx
+++ b/app/progress/overview/daily/[date]/page.tsx
@@ -1,0 +1,59 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getDailyReport } from '@/lib/daily-report-store';
+import { redirect, notFound } from 'next/navigation';
+
+export default async function DailyReportDetail({
+  params,
+}: {
+  params: { date: string };
+}) {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  const report = await getDailyReport(me.id, params.date);
+  if (!report) notFound();
+  let parsed: any = {};
+  try {
+    parsed = JSON.parse(report.content);
+  } catch {
+    parsed.summary = report.content;
+  }
+  return (
+    <main className="p-6">
+      <h1 className="mb-4 text-2xl font-bold">Report for {params.date}</h1>
+      <p className="mb-4 font-semibold">Score: {report.score}</p>
+      <pre className="whitespace-pre-wrap">{parsed.summary ?? ''}</pre>
+      {parsed.good && (
+        <div className="mt-4">
+          <h2 className="font-semibold">What went well</h2>
+          <ul className="list-disc pl-4">
+            {parsed.good.map((g: string, i: number) => (
+              <li key={i}>{g}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {parsed.bad && (
+        <div className="mt-4">
+          <h2 className="font-semibold">What went bad</h2>
+          <ul className="list-disc pl-4">
+            {parsed.bad.map((g: string, i: number) => (
+              <li key={i}>{g}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {parsed.observations && (
+        <div className="mt-4">
+          <h2 className="font-semibold">Observations</h2>
+          <ul className="list-disc pl-4">
+            {parsed.observations.map((g: string, i: number) => (
+              <li key={i}>{g}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { redirect } from 'next/navigation';
+import { listDailyReports } from '@/lib/daily-report-store';
+
+export default async function DailyReportsPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  const reports = await listDailyReports(me.id);
+  return (
+    <main className="p-6">
+      <h1 className="mb-4 text-2xl font-bold">Daily Reports</h1>
+      <ul className="space-y-2">
+        {reports.map((r) => (
+          <li key={r.date}>
+            <Link
+              href={`/progress/overview/daily/${r.date}`}
+              className="flex justify-between rounded border p-4 hover:bg-orange-50"
+            >
+              <span>{r.date}</span>
+              <span>{r.score}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/progress/overview/page.tsx
+++ b/app/progress/overview/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+
+const items = [
+  { href: '/progress/overview/daily', label: 'Daily' },
+  { href: '/progress/overview/weekly', label: 'Weekly' },
+  { href: '/progress/overview/monthly', label: 'Monthly' },
+  { href: '/progress/overview/yearly', label: 'Yearly' },
+];
+
+export default function ProgressOverviewPage() {
+  return (
+    <main className="p-6">
+      <ul className="space-y-2">
+        {items.map((i) => (
+          <li key={i.href}>
+            <Link
+              href={i.href}
+              className="block rounded border p-4 hover:bg-orange-50"
+            >
+              {i.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -2,12 +2,18 @@ import Link from 'next/link';
 
 export default function ProgressPage() {
   return (
-    <main className="p-6">
+    <main className="p-6 space-x-4">
       <Link
         href="/progress/testchat"
         className="bg-orange-500 text-white px-4 py-2 rounded"
       >
         Chat with LLM
+      </Link>
+      <Link
+        href="/progress/overview"
+        className="bg-orange-500 text-white px-4 py-2 rounded"
+      >
+        Overview
       </Link>
     </main>
   );

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -14,6 +14,7 @@ const labels: Record<Section, string> = {
   review: 'Review',
   people: 'People',
   visibility: 'Visibility',
+  progress: 'Progress',
 };
 
 export function AppNav() {
@@ -30,6 +31,7 @@ export function AppNav() {
           'review',
           'people',
           'visibility',
+          'progress',
         ];
 
   return (

--- a/components/cake/cake-home.tsx
+++ b/components/cake/cake-home.tsx
@@ -1,14 +1,18 @@
 import { SideCalendar } from '@/components/calendar/side-calendar';
 import { CakeNavigation } from './cake-navigation';
 import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
+import { listDailyReportDates } from '@/lib/daily-report-store';
+import { GenerateDailyReportButton } from '@/components/progress/generate-daily-report-button';
 
 export async function CakeHome({ ownerId }: { ownerId: number }) {
   const snapshotDates = await listProfileSnapshotDates(ownerId);
+  const reportDates = await listDailyReportDates(ownerId);
   return (
     <section className="w-full">
       <h1 className="sr-only">Cake</h1>
-      <SideCalendar snapshotDates={snapshotDates} />
+      <SideCalendar snapshotDates={snapshotDates} reportDates={reportDates} />
       <CakeNavigation />
+      <GenerateDailyReportButton userId={ownerId} />
     </section>
   );
 }

--- a/components/calendar/side-calendar.tsx
+++ b/components/calendar/side-calendar.tsx
@@ -5,7 +5,13 @@ import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import { useViewContext } from '@/lib/view-context';
 
-export function SideCalendar({ snapshotDates }: { snapshotDates: string[] }) {
+export function SideCalendar({
+  snapshotDates,
+  reportDates = [],
+}: {
+  snapshotDates: string[];
+  reportDates?: string[];
+}) {
   const [open, setOpen] = useState(false);
   const [monthOffset, setMonthOffset] = useState(0);
   const router = useRouter();
@@ -77,6 +83,7 @@ export function SideCalendar({ snapshotDates }: { snapshotDates: string[] }) {
               const isToday = date.toDateString() === today.toDateString();
               const iso = date.toLocaleDateString('en-CA');
               const hasSnap = snapshotDates.includes(iso);
+              const hasReport = reportDates.includes(iso);
               return (
                 <button
                   key={date.toISOString()}
@@ -96,7 +103,9 @@ export function SideCalendar({ snapshotDates }: { snapshotDates: string[] }) {
                     hasSnap
                       ? 'cursor-pointer hover:bg-orange-100'
                       : 'text-zinc-400 cursor-default',
-                    isToday && 'bg-orange-500 text-white font-bold',
+                    hasReport
+                      ? 'bg-green-500 text-white'
+                      : isToday && 'bg-orange-500 text-white font-bold',
                   )}
                 >
                   {date.getDate()}

--- a/components/progress/generate-daily-report-button.tsx
+++ b/components/progress/generate-daily-report-button.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useLogs } from '@/components/dev/logs-provider';
+import { useRouter } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
+
+export function GenerateDailyReportButton({
+  userId,
+}: {
+  userId: number;
+}) {
+  const [loading, setLoading] = useState(false);
+  const { addLog } = useLogs();
+  const router = useRouter();
+  const [message, setMessage] = useState<string | null>(null);
+
+  const onClick = async () => {
+    setLoading(true);
+    const params = new URLSearchParams(window.location.search);
+    const dateParam = params.get('apoc_date');
+    let date = dateParam || '';
+    if (!date) {
+      const match = document.cookie.match(/apoc_clock=([^;]+)/);
+      if (match) {
+        const d = new Date(decodeURIComponent(match[1]));
+        if (!isNaN(d.getTime())) date = d.toISOString().slice(0, 10);
+      }
+      if (!date) date = new Date().toISOString().slice(0, 10);
+    }
+    const reviewKey = `review-${userId}-${date}`;
+    let reviews: Record<string, any> = {};
+    try {
+      const raw = window.localStorage.getItem(reviewKey);
+      if (raw) reviews = JSON.parse(raw);
+    } catch {
+      // ignore
+    }
+    const ethos = window.localStorage.getItem('review-rational') || '';
+    const body = { date, reviews, ethos };
+    const url = `/api/progress/daily-report${
+      params.toString() ? `?${params.toString()}` : ''
+    }`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    addLog({
+      request: data.context || JSON.stringify(body),
+      response: JSON.stringify(data.report ?? data),
+    });
+    setLoading(false);
+    if (data.error) {
+      setMessage(data.error);
+    } else {
+      setMessage(
+        `Daily report is created. Your score for today is: ${data.score}`,
+      );
+      router.refresh();
+    }
+  };
+
+  if (message) {
+    return <p className="mt-4 text-sm">{message}</p>;
+  }
+
+  return (
+    <Button
+      onClick={onClick}
+      disabled={loading}
+      title="You can only generate once per day"
+      className="mt-4"
+      id={`pr0g-gen-${userId}`}
+    >
+      {loading ? (
+        <>
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Generating…
+        </>
+      ) : (
+        'Generate daily report'
+      )}
+    </Button>
+  );
+}

--- a/drizzle/0018_create_daily_reports.sql
+++ b/drizzle/0018_create_daily_reports.sql
@@ -1,0 +1,9 @@
+CREATE TABLE daily_reports (
+  id serial PRIMARY KEY,
+  user_id integer NOT NULL REFERENCES users(id),
+  date date NOT NULL,
+  content text NOT NULL,
+  score integer NOT NULL,
+  created_at timestamp DEFAULT now(),
+  CONSTRAINT daily_reports_user_date_unique UNIQUE (user_id, date)
+);

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -1,0 +1,60 @@
+import { db } from './db';
+import { dailyReports } from './db/schema';
+import { eq, and, asc, sql } from 'drizzle-orm';
+import type { DailyReport } from '@/types/report';
+
+export async function listDailyReportDates(userId: number): Promise<string[]> {
+  const rows = await db
+    .select({ date: dailyReports.date })
+    .from(dailyReports)
+    .where(eq(dailyReports.userId, userId));
+  return rows.map((r) => r.date?.toString().slice(0, 10) ?? '');
+}
+
+export async function listDailyReports(
+  userId: number,
+): Promise<Array<{ date: string; score: number }>> {
+  const rows = await db
+    .select({ date: dailyReports.date, score: dailyReports.score })
+    .from(dailyReports)
+    .where(eq(dailyReports.userId, userId))
+    .orderBy(asc(dailyReports.date));
+  return rows.map((r) => ({
+    date: r.date?.toString().slice(0, 10) ?? '',
+    score: r.score ?? 0,
+  }));
+}
+
+export async function getDailyReport(
+  userId: number,
+  date: string,
+): Promise<DailyReport | null> {
+  const [row] = await db
+    .select()
+    .from(dailyReports)
+    .where(and(eq(dailyReports.userId, userId), eq(dailyReports.date, date)));
+  if (!row) return null;
+  return {
+    id: row.id,
+    userId: row.userId ?? 0,
+    date: row.date?.toString().slice(0, 10) ?? date,
+    content: row.content ?? '',
+    score: row.score ?? 0,
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+export async function createDailyReport(
+  userId: number,
+  date: string,
+  content: string,
+  score: number,
+) {
+  await db
+    .insert(dailyReports)
+    .values({ userId, date, content, score })
+    .onConflictDoUpdate({
+      target: [dailyReports.userId, dailyReports.date],
+      set: { content, score, createdAt: sql`now()` },
+    });
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -230,3 +230,23 @@ export const profileSnapshots = pgTable(
     ),
   }),
 );
+
+export const dailyReports = pgTable(
+  'daily_reports',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    date: date('date').notNull(),
+    content: text('content').notNull(),
+    score: integer('score').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserDate: uniqueIndex('daily_reports_user_date_unique').on(
+      table.userId,
+      table.date,
+    ),
+  }),
+);

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -7,7 +7,8 @@ export type Section =
   | 'ingredients'
   | 'review'
   | 'people'
-  | 'visibility';
+  | 'visibility'
+  | 'progress';
 
 /**
  * Compute an href for a navigation target. Accepts either a known section name
@@ -56,6 +57,8 @@ export function hrefFor(
         return `${base}/people`;
       case 'visibility':
         return base; // no visibility route for viewers/historical
+      case 'progress':
+        return base; // progress hidden in viewer/historical
     }
   }
   switch (sectionOrPath) {
@@ -74,5 +77,7 @@ export function hrefFor(
       return '/people';
     case 'visibility':
       return '/visibility';
+    case 'progress':
+      return '/progress';
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,13 @@
     "test": "playwright test"
   },
   "dependencies": {
+    "@panva/hkdf": "^1.2.1",
     "autoprefixer": "^10.4.16",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "drizzle-orm": "^0.44.4",
+    "jose": "^4.15.9",
+    "lucide-react": "^0.542.0",
     "next": "15.1.4",
     "next-auth": "^4.24.7",
     "pg": "^8.11.1",
@@ -22,9 +25,7 @@
     "react": "19.1.1",
     "react-dom": "19.1.1",
     "tailwind-merge": "^2.2.2",
-    "tailwindcss": "^3.4.1",
-    "jose": "^4.15.9",
-    "@panva/hkdf": "^1.2.1"
+    "tailwindcss": "^3.4.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.44.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@panva/hkdf':
+        specifier: ^1.2.1
+        version: 1.2.1
       autoprefixer:
         specifier: ^10.4.16
         version: 10.4.21(postcss@8.5.6)
@@ -20,6 +23,12 @@ importers:
       drizzle-orm:
         specifier: ^0.44.4
         version: 0.44.4(pg@8.16.3)
+      jose:
+        specifier: ^4.15.9
+        version: 4.15.9
+      lucide-react:
+        specifier: ^0.542.0
+        version: 0.542.0(react@19.1.1)
       next:
         specifier: 15.1.4
         version: 15.1.4(@playwright/test@1.54.2)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -44,12 +53,6 @@ importers:
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.17
-      jose:
-        specifier: ^4.15.9
-        version: 4.15.9
-      '@panva/hkdf':
-        specifier: ^1.2.1
-        version: 1.2.1
     devDependencies:
       '@playwright/test':
         specifier: ^1.44.0
@@ -1764,6 +1767,11 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lucide-react@0.542.0:
+    resolution: {integrity: sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -3540,8 +3548,8 @@ snapshots:
       '@typescript-eslint/parser': 8.39.1(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -3560,7 +3568,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -3571,22 +3579,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.39.1(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -3597,7 +3605,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4128,6 +4136,10 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lucide-react@0.542.0(react@19.1.1):
+    dependencies:
+      react: 19.1.1
 
   math-intrinsics@1.1.0: {}
 

--- a/tests/progress.spec.ts
+++ b/tests/progress.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('progress link and overview', async ({ page }) => {
+  const handle = `user${Date.now()}`;
+  const email = `${handle}@example.com`;
+  const password = 'pass1234';
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Tester');
+  await page.fill('input[placeholder="Handle"]', handle);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.click('text=Progress');
+  await expect(page.getByRole('link', { name: 'Chat with LLM' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Overview' })).toBeVisible();
+});

--- a/types/report.ts
+++ b/types/report.ts
@@ -1,0 +1,8 @@
+export interface DailyReport {
+  id: number;
+  userId: number;
+  date: string; // YYYY-MM-DD
+  content: string; // JSON string of report
+  score: number;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- restructure daily report endpoint with site-time aware context and review data
- upsert daily reports and expose generator button with logging
- always show generator for testing and forward user-specific data
- structure daily report input with ethos, daily aim, activities, and reviews
- log LLM request and response for daily report generation
- match daily report context to exact user-specified structure and add spinner-equipped generator button with ID

## Testing
- `pnpm lint`
- `npx tsc --noEmit`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68adba72ae80832a91cdd9b7e04f8283