### PR TITLE
fix: persist daily reports via drizzle

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -219,3 +219,4 @@
 - 2025-10-27: Explicitly cast daily report content column to JSON for schema push compatibility.
 - 2025-10-27: Reverted daily report content column to text and added safe JSON parsing to avoid push casting errors.
 - 2025-10-27: Reverted users.view_id column to text to avoid UUID cast errors during schema pushes.
+- 2025-10-27: Replaced raw SQL upsert with Drizzle builder for daily reports and showed observations on daily overview page.

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -42,6 +42,16 @@ export default async function DailyReportsPage() {
                 </ul>
               </div>
             )}
+            {r.observations.length > 0 && (
+              <div className="mt-2">
+                <h3 className="font-semibold">Observations</h3>
+                <ul className="list-disc pl-4">
+                  {r.observations.map((o, i) => (
+                    <li key={i}>{o}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
             <Link
               href={`/progress/overview/daily/${r.slug}`}
               className="mt-2 block text-sm text-orange-600 hover:underline"

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -41,6 +41,7 @@ export async function listDailyReports(userId: number): Promise<
     summary: string;
     good: string[];
     bad: string[];
+    observations: string[];
   }>
 > {
   const rows = await db
@@ -62,6 +63,7 @@ export async function listDailyReports(userId: number): Promise<
       summary: parsed.summary ?? '',
       good: parsed.good ?? [],
       bad: parsed.bad ?? [],
+      observations: parsed.observations ?? [],
     };
   });
 }
@@ -92,16 +94,19 @@ export async function createDailyReport(
   content: Record<string, unknown>,
   score: number,
 ) {
-  // Use a raw SQL upsert to guarantee the report is stored for the
-  // caller-provided date. This avoids issues with parameter ordering when
-  // the server and client have differing conceptions of "today" due to
-  // overridden site time.
-  await db.execute(sql`
-    insert into daily_reports (user_id, date, content, score)
-    values (${userId}, ${date}::date, ${JSON.stringify(content)}, ${score})
-    on conflict (user_id, date) do update
-      set content = excluded.content,
-          score = excluded.score,
-          created_at = now();
-  `);
+  // Use Drizzle's query builder to perform an UPSERT. This avoids raw SQL
+  // issues and ensures parameters are bound correctly regardless of the
+  // environment's timezone or Postgres settings.
+  const serialized = JSON.stringify(content);
+  await db
+    .insert(dailyReports)
+    .values({ userId, date, content: serialized, score })
+    .onConflictDoUpdate({
+      target: [dailyReports.userId, dailyReports.date],
+      set: {
+        content: serialized,
+        score,
+        createdAt: sql`now()`,
+      },
+    });
 }


### PR DESCRIPTION
## Summary
- upsert daily reports via Drizzle query builder to avoid insertion errors
- display observations alongside summary, good and bad items on daily overview

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68aed1985b04832a97dd6face715ba1f