### PR TITLE
fix: persist daily report content and show observations

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -219,3 +219,4 @@
 - 2025-10-27: Explicitly cast daily report content column to JSON for schema push compatibility.
 - 2025-10-27: Reverted daily report content column to text and added safe JSON parsing to avoid push casting errors.
 - 2025-10-27: Reverted users.view_id column to text to avoid UUID cast errors during schema pushes.
+- 2025-10-27: Cast daily report content to text to fix insert failure and display observations on daily overview.

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -42,6 +42,16 @@ export default async function DailyReportsPage() {
                 </ul>
               </div>
             )}
+            {r.observations.length > 0 && (
+              <div className="mt-2">
+                <h3 className="font-semibold">Observations</h3>
+                <ul className="list-disc pl-4">
+                  {r.observations.map((o, i) => (
+                    <li key={i}>{o}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
             <Link
               href={`/progress/overview/daily/${r.slug}`}
               className="mt-2 block text-sm text-orange-600 hover:underline"

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -41,6 +41,7 @@ export async function listDailyReports(userId: number): Promise<
     summary: string;
     good: string[];
     bad: string[];
+    observations: string[];
   }>
 > {
   const rows = await db
@@ -62,6 +63,7 @@ export async function listDailyReports(userId: number): Promise<
       summary: parsed.summary ?? '',
       good: parsed.good ?? [],
       bad: parsed.bad ?? [],
+      observations: parsed.observations ?? [],
     };
   });
 }
@@ -98,7 +100,7 @@ export async function createDailyReport(
   // overridden site time.
   await db.execute(sql`
     insert into daily_reports (user_id, date, content, score)
-    values (${userId}, ${date}::date, ${JSON.stringify(content)}, ${score})
+    values (${userId}, ${date}::date, ${JSON.stringify(content)}::text, ${score})
     on conflict (user_id, date) do update
       set content = excluded.content,
           score = excluded.score,


### PR DESCRIPTION
## Summary
- cast daily report content to text during upsert to avoid insert failure
- surface observation lines from saved reports on the daily overview page

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68aed1985b04832a97dd6face715ba1f