### PR TITLE
fix: allow date-only overrides and stabilize report migration

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -214,3 +214,4 @@
 - 2025-10-27: Hardened handle unique constraint migration to reuse existing index and allow clean schema pushes.
 - 2025-10-27: Guarded notification type enum migrations so reruns skip existing values and jsonb schema pushes succeed.
 - 2025-10-27: Repaired users.view_id column with idempotent migration and switched to uuid type.
+- 2025-08-27: Allowed clock override with only date parameter and simplified daily report JSONB migration for push.

--- a/drizzle/0019_alter_daily_reports_content_jsonb.sql
+++ b/drizzle/0019_alter_daily_reports_content_jsonb.sql
@@ -2,5 +2,5 @@ ALTER TABLE daily_reports
   ALTER COLUMN content TYPE jsonb
   USING CASE
     WHEN content IS NULL OR content = '' THEN '{}'::jsonb
-    ELSE jsonb_build_object('raw', content)
+    ELSE content::jsonb
   END;

--- a/lib/clock.ts
+++ b/lib/clock.ts
@@ -54,9 +54,9 @@ export function getNow(
 
   const dateParam = first(req?.searchParams?.['apoc_date']);
   const timeParam = first(req?.searchParams?.['apoc_time']);
-  if (dateParam && timeParam) {
+  if (dateParam) {
     const [y, m, d] = dateParam.split('-').map(Number);
-    const [hh, mm] = timeParam.split(':').map(Number);
+    const [hh, mm] = timeParam ? timeParam.split(':').map(Number) : [0, 0];
     const dateUTC = Date.UTC(y, m - 1, d, hh, mm);
     const offset = getOffset(new Date(dateUTC), tz);
     result = new Date(dateUTC - offset);


### PR DESCRIPTION
## Summary
- Allow overriding the app clock with only an `apoc_date` parameter so daily reports save for the intended day
- Simplify daily report content migration using `content::jsonb` cast for easier `drizzle-kit push`

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68aebc6405c0832a83156061c4734b70