### PR TITLE
fix: persist daily report content and display summary

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -204,3 +204,5 @@
 - 2025-10-27: Refined daily report agent to honor provided dates, always return prompt context on errors, hide the generator once a report exists, and tightened system instructions.
 - 2025-10-27: Filled daily report context with plan data, ingredient/flavor IDs, and local plan fallback.
 - 2025-10-27: Persisted review notes in local storage so rational and guilty pleasure text survives reloads.
+
+- 2025-10-27: Fixed daily report storage to stringify content automatically and show summary, good, bad, and score on the overview page.

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -29,13 +29,13 @@ export async function POST(req: NextRequest) {
   const reviews = body.reviews || {};
   const ethos = body.ethos || body.rational || '';
 
-  const { date: dateObj, tz } = resolvePlanDate(
-    'live',
-    session?.user as any,
-    { cookies: req.cookies, searchParams: Object.fromEntries(req.nextUrl.searchParams) },
-  );
+  const { date: dateObj, tz } = resolvePlanDate('live', session?.user as any, {
+    cookies: req.cookies,
+    searchParams: Object.fromEntries(req.nextUrl.searchParams),
+  });
   const today = toYMD(dateObj, tz);
-  const targetDate = typeof body.date === 'string' && body.date ? body.date : today;
+  const targetDate =
+    typeof body.date === 'string' && body.date ? body.date : today;
 
   const plan = body.plan
     ? {
@@ -60,7 +60,9 @@ export async function POST(req: NextRequest) {
   );
 
   const activities = [] as any[];
-  const sorted = [...plan.blocks].sort((a, b) => a.start.localeCompare(b.start));
+  const sorted = [...plan.blocks].sort((a, b) =>
+    a.start.localeCompare(b.start),
+  );
   for (const blk of sorted) {
     const ings = await Promise.all(
       blk.ingredientIds.map((id: number) => loadIngredient(id)),
@@ -152,8 +154,12 @@ export async function POST(req: NextRequest) {
     "in this part the review of the user are provided: start by the review of the daily aim, and the review of the ingredients (if filled in, if not filled in it will say everywhere, user didn't leave feedback)",
   );
   lines.push('review of the daily aim:');
-  lines.push(`- what went good: ${dailyAimReview.good || 'user did not leave feedback'}`);
-  lines.push(`- what went bad: ${dailyAimReview.bad || 'user did not leave feedback'}`);
+  lines.push(
+    `- what went good: ${dailyAimReview.good || 'user did not leave feedback'}`,
+  );
+  lines.push(
+    `- what went bad: ${dailyAimReview.bad || 'user did not leave feedback'}`,
+  );
   lines.push('- ingredient feedback:');
   const aimIngReviews = dailyAimReview.ingredients || {};
   if (Object.keys(aimIngReviews).length === 0) {
@@ -239,7 +245,7 @@ export async function POST(req: NextRequest) {
       parsed = { summary: msg, good: [], bad: [], observations: [], score: 0 };
     }
     const score = Number(parsed.score) || 0;
-    await createDailyReport(userId, targetDate, JSON.stringify(parsed), score);
+    await createDailyReport(userId, targetDate, parsed, score);
     return NextResponse.json({ report: parsed, score, context });
   } catch (e: any) {
     return NextResponse.json(

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -12,16 +12,36 @@ export default async function DailyReportsPage() {
   return (
     <main className="p-6">
       <h1 className="mb-4 text-2xl font-bold">Daily Reports</h1>
-      <ul className="space-y-2">
+      <ul className="space-y-4">
         {reports.map((r) => (
-          <li key={r.date}>
-            <Link
-              href={`/progress/overview/daily/${r.date}`}
-              className="flex justify-between rounded border p-4 hover:bg-orange-50"
-            >
-              <span>{r.date}</span>
-              <span>{r.score}</span>
-            </Link>
+          <li key={r.date} className="rounded border p-4 hover:bg-orange-50">
+            <div className="mb-2 flex justify-between">
+              <Link href={`/progress/overview/daily/${r.date}`}>{r.date}</Link>
+              <span className="font-semibold">Score: {r.score}</span>
+            </div>
+            {r.summary && (
+              <p className="mb-2 whitespace-pre-wrap">{r.summary}</p>
+            )}
+            {r.good.length > 0 && (
+              <div className="mb-2">
+                <h2 className="font-semibold">Good</h2>
+                <ul className="list-disc pl-4">
+                  {r.good.map((g, i) => (
+                    <li key={i}>{g}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {r.bad.length > 0 && (
+              <div>
+                <h2 className="font-semibold">Bad</h2>
+                <ul className="list-disc pl-4">
+                  {r.bad.map((b, i) => (
+                    <li key={i}>{b}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </li>
         ))}
       </ul>

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -11,18 +11,39 @@ export async function listDailyReportDates(userId: number): Promise<string[]> {
   return rows.map((r) => r.date?.toString().slice(0, 10) ?? '');
 }
 
-export async function listDailyReports(
-  userId: number,
-): Promise<Array<{ date: string; score: number }>> {
+export async function listDailyReports(userId: number): Promise<
+  Array<{
+    date: string;
+    score: number;
+    summary: string;
+    good: string[];
+    bad: string[];
+  }>
+> {
   const rows = await db
-    .select({ date: dailyReports.date, score: dailyReports.score })
+    .select({
+      date: dailyReports.date,
+      score: dailyReports.score,
+      content: dailyReports.content,
+    })
     .from(dailyReports)
     .where(eq(dailyReports.userId, userId))
     .orderBy(asc(dailyReports.date));
-  return rows.map((r) => ({
-    date: r.date?.toString().slice(0, 10) ?? '',
-    score: r.score ?? 0,
-  }));
+  return rows.map((r) => {
+    let parsed: any = {};
+    try {
+      parsed = JSON.parse(r.content ?? '{}');
+    } catch {
+      parsed = {};
+    }
+    return {
+      date: r.date?.toString().slice(0, 10) ?? '',
+      score: r.score ?? 0,
+      summary: parsed.summary ?? '',
+      good: Array.isArray(parsed.good) ? parsed.good : [],
+      bad: Array.isArray(parsed.bad) ? parsed.bad : [],
+    };
+  });
 }
 
 export async function getDailyReport(
@@ -47,14 +68,16 @@ export async function getDailyReport(
 export async function createDailyReport(
   userId: number,
   date: string,
-  content: string,
+  content: string | object,
   score: number,
 ) {
+  const serialized =
+    typeof content === 'string' ? content : JSON.stringify(content);
   await db
     .insert(dailyReports)
-    .values({ userId, date, content, score })
+    .values({ userId, date, content: serialized, score })
     .onConflictDoUpdate({
       target: [dailyReports.userId, dailyReports.date],
-      set: { content, score, createdAt: sql`now()` },
+      set: { content: serialized, score, createdAt: sql`now()` },
     });
 }


### PR DESCRIPTION
## Summary
- ensure daily report content is stringified before DB writes
- show each day's summary, good, bad, and score on the overview page
- accept parsed report objects when saving

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` (fails: Timed out waiting 120000ms from config.webServer)

------
https://chatgpt.com/codex/tasks/task_e_68ae0c960104832aa59a4157dd676692