### PR TITLE
fix: make user handle constraint migration idempotent

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -211,3 +211,4 @@
 - 2025-10-27: Coerced legacy daily report text into JSONB and documented `drizzle-kit migrate` in the README.
 - 2025-10-27: Added migration journal so `pnpm drizzle-kit migrate` can run without errors.
 - 2025-10-27: Made people migration idempotent to avoid enum duplication errors when rerunning migrations.
+- 2025-10-27: Hardened handle unique constraint migration to reuse existing index and allow clean schema pushes.

--- a/drizzle/0003_people.sql
+++ b/drizzle/0003_people.sql
@@ -9,9 +9,22 @@ ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "display_name" text;
 ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "avatar_url" text;
 ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "account_visibility" "account_visibility" NOT NULL DEFAULT 'open';
 ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "updated_at" timestamp DEFAULT now();
-DO $$ BEGIN
-  ALTER TABLE "users" ADD CONSTRAINT "users_handle_unique" UNIQUE("handle");
-EXCEPTION WHEN duplicate_object THEN NULL;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_handle_unique'
+  ) THEN
+    IF EXISTS (
+      SELECT 1 FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname = 'users_handle_unique'
+    ) THEN
+      ALTER TABLE "users"
+        ADD CONSTRAINT "users_handle_unique" UNIQUE USING INDEX "users_handle_unique";
+    ELSE
+      ALTER TABLE "users" ADD CONSTRAINT "users_handle_unique" UNIQUE ("handle");
+    END IF;
+  END IF;
 END $$;
 
 -- Follow status enum


### PR DESCRIPTION
## Summary
- ensure people migration reuses existing handle index before adding unique constraint
- document migration fix in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/postgres' pnpm drizzle-kit migrate`
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/postgres' pnpm drizzle-kit push`


------
https://chatgpt.com/codex/tasks/task_e_68aeb455b9a8832a80351f81db96ede6