### PR TITLE
fix: stabilize daily report storage

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -214,3 +214,5 @@
 - 2025-10-27: Hardened handle unique constraint migration to reuse existing index and allow clean schema pushes.
 - 2025-10-27: Guarded notification type enum migrations so reruns skip existing values and jsonb schema pushes succeed.
 - 2025-10-27: Repaired users.view_id column with idempotent migration and switched to uuid type.
+- 2025-10-27: Stabilized daily report storage using raw SQL upsert and added JSONB migration for schema push compatibility.
+- 2025-10-27: Switched daily report content column to JSON for easier schema pushes.

--- a/drizzle/0019_alter_daily_reports_content_json.sql
+++ b/drizzle/0019_alter_daily_reports_content_json.sql
@@ -1,0 +1,6 @@
+ALTER TABLE daily_reports
+  ALTER COLUMN content TYPE json
+  USING CASE
+    WHEN content IS NULL OR content = '' THEN '{}'::json
+    ELSE json_build_object('raw', content)
+  END;

--- a/drizzle/0019_alter_daily_reports_content_jsonb.sql
+++ b/drizzle/0019_alter_daily_reports_content_jsonb.sql
@@ -1,6 +1,0 @@
-ALTER TABLE daily_reports
-  ALTER COLUMN content TYPE jsonb
-  USING CASE
-    WHEN content IS NULL OR content = '' THEN '{}'::jsonb
-    ELSE jsonb_build_object('raw', content)
-  END;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -139,7 +139,7 @@
       "idx": 19,
       "version": "7",
       "when": 1756278255851,
-      "tag": "0019_alter_daily_reports_content_jsonb",
+      "tag": "0019_alter_daily_reports_content_json",
       "breakpoints": true
     },
     {

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -83,20 +83,16 @@ export async function createDailyReport(
   content: Record<string, unknown>,
   score: number,
 ) {
-  await db
-    .insert(dailyReports)
-    .values({
-      userId,
-      date: sql`${date}::date`,
-      content,
-      score,
-    })
-    .onConflictDoUpdate({
-      target: [dailyReports.userId, dailyReports.date],
-      set: {
-        content,
-        score,
-        createdAt: sql`now()`,
-      },
-    });
+  // Use a raw SQL upsert to guarantee the report is stored for the
+  // caller-provided date. This avoids issues with parameter ordering when
+  // the server and client have differing conceptions of "today" due to
+  // overridden site time.
+  await db.execute(sql`
+    insert into daily_reports (user_id, date, content, score)
+    values (${userId}, ${date}::date, ${JSON.stringify(content)}::json, ${score})
+    on conflict (user_id, date) do update
+      set content = excluded.content,
+          score = excluded.score,
+          created_at = now();
+  `);
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -8,6 +8,7 @@ import {
   integer,
   pgEnum,
   uniqueIndex,
+  json,
   jsonb,
   uuid,
 } from 'drizzle-orm/pg-core';
@@ -244,7 +245,7 @@ export const dailyReports = pgTable(
       .references(() => users.id)
       .notNull(),
     date: date('date').notNull(),
-    content: jsonb('content').notNull(),
+    content: json('content').notNull(),
     score: integer('score').notNull(),
     createdAt: timestamp('created_at').defaultNow(),
   },


### PR DESCRIPTION
## Summary
- switch daily report content column from JSONB to JSON so schema pushes don't require casts
- drop JSONB migrations and update upsert to store JSON data
- document daily report storage change in project log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*
- `pnpm drizzle-kit push` *(fails: Either connection "url" or "host", "database" are required for PostgreSQL database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68aebc6405c0832a83156061c4734b70