### PR TITLE
feat: show daily report details in overview

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -36,8 +36,9 @@
 - 2025-08-27: Auto-created missing user records during follow to avoid "User not found" errors.
 - 2025-08-27: Reconciled session users with DB via email, preventing duplicate records and hiding self on People page.
 - 2025-08-28: Enabled class-based dark mode toggle, added account visibility API route, and sent inbox notifications for auto-accepted follows.
-- 2025-08-30: Added followers API, updated settings menu with live follower count, dark mode toggle fix, and link to new account settings page for visibility changes.
+ - 2025-08-30: Added followers API, updated settings menu with live follower count, dark mode toggle fix, and link to new account settings page for visibility changes.
 - 2025-08-30: Fixed follow visibility and notifications; renamed People page section to "Following" so followed users remain discoverable.
+- 2025-08-31: Replaced failing daily report upsert with manual insert/update so assessment summaries store and render reliably.
 - 2025-08-30: Kept closed-account follows visible, added unfollow notifications, and surfaced them in the inbox.
 - 2025-08-30: Enabled follow-back after accepting requests, added decline notifications, and ensured closed accounts appear in Discover.
 - 2025-08-30: Fixed profile route params handling and ensured inbox shows follow requests/notifications for all users.
@@ -204,3 +205,5 @@
 - 2025-10-27: Refined daily report agent to honor provided dates, always return prompt context on errors, hide the generator once a report exists, and tightened system instructions.
 - 2025-10-27: Filled daily report context with plan data, ingredient/flavor IDs, and local plan fallback.
 - 2025-10-27: Persisted review notes in local storage so rational and guilty pleasure text survives reloads.
+- 2025-10-27: Stored AI-generated daily reports in the database and surfaced summary, positives, negatives, and score on the daily overview page.
+- 2025-10-27: Fixed daily report upsert by issuing a direct SQL insert/update so reports save and display correctly.

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -12,15 +12,41 @@ export default async function DailyReportsPage() {
   return (
     <main className="p-6">
       <h1 className="mb-4 text-2xl font-bold">Daily Reports</h1>
-      <ul className="space-y-2">
+      <ul className="space-y-4">
         {reports.map((r) => (
-          <li key={r.date}>
+          <li key={r.date} className="rounded border p-4">
+            <div className="flex items-center justify-between">
+              <h2 className="font-semibold">{r.date}</h2>
+              <span className="font-semibold">{r.score}</span>
+            </div>
+            {r.summary && (
+              <p className="mt-2 whitespace-pre-wrap">{r.summary}</p>
+            )}
+            {r.good.length > 0 && (
+              <div className="mt-2">
+                <h3 className="font-semibold">What went well</h3>
+                <ul className="list-disc pl-4">
+                  {r.good.map((g, i) => (
+                    <li key={i}>{g}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {r.bad.length > 0 && (
+              <div className="mt-2">
+                <h3 className="font-semibold">What went bad</h3>
+                <ul className="list-disc pl-4">
+                  {r.bad.map((b, i) => (
+                    <li key={i}>{b}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
             <Link
               href={`/progress/overview/daily/${r.date}`}
-              className="flex justify-between rounded border p-4 hover:bg-orange-50"
+              className="mt-2 block text-sm text-orange-600 hover:underline"
             >
-              <span>{r.date}</span>
-              <span>{r.score}</span>
+              View details
             </Link>
           </li>
         ))}

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -11,18 +11,39 @@ export async function listDailyReportDates(userId: number): Promise<string[]> {
   return rows.map((r) => r.date?.toString().slice(0, 10) ?? '');
 }
 
-export async function listDailyReports(
-  userId: number,
-): Promise<Array<{ date: string; score: number }>> {
+export async function listDailyReports(userId: number): Promise<
+  Array<{
+    date: string;
+    score: number;
+    summary: string;
+    good: string[];
+    bad: string[];
+  }>
+> {
   const rows = await db
-    .select({ date: dailyReports.date, score: dailyReports.score })
+    .select({
+      date: dailyReports.date,
+      score: dailyReports.score,
+      content: dailyReports.content,
+    })
     .from(dailyReports)
     .where(eq(dailyReports.userId, userId))
     .orderBy(asc(dailyReports.date));
-  return rows.map((r) => ({
-    date: r.date?.toString().slice(0, 10) ?? '',
-    score: r.score ?? 0,
-  }));
+  return rows.map((r) => {
+    let parsed: any = {};
+    try {
+      parsed = JSON.parse(r.content ?? '{}');
+    } catch {
+      parsed = {};
+    }
+    return {
+      date: r.date?.toString().slice(0, 10) ?? '',
+      score: r.score ?? 0,
+      summary: parsed.summary ?? '',
+      good: parsed.good ?? [],
+      bad: parsed.bad ?? [],
+    };
+  });
 }
 
 export async function getDailyReport(
@@ -47,14 +68,29 @@ export async function getDailyReport(
 export async function createDailyReport(
   userId: number,
   date: string,
-  content: string,
+  content: string | Record<string, unknown>,
   score: number,
 ) {
-  await db
-    .insert(dailyReports)
-    .values({ userId, date, content, score })
-    .onConflictDoUpdate({
-      target: [dailyReports.userId, dailyReports.date],
-      set: { content, score, createdAt: sql`now()` },
+  const contentStr =
+    typeof content === 'string' ? content : JSON.stringify(content);
+
+  // manual upsert to avoid relying on a unique constraint that may not exist yet
+  const existing = await db
+    .select({ id: dailyReports.id })
+    .from(dailyReports)
+    .where(and(eq(dailyReports.userId, userId), eq(dailyReports.date, date)));
+
+  if (existing.length) {
+    await db
+      .update(dailyReports)
+      .set({ content: contentStr, score, createdAt: sql`now()` })
+      .where(eq(dailyReports.id, existing[0].id));
+  } else {
+    await db.insert(dailyReports).values({
+      userId,
+      date,
+      content: contentStr,
+      score,
     });
+  }
 }


### PR DESCRIPTION
## Summary
- parse daily report JSON content when listing reports and persist results safely
- show summary, positives, negatives, and score for each day on daily overview page
- store daily reports via manual insert/update to avoid constraint errors and ensure reports render

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0c960104832aa59a4157dd676692