### PR TITLE
fix: store daily reports as json and slug date

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -207,3 +207,5 @@
 - 2025-10-27: Stored AI-generated daily reports in the database and surfaced summary, positives, negatives, and score on the daily overview page.
 - 2025-10-27: Fixed daily report upsert by issuing a direct SQL insert/update so reports save and display correctly.
 - 2025-10-27: Resolved daily report insert errors by upserting via Drizzle with date casting and JSON string content.
+- 2025-10-27: Converted daily report content to JSONB, saved raw LLM output, and used ddmmyyyy slugs for report detail routes.
+- 2025-10-27: Safely migrated legacy daily report text to JSONB to prevent cast errors during pushes.

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -29,13 +29,13 @@ export async function POST(req: NextRequest) {
   const reviews = body.reviews || {};
   const ethos = body.ethos || body.rational || '';
 
-  const { date: dateObj, tz } = resolvePlanDate(
-    'live',
-    session?.user as any,
-    { cookies: req.cookies, searchParams: Object.fromEntries(req.nextUrl.searchParams) },
-  );
+  const { date: dateObj, tz } = resolvePlanDate('live', session?.user as any, {
+    cookies: req.cookies,
+    searchParams: Object.fromEntries(req.nextUrl.searchParams),
+  });
   const today = toYMD(dateObj, tz);
-  const targetDate = typeof body.date === 'string' && body.date ? body.date : today;
+  const targetDate =
+    typeof body.date === 'string' && body.date ? body.date : today;
 
   const plan = body.plan
     ? {
@@ -60,7 +60,9 @@ export async function POST(req: NextRequest) {
   );
 
   const activities = [] as any[];
-  const sorted = [...plan.blocks].sort((a, b) => a.start.localeCompare(b.start));
+  const sorted = [...plan.blocks].sort((a, b) =>
+    a.start.localeCompare(b.start),
+  );
   for (const blk of sorted) {
     const ings = await Promise.all(
       blk.ingredientIds.map((id: number) => loadIngredient(id)),
@@ -152,8 +154,12 @@ export async function POST(req: NextRequest) {
     "in this part the review of the user are provided: start by the review of the daily aim, and the review of the ingredients (if filled in, if not filled in it will say everywhere, user didn't leave feedback)",
   );
   lines.push('review of the daily aim:');
-  lines.push(`- what went good: ${dailyAimReview.good || 'user did not leave feedback'}`);
-  lines.push(`- what went bad: ${dailyAimReview.bad || 'user did not leave feedback'}`);
+  lines.push(
+    `- what went good: ${dailyAimReview.good || 'user did not leave feedback'}`,
+  );
+  lines.push(
+    `- what went bad: ${dailyAimReview.bad || 'user did not leave feedback'}`,
+  );
   lines.push('- ingredient feedback:');
   const aimIngReviews = dailyAimReview.ingredients || {};
   if (Object.keys(aimIngReviews).length === 0) {
@@ -239,7 +245,7 @@ export async function POST(req: NextRequest) {
       parsed = { summary: msg, good: [], bad: [], observations: [], score: 0 };
     }
     const score = Number(parsed.score) || 0;
-    await createDailyReport(userId, targetDate, JSON.stringify(parsed), score);
+    await createDailyReport(userId, targetDate, parsed, score);
     return NextResponse.json({ report: parsed, score, context });
   } catch (e: any) {
     return NextResponse.json(

--- a/app/progress/overview/daily/[date]/page.tsx
+++ b/app/progress/overview/daily/[date]/page.tsx
@@ -13,15 +13,10 @@ export default async function DailyReportDetail({
   const me = await ensureUser(session);
   const report = await getDailyReport(me.id, params.date);
   if (!report) notFound();
-  let parsed: any = {};
-  try {
-    parsed = JSON.parse(report.content);
-  } catch {
-    parsed.summary = report.content;
-  }
+  const parsed = report.content;
   return (
     <main className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">Report for {params.date}</h1>
+      <h1 className="mb-4 text-2xl font-bold">Report for {report.date}</h1>
       <p className="mb-4 font-semibold">Score: {report.score}</p>
       <pre className="whitespace-pre-wrap">{parsed.summary ?? ''}</pre>
       {parsed.good && (

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -43,7 +43,7 @@ export default async function DailyReportsPage() {
               </div>
             )}
             <Link
-              href={`/progress/overview/daily/${r.date}`}
+              href={`/progress/overview/daily/${r.slug}`}
               className="mt-2 block text-sm text-orange-600 hover:underline"
             >
               View details

--- a/drizzle/0019_alter_daily_reports_content_jsonb.sql
+++ b/drizzle/0019_alter_daily_reports_content_jsonb.sql
@@ -1,0 +1,8 @@
+ALTER TABLE daily_reports
+  ALTER COLUMN content TYPE jsonb
+  USING CASE
+    -- keep existing JSON, default empty JSON, or wrap legacy text
+    WHEN content IS NULL OR trim(content) = '' THEN '{}'::jsonb
+    WHEN content ~ '^\\s*[\\[{]' THEN content::jsonb
+    ELSE to_jsonb(content)
+  END;

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -1,7 +1,20 @@
 import { db } from './db';
 import { dailyReports } from './db/schema';
 import { eq, and, asc, sql } from 'drizzle-orm';
-import type { DailyReport } from '@/types/report';
+import type { DailyReport, ReportContent } from '@/types/report';
+
+function slugFromDate(ymd: string): string {
+  const [y, m, d] = ymd.split('-');
+  return `${d}${m}${y}`;
+}
+
+function dateFromSlug(slug: string): string {
+  if (slug.length !== 8) return slug;
+  const d = slug.slice(0, 2);
+  const m = slug.slice(2, 4);
+  const y = slug.slice(4);
+  return `${y}-${m}-${d}`;
+}
 
 export async function listDailyReportDates(userId: number): Promise<string[]> {
   const rows = await db
@@ -14,6 +27,7 @@ export async function listDailyReportDates(userId: number): Promise<string[]> {
 export async function listDailyReports(userId: number): Promise<
   Array<{
     date: string;
+    slug: string;
     score: number;
     summary: string;
     good: string[];
@@ -30,14 +44,11 @@ export async function listDailyReports(userId: number): Promise<
     .where(eq(dailyReports.userId, userId))
     .orderBy(asc(dailyReports.date));
   return rows.map((r) => {
-    let parsed: any = {};
-    try {
-      parsed = JSON.parse(r.content ?? '{}');
-    } catch {
-      parsed = {};
-    }
+    const ymd = r.date?.toString().slice(0, 10) ?? '';
+    const parsed = (r.content as ReportContent) || {};
     return {
-      date: r.date?.toString().slice(0, 10) ?? '',
+      date: ymd,
+      slug: slugFromDate(ymd),
       score: r.score ?? 0,
       summary: parsed.summary ?? '',
       good: parsed.good ?? [],
@@ -48,8 +59,9 @@ export async function listDailyReports(userId: number): Promise<
 
 export async function getDailyReport(
   userId: number,
-  date: string,
+  slug: string,
 ): Promise<DailyReport | null> {
+  const date = dateFromSlug(slug);
   const [row] = await db
     .select()
     .from(dailyReports)
@@ -58,8 +70,8 @@ export async function getDailyReport(
   return {
     id: row.id,
     userId: row.userId ?? 0,
-    date: row.date?.toString().slice(0, 10) ?? date,
-    content: row.content ?? '',
+    date,
+    content: (row.content as ReportContent) ?? ({} as ReportContent),
     score: row.score ?? 0,
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
   };
@@ -68,23 +80,21 @@ export async function getDailyReport(
 export async function createDailyReport(
   userId: number,
   date: string,
-  content: string | Record<string, unknown>,
+  content: Record<string, unknown>,
   score: number,
 ) {
-  const contentStr =
-    typeof content === 'string' ? content : JSON.stringify(content);
   await db
     .insert(dailyReports)
     .values({
       userId,
       date: sql`${date}::date`,
-      content: contentStr,
+      content,
       score,
     })
     .onConflictDoUpdate({
       target: [dailyReports.userId, dailyReports.date],
       set: {
-        content: contentStr,
+        content,
         score,
         createdAt: sql`now()`,
       },

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -239,7 +239,7 @@ export const dailyReports = pgTable(
       .references(() => users.id)
       .notNull(),
     date: date('date').notNull(),
-    content: text('content').notNull(),
+    content: jsonb('content').notNull(),
     score: integer('score').notNull(),
     createdAt: timestamp('created_at').defaultNow(),
   },

--- a/types/report.ts
+++ b/types/report.ts
@@ -1,8 +1,16 @@
+export interface ReportContent {
+  summary: string;
+  good: string[];
+  bad: string[];
+  observations: string[];
+  score: number;
+}
+
 export interface DailyReport {
   id: number;
   userId: number;
   date: string; // YYYY-MM-DD
-  content: string; // JSON string of report
+  content: ReportContent; // raw JSON of report
   score: number;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- store daily report content as JSONB and keep raw LLM output
- use ddmmyyyy slugs for daily report detail routes
- upsert daily reports with json objects instead of strings
- handle legacy text when migrating to JSONB to avoid cast errors

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*
- `pnpm drizzle-kit push` *(fails: Either connection "url" or "host", "database" are required for PostgreSQL database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68aea7dc56dc832a8744fb7be66c44ad