### PR TITLE
fix: store daily reports as json and slug date

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
    - `DATABASE_URL` – PostgreSQL connection string
 3. Apply database migrations
    ```sh
-   pnpm drizzle-kit push
+   pnpm drizzle-kit migrate
    ```
 4. Start the dev server on port 3001
    ```sh

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -207,3 +207,7 @@
 - 2025-10-27: Stored AI-generated daily reports in the database and surfaced summary, positives, negatives, and score on the daily overview page.
 - 2025-10-27: Fixed daily report upsert by issuing a direct SQL insert/update so reports save and display correctly.
 - 2025-10-27: Resolved daily report insert errors by upserting via Drizzle with date casting and JSON string content.
+- 2025-10-27: Converted daily report content to JSONB, saved raw LLM output, and used ddmmyyyy slugs for report detail routes.
+- 2025-10-27: Coerced legacy daily report text into JSONB and documented `drizzle-kit migrate` in the README.
+- 2025-10-27: Added migration journal so `pnpm drizzle-kit migrate` can run without errors.
+- 2025-10-27: Made people migration idempotent to avoid enum duplication errors when rerunning migrations.

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -29,13 +29,13 @@ export async function POST(req: NextRequest) {
   const reviews = body.reviews || {};
   const ethos = body.ethos || body.rational || '';
 
-  const { date: dateObj, tz } = resolvePlanDate(
-    'live',
-    session?.user as any,
-    { cookies: req.cookies, searchParams: Object.fromEntries(req.nextUrl.searchParams) },
-  );
+  const { date: dateObj, tz } = resolvePlanDate('live', session?.user as any, {
+    cookies: req.cookies,
+    searchParams: Object.fromEntries(req.nextUrl.searchParams),
+  });
   const today = toYMD(dateObj, tz);
-  const targetDate = typeof body.date === 'string' && body.date ? body.date : today;
+  const targetDate =
+    typeof body.date === 'string' && body.date ? body.date : today;
 
   const plan = body.plan
     ? {
@@ -60,7 +60,9 @@ export async function POST(req: NextRequest) {
   );
 
   const activities = [] as any[];
-  const sorted = [...plan.blocks].sort((a, b) => a.start.localeCompare(b.start));
+  const sorted = [...plan.blocks].sort((a, b) =>
+    a.start.localeCompare(b.start),
+  );
   for (const blk of sorted) {
     const ings = await Promise.all(
       blk.ingredientIds.map((id: number) => loadIngredient(id)),
@@ -152,8 +154,12 @@ export async function POST(req: NextRequest) {
     "in this part the review of the user are provided: start by the review of the daily aim, and the review of the ingredients (if filled in, if not filled in it will say everywhere, user didn't leave feedback)",
   );
   lines.push('review of the daily aim:');
-  lines.push(`- what went good: ${dailyAimReview.good || 'user did not leave feedback'}`);
-  lines.push(`- what went bad: ${dailyAimReview.bad || 'user did not leave feedback'}`);
+  lines.push(
+    `- what went good: ${dailyAimReview.good || 'user did not leave feedback'}`,
+  );
+  lines.push(
+    `- what went bad: ${dailyAimReview.bad || 'user did not leave feedback'}`,
+  );
   lines.push('- ingredient feedback:');
   const aimIngReviews = dailyAimReview.ingredients || {};
   if (Object.keys(aimIngReviews).length === 0) {
@@ -239,7 +245,7 @@ export async function POST(req: NextRequest) {
       parsed = { summary: msg, good: [], bad: [], observations: [], score: 0 };
     }
     const score = Number(parsed.score) || 0;
-    await createDailyReport(userId, targetDate, JSON.stringify(parsed), score);
+    await createDailyReport(userId, targetDate, parsed, score);
     return NextResponse.json({ report: parsed, score, context });
   } catch (e: any) {
     return NextResponse.json(

--- a/app/progress/overview/daily/[date]/page.tsx
+++ b/app/progress/overview/daily/[date]/page.tsx
@@ -13,15 +13,10 @@ export default async function DailyReportDetail({
   const me = await ensureUser(session);
   const report = await getDailyReport(me.id, params.date);
   if (!report) notFound();
-  let parsed: any = {};
-  try {
-    parsed = JSON.parse(report.content);
-  } catch {
-    parsed.summary = report.content;
-  }
+  const parsed = report.content;
   return (
     <main className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">Report for {params.date}</h1>
+      <h1 className="mb-4 text-2xl font-bold">Report for {report.date}</h1>
       <p className="mb-4 font-semibold">Score: {report.score}</p>
       <pre className="whitespace-pre-wrap">{parsed.summary ?? ''}</pre>
       {parsed.good && (

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -43,7 +43,7 @@ export default async function DailyReportsPage() {
               </div>
             )}
             <Link
-              href={`/progress/overview/daily/${r.date}`}
+              href={`/progress/overview/daily/${r.slug}`}
               className="mt-2 block text-sm text-orange-600 hover:underline"
             >
               View details

--- a/drizzle/0003_people.sql
+++ b/drizzle/0003_people.sql
@@ -1,17 +1,26 @@
 -- Account visibility enum
-CREATE TYPE "account_visibility" AS ENUM ('open','closed','private');
+DO $$ BEGIN
+  CREATE TYPE "account_visibility" AS ENUM ('open','closed','private');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
-ALTER TABLE "users" ADD COLUMN "handle" varchar(50) NOT NULL;
-ALTER TABLE "users" ADD COLUMN "display_name" text;
-ALTER TABLE "users" ADD COLUMN "avatar_url" text;
-ALTER TABLE "users" ADD COLUMN "account_visibility" "account_visibility" NOT NULL DEFAULT 'open';
-ALTER TABLE "users" ADD COLUMN "updated_at" timestamp DEFAULT now();
-ALTER TABLE "users" ADD CONSTRAINT "users_handle_unique" UNIQUE("handle");
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "handle" varchar(50) NOT NULL;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "display_name" text;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "avatar_url" text;
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "account_visibility" "account_visibility" NOT NULL DEFAULT 'open';
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "updated_at" timestamp DEFAULT now();
+DO $$ BEGIN
+  ALTER TABLE "users" ADD CONSTRAINT "users_handle_unique" UNIQUE("handle");
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
 -- Follow status enum
-CREATE TYPE "follow_status" AS ENUM ('pending','accepted');
+DO $$ BEGIN
+  CREATE TYPE "follow_status" AS ENUM ('pending','accepted');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
-CREATE TABLE "follows" (
+CREATE TABLE IF NOT EXISTS "follows" (
   "id" serial PRIMARY KEY,
   "follower_id" integer NOT NULL REFERENCES "users"("id"),
   "following_id" integer NOT NULL REFERENCES "users"("id"),
@@ -22,9 +31,12 @@ CREATE TABLE "follows" (
 );
 
 -- Notification type enum
-CREATE TYPE "notification_type" AS ENUM ('follow_request','follow_accepted');
+DO $$ BEGIN
+  CREATE TYPE "notification_type" AS ENUM ('follow_request','follow_accepted');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
-CREATE TABLE "notifications" (
+CREATE TABLE IF NOT EXISTS "notifications" (
   "id" serial PRIMARY KEY,
   "to_user_id" integer NOT NULL REFERENCES "users"("id"),
   "from_user_id" integer NOT NULL REFERENCES "users"("id"),

--- a/drizzle/0019_alter_daily_reports_content_jsonb.sql
+++ b/drizzle/0019_alter_daily_reports_content_jsonb.sql
@@ -1,0 +1,6 @@
+ALTER TABLE daily_reports
+  ALTER COLUMN content TYPE jsonb
+  USING CASE
+    WHEN content IS NULL OR content = '' THEN '{}'::jsonb
+    ELSE jsonb_build_object('raw', content)
+  END;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,146 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1756278255832,
+      "tag": "0000_init",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1756278255833,
+      "tag": "0001_add_slug_column",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1756278255834,
+      "tag": "0002_create_subflavors",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1756278255835,
+      "tag": "0003_people",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1756278255836,
+      "tag": "0004_add_unfollow_notification",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1756278255837,
+      "tag": "0005_add_follow_declined_notification",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1756278255838,
+      "tag": "0006_add_view_id",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1756278255839,
+      "tag": "0007_add_plans",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1756278255840,
+      "tag": "0008_create_ingredients",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1756278255841,
+      "tag": "0009_expand_icon_columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1756278255842,
+      "tag": "0010_create_user_icons",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1756278255843,
+      "tag": "0011_add_ingredient_icon",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1756278255844,
+      "tag": "0012_drop_user_icons_unique_index",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1756278255845,
+      "tag": "0013_create_plan_revisions",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1756278255846,
+      "tag": "0014_add_plan_block_ingredients",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1756278255847,
+      "tag": "0015_add_plan_daily_aim",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1756278255848,
+      "tag": "0016_add_plan_block_color_preset",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1756278255849,
+      "tag": "0017_add_plan_block_flavors",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1756278255850,
+      "tag": "0018_create_daily_reports",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1756278255851,
+      "tag": "0019_alter_daily_reports_content_jsonb",
+      "breakpoints": true
+    }
+  ]
+}

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -1,7 +1,20 @@
 import { db } from './db';
 import { dailyReports } from './db/schema';
 import { eq, and, asc, sql } from 'drizzle-orm';
-import type { DailyReport } from '@/types/report';
+import type { DailyReport, ReportContent } from '@/types/report';
+
+function slugFromDate(ymd: string): string {
+  const [y, m, d] = ymd.split('-');
+  return `${d}${m}${y}`;
+}
+
+function dateFromSlug(slug: string): string {
+  if (slug.length !== 8) return slug;
+  const d = slug.slice(0, 2);
+  const m = slug.slice(2, 4);
+  const y = slug.slice(4);
+  return `${y}-${m}-${d}`;
+}
 
 export async function listDailyReportDates(userId: number): Promise<string[]> {
   const rows = await db
@@ -14,6 +27,7 @@ export async function listDailyReportDates(userId: number): Promise<string[]> {
 export async function listDailyReports(userId: number): Promise<
   Array<{
     date: string;
+    slug: string;
     score: number;
     summary: string;
     good: string[];
@@ -30,14 +44,11 @@ export async function listDailyReports(userId: number): Promise<
     .where(eq(dailyReports.userId, userId))
     .orderBy(asc(dailyReports.date));
   return rows.map((r) => {
-    let parsed: any = {};
-    try {
-      parsed = JSON.parse(r.content ?? '{}');
-    } catch {
-      parsed = {};
-    }
+    const ymd = r.date?.toString().slice(0, 10) ?? '';
+    const parsed = (r.content as ReportContent) || {};
     return {
-      date: r.date?.toString().slice(0, 10) ?? '',
+      date: ymd,
+      slug: slugFromDate(ymd),
       score: r.score ?? 0,
       summary: parsed.summary ?? '',
       good: parsed.good ?? [],
@@ -48,8 +59,9 @@ export async function listDailyReports(userId: number): Promise<
 
 export async function getDailyReport(
   userId: number,
-  date: string,
+  slug: string,
 ): Promise<DailyReport | null> {
+  const date = dateFromSlug(slug);
   const [row] = await db
     .select()
     .from(dailyReports)
@@ -58,8 +70,8 @@ export async function getDailyReport(
   return {
     id: row.id,
     userId: row.userId ?? 0,
-    date: row.date?.toString().slice(0, 10) ?? date,
-    content: row.content ?? '',
+    date,
+    content: (row.content as ReportContent) ?? ({} as ReportContent),
     score: row.score ?? 0,
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
   };
@@ -68,23 +80,21 @@ export async function getDailyReport(
 export async function createDailyReport(
   userId: number,
   date: string,
-  content: string | Record<string, unknown>,
+  content: Record<string, unknown>,
   score: number,
 ) {
-  const contentStr =
-    typeof content === 'string' ? content : JSON.stringify(content);
   await db
     .insert(dailyReports)
     .values({
       userId,
       date: sql`${date}::date`,
-      content: contentStr,
+      content,
       score,
     })
     .onConflictDoUpdate({
       target: [dailyReports.userId, dailyReports.date],
       set: {
-        content: contentStr,
+        content,
         score,
         createdAt: sql`now()`,
       },

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -239,7 +239,7 @@ export const dailyReports = pgTable(
       .references(() => users.id)
       .notNull(),
     date: date('date').notNull(),
-    content: text('content').notNull(),
+    content: jsonb('content').notNull(),
     score: integer('score').notNull(),
     createdAt: timestamp('created_at').defaultNow(),
   },

--- a/types/report.ts
+++ b/types/report.ts
@@ -1,8 +1,16 @@
+export interface ReportContent {
+  summary: string;
+  good: string[];
+  bad: string[];
+  observations: string[];
+  score: number;
+}
+
 export interface DailyReport {
   id: number;
   userId: number;
   date: string; // YYYY-MM-DD
-  content: string; // JSON string of report
+  content: ReportContent; // raw JSON of report
   score: number;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- store daily report content as JSONB and keep raw LLM output
- use ddmmyyyy slugs for daily report detail routes
- upsert daily reports with json objects instead of strings
- coerce legacy daily report text into JSON during migration and document `drizzle-kit migrate`
- include migration journal so `pnpm drizzle-kit migrate` applies migrations without errors
- make early people migration idempotent so rerunning migrations won't fail on existing enums

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early.)*

------
https://chatgpt.com/codex/tasks/task_e_68aea7dc56dc832a8744fb7be66c44ad