### PR TITLE
fix: repair view_id column with uuid migration

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -211,3 +211,6 @@
 - 2025-10-27: Coerced legacy daily report text into JSONB and documented `drizzle-kit migrate` in the README.
 - 2025-10-27: Added migration journal so `pnpm drizzle-kit migrate` can run without errors.
 - 2025-10-27: Made people migration idempotent to avoid enum duplication errors when rerunning migrations.
+- 2025-10-27: Hardened handle unique constraint migration to reuse existing index and allow clean schema pushes.
+- 2025-10-27: Guarded notification type enum migrations so reruns skip existing values and jsonb schema pushes succeed.
+- 2025-10-27: Repaired users.view_id column with idempotent migration and switched to uuid type.

--- a/drizzle/0003_people.sql
+++ b/drizzle/0003_people.sql
@@ -9,9 +9,22 @@ ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "display_name" text;
 ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "avatar_url" text;
 ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "account_visibility" "account_visibility" NOT NULL DEFAULT 'open';
 ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "updated_at" timestamp DEFAULT now();
-DO $$ BEGIN
-  ALTER TABLE "users" ADD CONSTRAINT "users_handle_unique" UNIQUE("handle");
-EXCEPTION WHEN duplicate_object THEN NULL;
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_handle_unique'
+  ) THEN
+    IF EXISTS (
+      SELECT 1 FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname = 'users_handle_unique'
+    ) THEN
+      ALTER TABLE "users"
+        ADD CONSTRAINT "users_handle_unique" UNIQUE USING INDEX "users_handle_unique";
+    ELSE
+      ALTER TABLE "users" ADD CONSTRAINT "users_handle_unique" UNIQUE ("handle");
+    END IF;
+  END IF;
 END $$;
 
 -- Follow status enum

--- a/drizzle/0004_add_unfollow_notification.sql
+++ b/drizzle/0004_add_unfollow_notification.sql
@@ -1,1 +1,12 @@
-ALTER TYPE "notification_type" ADD VALUE 'unfollow';
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_enum e
+    JOIN pg_type t ON e.enumtypid = t.oid
+    WHERE t.typname = 'notification_type'
+      AND e.enumlabel = 'unfollow'
+  ) THEN
+    ALTER TYPE "notification_type" ADD VALUE 'unfollow';
+  END IF;
+END $$;

--- a/drizzle/0005_add_follow_declined_notification.sql
+++ b/drizzle/0005_add_follow_declined_notification.sql
@@ -1,1 +1,12 @@
-ALTER TYPE "notification_type" ADD VALUE 'follow_declined';
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_enum e
+    JOIN pg_type t ON e.enumtypid = t.oid
+    WHERE t.typname = 'notification_type'
+      AND e.enumlabel = 'follow_declined'
+  ) THEN
+    ALTER TYPE "notification_type" ADD VALUE 'follow_declined';
+  END IF;
+END $$;

--- a/drizzle/0020_repair_users_view_id.sql
+++ b/drizzle/0020_repair_users_view_id.sql
@@ -1,0 +1,48 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Add column if missing and ensure uuid type
+ALTER TABLE users ADD COLUMN IF NOT EXISTS view_id uuid;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'users'
+      AND column_name = 'view_id'
+      AND data_type <> 'uuid'
+  ) THEN
+    ALTER TABLE users ALTER COLUMN view_id TYPE uuid USING view_id::uuid;
+  END IF;
+END $$;
+
+-- Backfill nulls
+UPDATE users
+SET view_id = gen_random_uuid()
+WHERE view_id IS NULL;
+
+-- Enforce NOT NULL if nullable
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'users'
+      AND column_name = 'view_id'
+      AND is_nullable = 'YES'
+  ) THEN
+    ALTER TABLE users ALTER COLUMN view_id SET NOT NULL;
+  END IF;
+END $$;
+
+-- Add UNIQUE constraint if missing
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'users_view_id_unique'
+      AND conrelid = 'users'::regclass
+  ) THEN
+    ALTER TABLE users ADD CONSTRAINT users_view_id_unique UNIQUE (view_id);
+  END IF;
+END $$;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1756278255851,
       "tag": "0019_alter_daily_reports_content_jsonb",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1756281136991,
+      "tag": "0020_repair_users_view_id",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,7 +9,9 @@ import {
   pgEnum,
   uniqueIndex,
   jsonb,
+  uuid,
 } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
 
 export const accountVisibilityEnum = pgEnum('account_visibility', [
   'open',
@@ -34,7 +36,10 @@ export const users = pgTable('users', {
   handle: varchar('handle', { length: 50 }).notNull().unique(),
   displayName: text('display_name'),
   avatarUrl: text('avatar_url'),
-  viewId: text('view_id').notNull().unique(),
+  viewId: uuid('view_id')
+    .default(sql`gen_random_uuid()`)
+    .notNull()
+    .unique(),
   accountVisibility: accountVisibilityEnum('account_visibility')
     .notNull()
     .default('open'),


### PR DESCRIPTION
## Summary
- add idempotent repair migration converting `users.view_id` to a UUID column with backfill and constraint guards
- define `viewId` field as `uuid` with `gen_random_uuid()` default in Drizzle schema
- document view_id repair in update log and migration journal

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/postgres' pnpm drizzle-kit migrate` *(fails: ECONNREFUSED)*
- `DATABASE_URL='postgresql://postgres:postgres@localhost:5432/postgres' pnpm drizzle-kit push` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68aeb455b9a8832a80351f81db96ede6