### PR TITLE
fix: store daily report JSON and use ddmmyyyy routes

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -207,3 +207,4 @@
 - 2025-10-27: Stored AI-generated daily reports in the database and surfaced summary, positives, negatives, and score on the daily overview page.
 - 2025-10-27: Fixed daily report upsert by issuing a direct SQL insert/update so reports save and display correctly.
 - 2025-10-27: Resolved daily report insert errors by upserting via Drizzle with date casting and JSON string content.
+- 2025-10-28: Stored daily report content as JSONB, saving raw LLM output and using DDMMYYYY URLs for report detail pages.

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -239,7 +239,7 @@ export async function POST(req: NextRequest) {
       parsed = { summary: msg, good: [], bad: [], observations: [], score: 0 };
     }
     const score = Number(parsed.score) || 0;
-    await createDailyReport(userId, targetDate, JSON.stringify(parsed), score);
+    await createDailyReport(userId, targetDate, parsed, score);
     return NextResponse.json({ report: parsed, score, context });
   } catch (e: any) {
     return NextResponse.json(

--- a/app/progress/overview/daily/[date]/page.tsx
+++ b/app/progress/overview/daily/[date]/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { getDailyReport } from '@/lib/daily-report-store';
+import { fromDmy } from '@/lib/date-format';
 import { redirect, notFound } from 'next/navigation';
 
 export default async function DailyReportDetail({
@@ -11,17 +12,13 @@ export default async function DailyReportDetail({
   const session = await auth();
   if (!session) redirect('/signin');
   const me = await ensureUser(session);
-  const report = await getDailyReport(me.id, params.date);
+  const ymd = fromDmy(params.date);
+  const report = await getDailyReport(me.id, ymd);
   if (!report) notFound();
-  let parsed: any = {};
-  try {
-    parsed = JSON.parse(report.content);
-  } catch {
-    parsed.summary = report.content;
-  }
+  const parsed: any = report.content;
   return (
     <main className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">Report for {params.date}</h1>
+      <h1 className="mb-4 text-2xl font-bold">Report for {ymd}</h1>
       <p className="mb-4 font-semibold">Score: {report.score}</p>
       <pre className="whitespace-pre-wrap">{parsed.summary ?? ''}</pre>
       {parsed.good && (

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -3,6 +3,7 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { redirect } from 'next/navigation';
 import { listDailyReports } from '@/lib/daily-report-store';
+import { toDmy } from '@/lib/date-format';
 
 export default async function DailyReportsPage() {
   const session = await auth();
@@ -43,7 +44,7 @@ export default async function DailyReportsPage() {
               </div>
             )}
             <Link
-              href={`/progress/overview/daily/${r.date}`}
+              href={`/progress/overview/daily/${toDmy(r.date)}`}
               className="mt-2 block text-sm text-orange-600 hover:underline"
             >
               View details

--- a/drizzle/0019_alter_daily_reports_content_jsonb.sql
+++ b/drizzle/0019_alter_daily_reports_content_jsonb.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "daily_reports" ALTER COLUMN "content" TYPE jsonb USING "content"::jsonb;

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -30,12 +30,7 @@ export async function listDailyReports(userId: number): Promise<
     .where(eq(dailyReports.userId, userId))
     .orderBy(asc(dailyReports.date));
   return rows.map((r) => {
-    let parsed: any = {};
-    try {
-      parsed = JSON.parse(r.content ?? '{}');
-    } catch {
-      parsed = {};
-    }
+    const parsed: any = r.content ?? {};
     return {
       date: r.date?.toString().slice(0, 10) ?? '',
       score: r.score ?? 0,
@@ -59,7 +54,7 @@ export async function getDailyReport(
     id: row.id,
     userId: row.userId ?? 0,
     date: row.date?.toString().slice(0, 10) ?? date,
-    content: row.content ?? '',
+    content: (row.content as any) ?? {},
     score: row.score ?? 0,
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
   };
@@ -68,23 +63,21 @@ export async function getDailyReport(
 export async function createDailyReport(
   userId: number,
   date: string,
-  content: string | Record<string, unknown>,
+  content: Record<string, unknown>,
   score: number,
 ) {
-  const contentStr =
-    typeof content === 'string' ? content : JSON.stringify(content);
   await db
     .insert(dailyReports)
     .values({
       userId,
       date: sql`${date}::date`,
-      content: contentStr,
+      content,
       score,
     })
     .onConflictDoUpdate({
       target: [dailyReports.userId, dailyReports.date],
       set: {
-        content: contentStr,
+        content,
         score,
         createdAt: sql`now()`,
       },

--- a/lib/date-format.ts
+++ b/lib/date-format.ts
@@ -1,0 +1,13 @@
+export function toDmy(ymd: string): string {
+  if (!/\d{4}-\d{2}-\d{2}/.test(ymd)) return ymd;
+  const [y, m, d] = ymd.split('-');
+  return `${d}${m}${y}`;
+}
+
+export function fromDmy(dmy: string): string {
+  if (!/\d{8}/.test(dmy)) return dmy;
+  const d = dmy.slice(0, 2);
+  const m = dmy.slice(2, 4);
+  const y = dmy.slice(4, 8);
+  return `${y}-${m}-${d}`;
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -239,7 +239,7 @@ export const dailyReports = pgTable(
       .references(() => users.id)
       .notNull(),
     date: date('date').notNull(),
-    content: text('content').notNull(),
+    content: jsonb('content').notNull(),
     score: integer('score').notNull(),
     createdAt: timestamp('created_at').defaultNow(),
   },

--- a/types/report.ts
+++ b/types/report.ts
@@ -2,7 +2,7 @@ export interface DailyReport {
   id: number;
   userId: number;
   date: string; // YYYY-MM-DD
-  content: string; // JSON string of report
+  content: Record<string, unknown>; // raw LLM output JSON
   score: number;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- store daily report content as JSONB and save raw LLM output
- link daily reports using DDMMYYYY URLs with helpers
- persist parsed report JSON directly from API

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Command "typecheck" not found)*
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68aea7dc56dc832a8744fb7be66c44ad