### PR TITLE
fix: store daily report content and user view_id as text

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -217,3 +217,5 @@
 - 2025-10-27: Stabilized daily report storage using raw SQL upsert and added JSONB migration for schema push compatibility.
 - 2025-10-27: Switched daily report content column to JSON for easier schema pushes.
 - 2025-10-27: Explicitly cast daily report content column to JSON for schema push compatibility.
+- 2025-10-27: Reverted daily report content column to text and added safe JSON parsing to avoid push casting errors.
+- 2025-10-27: Reverted users.view_id column to text to avoid UUID cast errors during schema pushes.

--- a/drizzle/0022_revert_daily_reports_content_text.sql
+++ b/drizzle/0022_revert_daily_reports_content_text.sql
@@ -1,0 +1,2 @@
+ALTER TABLE daily_reports
+  ALTER COLUMN content TYPE text USING content::text;

--- a/drizzle/0023_revert_users_view_id_text.sql
+++ b/drizzle/0023_revert_users_view_id_text.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+  ALTER COLUMN view_id TYPE text USING view_id::text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -156,5 +156,20 @@
       "tag": "0021_force_daily_reports_content_json",
       "breakpoints": true
     }
+    ,
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1756284819555,
+      "tag": "0022_revert_daily_reports_content_text",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1756284819556,
+      "tag": "0023_revert_users_view_id_text",
+      "breakpoints": true
+    }
   ]
 }

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -24,6 +24,15 @@ export async function listDailyReportDates(userId: number): Promise<string[]> {
   return rows.map((r) => r.date?.toString().slice(0, 10) ?? '');
 }
 
+function parseReportContent(raw: unknown): ReportContent {
+  if (!raw) return {} as ReportContent;
+  try {
+    return JSON.parse(String(raw)) as ReportContent;
+  } catch {
+    return {} as ReportContent;
+  }
+}
+
 export async function listDailyReports(userId: number): Promise<
   Array<{
     date: string;
@@ -45,7 +54,7 @@ export async function listDailyReports(userId: number): Promise<
     .orderBy(asc(dailyReports.date));
   return rows.map((r) => {
     const ymd = r.date?.toString().slice(0, 10) ?? '';
-    const parsed = (r.content as ReportContent) || {};
+    const parsed = parseReportContent(r.content);
     return {
       date: ymd,
       slug: slugFromDate(ymd),
@@ -71,7 +80,7 @@ export async function getDailyReport(
     id: row.id,
     userId: row.userId ?? 0,
     date,
-    content: (row.content as ReportContent) ?? ({} as ReportContent),
+    content: parseReportContent(row.content),
     score: row.score ?? 0,
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
   };
@@ -89,7 +98,7 @@ export async function createDailyReport(
   // overridden site time.
   await db.execute(sql`
     insert into daily_reports (user_id, date, content, score)
-    values (${userId}, ${date}::date, ${JSON.stringify(content)}::json, ${score})
+    values (${userId}, ${date}::date, ${JSON.stringify(content)}, ${score})
     on conflict (user_id, date) do update
       set content = excluded.content,
           score = excluded.score,

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -10,7 +10,6 @@ import {
   uniqueIndex,
   json,
   jsonb,
-  uuid,
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 
@@ -37,8 +36,9 @@ export const users = pgTable('users', {
   handle: varchar('handle', { length: 50 }).notNull().unique(),
   displayName: text('display_name'),
   avatarUrl: text('avatar_url'),
-  viewId: uuid('view_id')
-    .default(sql`gen_random_uuid()`)
+  // Store view IDs as text to avoid casting issues; values remain UUID strings
+  viewId: text('view_id')
+    .default(sql`gen_random_uuid()::text`)
     .notNull()
     .unique(),
   accountVisibility: accountVisibilityEnum('account_visibility')
@@ -245,7 +245,9 @@ export const dailyReports = pgTable(
       .references(() => users.id)
       .notNull(),
     date: date('date').notNull(),
-    content: json('content').notNull(),
+    // Store report content as plain text to avoid JSON casting issues during
+    // schema pushes. Consumers should parse the JSON string manually.
+    content: text('content').notNull(),
     score: integer('score').notNull(),
     createdAt: timestamp('created_at').defaultNow(),
   },


### PR DESCRIPTION
## Summary
- revert users.view_id column to plain text to avoid UUID cast errors during pushes
- document viewId change and track new migration in journal

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68aecb478360832a8fea3ae6bf543ac3