### PR TITLE
feat: allow versioned daily reports

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -219,3 +219,6 @@
 - 2025-10-27: Explicitly cast daily report content column to JSON for schema push compatibility.
 - 2025-10-27: Reverted daily report content column to text and added safe JSON parsing to avoid push casting errors.
 - 2025-10-27: Reverted users.view_id column to text to avoid UUID cast errors during schema pushes.
+- 2025-10-27: Cast daily report content to text to fix insert failure and display observations on daily overview.
+- 2025-10-27: Stringified daily report content before upsert to resolve insert errors.
+- 2025-10-27: Added versioned daily reports so multiple saves per date keep unique IDs and display in the overview.

--- a/app/progress/overview/daily/[date]/page.tsx
+++ b/app/progress/overview/daily/[date]/page.tsx
@@ -16,7 +16,10 @@ export default async function DailyReportDetail({
   const parsed = report.content;
   return (
     <main className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">Report for {report.date}</h1>
+      <h1 className="mb-4 text-2xl font-bold">
+        Report for {report.date}
+        {report.version > 1 && <span className="ml-1">(v{report.version})</span>}
+      </h1>
       <p className="mb-4 font-semibold">Score: {report.score}</p>
       <pre className="whitespace-pre-wrap">{parsed.summary ?? ''}</pre>
       {parsed.good && (

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -14,9 +14,12 @@ export default async function DailyReportsPage() {
       <h1 className="mb-4 text-2xl font-bold">Daily Reports</h1>
       <ul className="space-y-4">
         {reports.map((r) => (
-          <li key={r.date} className="rounded border p-4">
+          <li key={r.slug} className="rounded border p-4">
             <div className="flex items-center justify-between">
-              <h2 className="font-semibold">{r.date}</h2>
+              <h2 className="font-semibold">
+                {r.date}
+                {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
+              </h2>
               <span className="font-semibold">{r.score}</span>
             </div>
             {r.summary && (
@@ -38,6 +41,16 @@ export default async function DailyReportsPage() {
                 <ul className="list-disc pl-4">
                   {r.bad.map((b, i) => (
                     <li key={i}>{b}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {r.observations.length > 0 && (
+              <div className="mt-2">
+                <h3 className="font-semibold">Observations</h3>
+                <ul className="list-disc pl-4">
+                  {r.observations.map((o, i) => (
+                    <li key={i}>{o}</li>
                   ))}
                 </ul>
               </div>

--- a/components/cake/cake-home.tsx
+++ b/components/cake/cake-home.tsx
@@ -3,25 +3,16 @@ import { CakeNavigation } from './cake-navigation';
 import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
 import { listDailyReportDates } from '@/lib/daily-report-store';
 import { GenerateDailyReportButton } from '@/components/progress/generate-daily-report-button';
-import { resolvePlanDate, toYMD } from '@/lib/plan-date';
-import { cookies } from 'next/headers';
 
 export async function CakeHome({ ownerId }: { ownerId: number }) {
   const snapshotDates = await listProfileSnapshotDates(ownerId);
   const reportDates = await listDailyReportDates(ownerId);
-  const cookieStore = await cookies();
-  const { date, tz } = resolvePlanDate('live', { timeZone: undefined }, {
-    cookies: cookieStore,
-    searchParams: {},
-  });
-  const today = toYMD(date, tz);
-  const hasReport = reportDates.includes(today);
   return (
     <section className="w-full">
       <h1 className="sr-only">Cake</h1>
       <SideCalendar snapshotDates={snapshotDates} reportDates={reportDates} />
       <CakeNavigation />
-      <GenerateDailyReportButton userId={ownerId} hasReport={hasReport} />
+      <GenerateDailyReportButton userId={ownerId} />
     </section>
   );
 }

--- a/components/progress/generate-daily-report-button.tsx
+++ b/components/progress/generate-daily-report-button.tsx
@@ -7,10 +7,8 @@ import { useRouter } from 'next/navigation';
 
 export function GenerateDailyReportButton({
   userId,
-  hasReport = false,
 }: {
   userId: number;
-  hasReport?: boolean;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -76,15 +74,10 @@ export function GenerateDailyReportButton({
     return <p className="mt-4 text-sm">{message}</p>;
   }
 
-  if (hasReport) {
-    return <p className="mt-4 text-sm">Daily report already created.</p>;
-  }
-
   return (
     <Button
       onClick={onClick}
       disabled={loading}
-      title="You can only generate once per day"
       className="mt-4 flex items-center gap-2"
     >
       {loading && (

--- a/drizzle/0024_add_daily_report_version.sql
+++ b/drizzle/0024_add_daily_report_version.sql
@@ -1,0 +1,6 @@
+ALTER TABLE daily_reports
+  ADD COLUMN version integer NOT NULL DEFAULT 1;
+
+DROP INDEX IF EXISTS daily_reports_user_date_unique;
+CREATE UNIQUE INDEX daily_reports_user_date_version_unique
+  ON daily_reports (user_id, date, version);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -170,6 +170,13 @@
       "when": 1756284819556,
       "tag": "0023_revert_users_view_id_text",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1756284819557,
+      "tag": "0024_add_daily_report_version",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -3,17 +3,17 @@ import { dailyReports } from './db/schema';
 import { eq, and, asc, sql } from 'drizzle-orm';
 import type { DailyReport, ReportContent } from '@/types/report';
 
-function slugFromDate(ymd: string): string {
+function slugFromDate(ymd: string, version = 1): string {
   const [y, m, d] = ymd.split('-');
-  return `${d}${m}${y}`;
+  const base = `${d}${m}${y}`;
+  return version > 1 ? `${base}V${version}` : base;
 }
 
-function dateFromSlug(slug: string): string {
-  if (slug.length !== 8) return slug;
-  const d = slug.slice(0, 2);
-  const m = slug.slice(2, 4);
-  const y = slug.slice(4);
-  return `${y}-${m}-${d}`;
+function parseSlug(slug: string): { date: string; version: number } {
+  const match = /^([0-9]{2})([0-9]{2})([0-9]{4})(?:V(\d+))?$/.exec(slug);
+  if (!match) return { date: slug, version: 1 };
+  const [, d, m, y, v] = match;
+  return { date: `${y}-${m}-${d}`, version: v ? Number(v) : 1 };
 }
 
 export async function listDailyReportDates(userId: number): Promise<string[]> {
@@ -21,7 +21,9 @@ export async function listDailyReportDates(userId: number): Promise<string[]> {
     .select({ date: dailyReports.date })
     .from(dailyReports)
     .where(eq(dailyReports.userId, userId));
-  return rows.map((r) => r.date?.toString().slice(0, 10) ?? '');
+  const set = new Set<string>();
+  for (const r of rows) set.add(r.date?.toString().slice(0, 10) ?? '');
+  return Array.from(set);
 }
 
 function parseReportContent(raw: unknown): ReportContent {
@@ -37,10 +39,12 @@ export async function listDailyReports(userId: number): Promise<
   Array<{
     date: string;
     slug: string;
+    version: number;
     score: number;
     summary: string;
     good: string[];
     bad: string[];
+    observations: string[];
   }>
 > {
   const rows = await db
@@ -48,20 +52,24 @@ export async function listDailyReports(userId: number): Promise<
       date: dailyReports.date,
       score: dailyReports.score,
       content: dailyReports.content,
+      version: dailyReports.version,
     })
     .from(dailyReports)
     .where(eq(dailyReports.userId, userId))
-    .orderBy(asc(dailyReports.date));
+    .orderBy(asc(dailyReports.date), asc(dailyReports.version));
   return rows.map((r) => {
     const ymd = r.date?.toString().slice(0, 10) ?? '';
     const parsed = parseReportContent(r.content);
+    const version = r.version ?? 1;
     return {
       date: ymd,
-      slug: slugFromDate(ymd),
+      slug: slugFromDate(ymd, version),
+      version,
       score: r.score ?? 0,
       summary: parsed.summary ?? '',
       good: parsed.good ?? [],
       bad: parsed.bad ?? [],
+      observations: parsed.observations ?? [],
     };
   });
 }
@@ -70,16 +78,23 @@ export async function getDailyReport(
   userId: number,
   slug: string,
 ): Promise<DailyReport | null> {
-  const date = dateFromSlug(slug);
+  const { date, version } = parseSlug(slug);
   const [row] = await db
     .select()
     .from(dailyReports)
-    .where(and(eq(dailyReports.userId, userId), eq(dailyReports.date, date)));
+    .where(
+      and(
+        eq(dailyReports.userId, userId),
+        eq(dailyReports.date, date),
+        eq(dailyReports.version, version),
+      ),
+    );
   if (!row) return null;
   return {
     id: row.id,
     userId: row.userId ?? 0,
     date,
+    version: row.version ?? 1,
     content: parseReportContent(row.content),
     score: row.score ?? 0,
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
@@ -92,16 +107,17 @@ export async function createDailyReport(
   content: Record<string, unknown>,
   score: number,
 ) {
-  // Use a raw SQL upsert to guarantee the report is stored for the
-  // caller-provided date. This avoids issues with parameter ordering when
-  // the server and client have differing conceptions of "today" due to
-  // overridden site time.
-  await db.execute(sql`
-    insert into daily_reports (user_id, date, content, score)
-    values (${userId}, ${date}::date, ${JSON.stringify(content)}, ${score})
-    on conflict (user_id, date) do update
-      set content = excluded.content,
-          score = excluded.score,
-          created_at = now();
-  `);
+  const raw = JSON.stringify(content);
+  const [{ maxVersion }] = await db
+    .select({ maxVersion: sql<number>`coalesce(max(${dailyReports.version}),0)` })
+    .from(dailyReports)
+    .where(and(eq(dailyReports.userId, userId), eq(dailyReports.date, date)));
+  const nextVersion = (maxVersion ?? 0) + 1;
+  await db.insert(dailyReports).values({
+    userId,
+    date,
+    content: raw,
+    score,
+    version: nextVersion,
+  });
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -249,12 +249,12 @@ export const dailyReports = pgTable(
     // schema pushes. Consumers should parse the JSON string manually.
     content: text('content').notNull(),
     score: integer('score').notNull(),
+    version: integer('version').notNull().default(1),
     createdAt: timestamp('created_at').defaultNow(),
   },
   (table) => ({
-    uniqueUserDate: uniqueIndex('daily_reports_user_date_unique').on(
-      table.userId,
-      table.date,
-    ),
+    uniqueUserDateVersion: uniqueIndex(
+      'daily_reports_user_date_version_unique',
+    ).on(table.userId, table.date, table.version),
   }),
 );

--- a/types/report.ts
+++ b/types/report.ts
@@ -10,6 +10,7 @@ export interface DailyReport {
   id: number;
   userId: number;
   date: string; // YYYY-MM-DD
+  version: number;
   content: ReportContent; // raw JSON of report
   score: number;
   createdAt: string;


### PR DESCRIPTION
## Summary
- allow multiple daily report entries per date by versioning schema and slug IDs
- update overview, detail, and generator to surface version numbers and permit repeated generations

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68aed1985b04832a97dd6face715ba1f