### PR TITLE
feat: persist review notes

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -203,3 +203,4 @@
 - 2025-10-27: Aligned daily report prompt formatting to the exact required structure for ethos, aim, activities, and reviews.
 - 2025-10-27: Refined daily report agent to honor provided dates, always return prompt context on errors, hide the generator once a report exists, and tightened system instructions.
 - 2025-10-27: Filled daily report context with plan data, ingredient/flavor IDs, and local plan fallback.
+- 2025-10-27: Persisted review notes in local storage so rational and guilty pleasure text survives reloads.

--- a/app/(app)/review/page.tsx
+++ b/app/(app)/review/page.tsx
@@ -1,18 +1,51 @@
-"use client";
+'use client';
 
 import Textarea from '@/components/ui/textarea';
 import { useViewContext } from '@/lib/view-context';
+import { useEffect, useState } from 'react';
 
 export function ReviewHome() {
   const { editable } = useViewContext();
+  const [rational, setRational] = useState('');
+  const [guilty, setGuilty] = useState('');
+
+  // Load saved notes from localStorage on mount
+  useEffect(() => {
+    const savedRational = localStorage.getItem('review-rational');
+    const savedGuilty = localStorage.getItem('review-guilty');
+    if (savedRational) setRational(savedRational);
+    if (savedGuilty) setGuilty(savedGuilty);
+  }, []);
+
+  const handleRationalChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    setRational(value);
+    if (value) {
+      localStorage.setItem('review-rational', value);
+    } else {
+      localStorage.removeItem('review-rational');
+    }
+  };
+
+  const handleGuiltyChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    setGuilty(value);
+    if (value) {
+      localStorage.setItem('review-guilty', value);
+    } else {
+      localStorage.removeItem('review-guilty');
+    }
+  };
   return (
     <section className="grid h-[calc(100vh-2rem)] grid-cols-2 gap-4 overflow-hidden">
       <div className="flex flex-col overflow-y-scroll pr-4">
-        <h2 className="mb-2 text-xl font-semibold">Youre rational</h2>
+        <h2 className="mb-2 text-xl font-semibold">Your rational</h2>
         <Textarea
           className="min-h-[1500px]"
           placeholder="Type here"
           disabled={!editable}
+          value={rational}
+          onChange={handleRationalChange}
         />
         <hr className="my-4" />
         <h2 className="mb-2 text-xl font-semibold">guilty pleasure</h2>
@@ -20,6 +53,8 @@ export function ReviewHome() {
           className="min-h-[1500px]"
           placeholder="Type here"
           disabled={!editable}
+          value={guilty}
+          onChange={handleGuiltyChange}
         />
       </div>
       <div className="flex items-center justify-center overflow-y-scroll border-l pl-4 text-gray-400">

--- a/tests/review.spec.ts
+++ b/tests/review.spec.ts
@@ -27,6 +27,14 @@ test('owner review page loads', async ({ page }) => {
   await left.evaluate((el) => el.scrollTo(0, el.scrollHeight));
   const rightTop = await right.evaluate((el) => el.scrollTop);
   expect(rightTop).toBe(0);
+
+  // text persists after reload
+  const tasks = page.locator('textarea');
+  await tasks.first().fill('rational text');
+  await tasks.nth(1).fill('guilty text');
+  await page.reload();
+  await expect(tasks.first()).toHaveValue('rational text');
+  await expect(tasks.nth(1)).toHaveValue('guilty text');
 });
 
 test('viewer review page is read-only', async ({ page }) => {


### PR DESCRIPTION
## Summary
- persist rational and guilty pleasure review notes locally so text stays after reload
- cover review note persistence with Playwright tests
- log change in UPDATE.md

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*


------
https://chatgpt.com/codex/tasks/task_e_68ae025f7f5c832a8539a4acb742a263