### PR TITLE
fix: validate daily report output and handle DB errors

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -204,3 +204,4 @@
 - 2025-10-27: Refined daily report agent to honor provided dates, always return prompt context on errors, hide the generator once a report exists, and tightened system instructions.
 - 2025-10-27: Filled daily report context with plan data, ingredient/flavor IDs, and local plan fallback.
 - 2025-10-27: Persisted review notes in local storage so rational and guilty pleasure text survives reloads.
+- 2025-10-27: Validated daily report LLM output, sanitized score handling, prevented SQL leaks, and added parser tests.

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { createDailyReport } from '@/lib/daily-report-store';
+import { extractDailyReport } from '@/lib/daily-report-parser';
 import { getPlanStrict } from '@/lib/plans-store';
 import { getIngredient } from '@/lib/ingredients-store';
 import { getFlavor } from '@/lib/flavors-store';
@@ -29,13 +30,13 @@ export async function POST(req: NextRequest) {
   const reviews = body.reviews || {};
   const ethos = body.ethos || body.rational || '';
 
-  const { date: dateObj, tz } = resolvePlanDate(
-    'live',
-    session?.user as any,
-    { cookies: req.cookies, searchParams: Object.fromEntries(req.nextUrl.searchParams) },
-  );
+  const { date: dateObj, tz } = resolvePlanDate('live', session?.user as any, {
+    cookies: req.cookies,
+    searchParams: Object.fromEntries(req.nextUrl.searchParams),
+  });
   const today = toYMD(dateObj, tz);
-  const targetDate = typeof body.date === 'string' && body.date ? body.date : today;
+  const targetDate =
+    typeof body.date === 'string' && body.date ? body.date : today;
 
   const plan = body.plan
     ? {
@@ -60,7 +61,9 @@ export async function POST(req: NextRequest) {
   );
 
   const activities = [] as any[];
-  const sorted = [...plan.blocks].sort((a, b) => a.start.localeCompare(b.start));
+  const sorted = [...plan.blocks].sort((a, b) =>
+    a.start.localeCompare(b.start),
+  );
   for (const blk of sorted) {
     const ings = await Promise.all(
       blk.ingredientIds.map((id: number) => loadIngredient(id)),
@@ -152,8 +155,12 @@ export async function POST(req: NextRequest) {
     "in this part the review of the user are provided: start by the review of the daily aim, and the review of the ingredients (if filled in, if not filled in it will say everywhere, user didn't leave feedback)",
   );
   lines.push('review of the daily aim:');
-  lines.push(`- what went good: ${dailyAimReview.good || 'user did not leave feedback'}`);
-  lines.push(`- what went bad: ${dailyAimReview.bad || 'user did not leave feedback'}`);
+  lines.push(
+    `- what went good: ${dailyAimReview.good || 'user did not leave feedback'}`,
+  );
+  lines.push(
+    `- what went bad: ${dailyAimReview.bad || 'user did not leave feedback'}`,
+  );
   lines.push('- ingredient feedback:');
   const aimIngReviews = dailyAimReview.ingredients || {};
   if (Object.keys(aimIngReviews).length === 0) {
@@ -231,19 +238,31 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: raw }, { status: aiRes.status });
     }
     const data = JSON.parse(raw);
-    const msg = data.choices?.[0]?.message?.content ?? '{}';
-    let parsed: any = {};
+    const msg = data.choices?.[0]?.message?.content ?? '';
+    let parsed;
     try {
-      parsed = JSON.parse(msg);
+      parsed = extractDailyReport(msg);
     } catch {
-      parsed = { summary: msg, good: [], bad: [], observations: [], score: 0 };
+      return NextResponse.json(
+        { error: 'Invalid LLM response', context },
+        { status: 500 },
+      );
     }
-    const score = Number(parsed.score) || 0;
-    await createDailyReport(userId, targetDate, JSON.stringify(parsed), score);
+    const content = JSON.stringify(parsed);
+    const score = parsed.score;
+    try {
+      await createDailyReport(userId, targetDate, content, score);
+    } catch (e) {
+      console.error('Failed to save daily report', e);
+      return NextResponse.json(
+        { error: 'Failed to save daily report', context },
+        { status: 500 },
+      );
+    }
     return NextResponse.json({ report: parsed, score, context });
   } catch (e: any) {
     return NextResponse.json(
-      { error: e.message || 'LLM request failed', context },
+      { error: 'LLM request failed', context },
       { status: 500 },
     );
   }

--- a/lib/daily-report-parser.ts
+++ b/lib/daily-report-parser.ts
@@ -1,0 +1,60 @@
+export interface DailyReportContent {
+  summary: string;
+  good: string[];
+  bad: string[];
+  observations: string[];
+  score: number;
+}
+
+function ensureStringArray(v: any): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((s) => typeof s === 'string');
+}
+
+export function extractDailyReport(raw: string): DailyReportContent {
+  if (typeof raw !== 'string') throw new Error('invalid input');
+  const trimmed = raw.trim();
+  // find first JSON object
+  let start = trimmed.indexOf('{');
+  if (start === -1) throw new Error('no json found');
+  let depth = 0;
+  let end = -1;
+  for (let i = start; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  if (end === -1) throw new Error('no json found');
+  const jsonText = trimmed.slice(start, end);
+  const extraBefore = trimmed.slice(0, start).trim();
+  const extraAfter = trimmed.slice(end).trim();
+  if (extraBefore || extraAfter) throw new Error('extra data present');
+  let obj: any;
+  try {
+    obj = JSON.parse(jsonText);
+  } catch {
+    throw new Error('invalid json');
+  }
+  const content: DailyReportContent = {
+    summary: typeof obj.summary === 'string' ? obj.summary : '',
+    good: ensureStringArray(obj.good),
+    bad: ensureStringArray(obj.bad),
+    observations: ensureStringArray(obj.observations),
+    score: Number.isInteger(obj.score) ? obj.score : NaN,
+  };
+  if (
+    !content.summary ||
+    !Number.isInteger(content.score) ||
+    content.score < 0 ||
+    content.score > 100
+  ) {
+    throw new Error('invalid shape');
+  }
+  return content;
+}

--- a/tests/daily-report-parser.spec.ts
+++ b/tests/daily-report-parser.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import { extractDailyReport } from '../lib/daily-report-parser';
+
+test('extracts valid report', () => {
+  const raw =
+    '{"summary":"s","good":["g"],"bad":[],"observations":[],"score":42}';
+  const parsed = extractDailyReport(raw);
+  expect(parsed.score).toBe(42);
+  expect(parsed.good).toEqual(['g']);
+});
+
+test('rejects duplicated payload', () => {
+  const raw =
+    '{"summary":"s","good":[],"bad":[],"observations":[],"score":10},83,{"summary":"s","good":[],"bad":[],"observations":[],"score":10},83';
+  expect(() => extractDailyReport(raw)).toThrow();
+});
+
+test('rejects missing or invalid score', () => {
+  const raw = '{"summary":"s","good":[],"bad":[],"observations":[]}';
+  expect(() => extractDailyReport(raw)).toThrow();
+  const raw2 =
+    '{"summary":"s","good":[],"bad":[],"observations":[],"score":"hi"}';
+  expect(() => extractDailyReport(raw2)).toThrow();
+});


### PR DESCRIPTION
## Summary
- validate LLM daily report JSON and score before storing
- sanitize DB errors and prevent duplicate payloads
- add parser unit tests

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: web server couldn't start, likely missing DB)*

------
https://chatgpt.com/codex/tasks/task_e_68ae063ea760832aa3ccddfd9fbbebce