### PR TITLE
feat: store and display daily report versions

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -192,3 +192,14 @@ Modal form IDs:
 - `hist-cake-{ownerId}-{date}` → historical cake page.
 - `hist-flav-{ownerId}-{date}` → historical flavors page.
 - `hist-subflav-{ownerId}-{flavorId}-{date}` → historical subflavors page.
+
+## Daily Reports
+
+- `d41lyr3p-{slug}-{ownerId}` → daily report entry in overview list.
+- `d41lyr3p-title-{slug}-{ownerId}` → daily report title.
+- `d41lyr3p-sum-{slug}-{ownerId}` → report summary text.
+- `d41lyr3p-good-{slug}-{ownerId}` → container for good items.
+- `d41lyr3p-good{index}-{slug}-{ownerId}` → individual good item.
+- `d41lyr3p-bad-{slug}-{ownerId}` → container for bad items.
+- `d41lyr3p-bad{index}-{slug}-{ownerId}` → individual bad item.
+- `d41lyr3p-score-{slug}-{ownerId}` → score/grade element.

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
-import { createDailyReport } from '@/lib/daily-report-store';
+import {
+  createDailyReport,
+  getNextDailyReportVersion,
+  slugFromDate,
+} from '@/lib/daily-report-store';
 import { getPlanStrict } from '@/lib/plans-store';
 import { getIngredient } from '@/lib/ingredients-store';
 import { getFlavor } from '@/lib/flavors-store';
@@ -245,8 +249,34 @@ export async function POST(req: NextRequest) {
       parsed = { summary: msg, good: [], bad: [], observations: [], score: 0 };
     }
     const score = Number(parsed.score) || 0;
-    await createDailyReport(userId, targetDate, parsed, score);
-    return NextResponse.json({ report: parsed, score, context });
+    const safe = {
+      summary: String(parsed.summary || ''),
+      good: Array.isArray(parsed.good) ? parsed.good.map(String) : [],
+      bad: Array.isArray(parsed.bad) ? parsed.bad.map(String) : [],
+      observations: Array.isArray(parsed.observations)
+        ? parsed.observations.map(String)
+        : [],
+    };
+    const version = await getNextDailyReportVersion(userId, targetDate);
+    const slug = slugFromDate(targetDate, version);
+    const content = {
+      summary: { id: `d41lyr3p-sum-${slug}-${userId}`, text: safe.summary },
+      good: safe.good.map((g: string, i: number) => ({
+        id: `d41lyr3p-good${i}-${slug}-${userId}`,
+        text: g,
+      })),
+      bad: safe.bad.map((b: string, i: number) => ({
+        id: `d41lyr3p-bad${i}-${slug}-${userId}`,
+        text: b,
+      })),
+      observations: safe.observations.map((o: string, i: number) => ({
+        id: `d41lyr3p-obs${i}-${slug}-${userId}`,
+        text: o,
+      })),
+      score: { id: `d41lyr3p-score-${slug}-${userId}`, value: score },
+    };
+    await createDailyReport(userId, targetDate, content, score, version);
+    return NextResponse.json({ report: content, score, context });
   } catch (e: any) {
     return NextResponse.json(
       { error: e.message || 'LLM request failed', context },

--- a/app/progress/overview/daily/[date]/page.tsx
+++ b/app/progress/overview/daily/[date]/page.tsx
@@ -14,40 +14,62 @@ export default async function DailyReportDetail({
   const report = await getDailyReport(me.id, params.date);
   if (!report) notFound();
   const parsed = report.content;
+  const slug = params.date;
   return (
     <main className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">
+      <h1
+        className="mb-4 text-2xl font-bold"
+        id={`d41lyr3p-title-${slug}-${me.id}`}
+      >
         Report for {report.date}
-        {report.version > 1 && <span className="ml-1">(v{report.version})</span>}
+        {report.version > 1 && (
+          <span className="ml-1">(v{report.version})</span>
+        )}
       </h1>
-      <p className="mb-4 font-semibold">Score: {report.score}</p>
-      <pre className="whitespace-pre-wrap">{parsed.summary ?? ''}</pre>
-      {parsed.good && (
-        <div className="mt-4">
+      <p
+        className="mb-4 font-semibold"
+        id={parsed.score.id || `d41lyr3p-score-${slug}-${me.id}`}
+      >
+        Score: {parsed.score.value}
+      </p>
+      <pre
+        id={parsed.summary.id || `d41lyr3p-sum-${slug}-${me.id}`}
+        className="whitespace-pre-wrap"
+      >
+        {parsed.summary.text}
+      </pre>
+      {parsed.good.length > 0 && (
+        <div className="mt-4" id={`d41lyr3p-good-${slug}-${me.id}`}>
           <h2 className="font-semibold">What went well</h2>
           <ul className="list-disc pl-4">
-            {parsed.good.map((g: string, i: number) => (
-              <li key={i}>{g}</li>
+            {parsed.good.map((g, i) => (
+              <li key={g.id || i} id={g.id}>
+                {g.text}
+              </li>
             ))}
           </ul>
         </div>
       )}
-      {parsed.bad && (
-        <div className="mt-4">
+      {parsed.bad.length > 0 && (
+        <div className="mt-4" id={`d41lyr3p-bad-${slug}-${me.id}`}>
           <h2 className="font-semibold">What went bad</h2>
           <ul className="list-disc pl-4">
-            {parsed.bad.map((g: string, i: number) => (
-              <li key={i}>{g}</li>
+            {parsed.bad.map((g, i) => (
+              <li key={g.id || i} id={g.id}>
+                {g.text}
+              </li>
             ))}
           </ul>
         </div>
       )}
-      {parsed.observations && (
-        <div className="mt-4">
+      {parsed.observations.length > 0 && (
+        <div className="mt-4" id={`d41lyr3p-obs-${slug}-${me.id}`}>
           <h2 className="font-semibold">Observations</h2>
           <ul className="list-disc pl-4">
-            {parsed.observations.map((g: string, i: number) => (
-              <li key={i}>{g}</li>
+            {parsed.observations.map((g, i) => (
+              <li key={g.id || i} id={g.id}>
+                {g.text}
+              </li>
             ))}
           </ul>
         </div>

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -14,43 +14,66 @@ export default async function DailyReportsPage() {
       <h1 className="mb-4 text-2xl font-bold">Daily Reports</h1>
       <ul className="space-y-4">
         {reports.map((r) => (
-          <li key={r.slug} className="rounded border p-4">
+          <li
+            key={r.slug}
+            id={`d41lyr3p-${r.slug}-${me.id}`}
+            className="rounded border p-4"
+          >
             <div className="flex items-center justify-between">
-              <h2 className="font-semibold">
-                {r.date}
-                {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
+              <h2
+                id={`d41lyr3p-title-${r.slug}-${me.id}`}
+                className="font-semibold"
+              >
+                Daily report {r.date}
+                {r.version > 1 && <span className="ml-1">V{r.version}</span>}
               </h2>
-              <span className="font-semibold">{r.score}</span>
+              <span
+                id={`d41lyr3p-score-${r.slug}-${me.id}`}
+                className="font-semibold"
+              >
+                {r.score}
+              </span>
             </div>
             {r.summary && (
-              <p className="mt-2 whitespace-pre-wrap">{r.summary}</p>
+              <p
+                id={`d41lyr3p-sum-${r.slug}-${me.id}`}
+                className="mt-2 whitespace-pre-wrap"
+              >
+                {r.summary}
+              </p>
             )}
             {r.good.length > 0 && (
-              <div className="mt-2">
+              <div id={`d41lyr3p-good-${r.slug}-${me.id}`} className="mt-2">
                 <h3 className="font-semibold">What went well</h3>
                 <ul className="list-disc pl-4">
                   {r.good.map((g, i) => (
-                    <li key={i}>{g}</li>
+                    <li key={i} id={`d41lyr3p-good${i}-${r.slug}-${me.id}`}>
+                      {g}
+                    </li>
                   ))}
                 </ul>
               </div>
             )}
             {r.bad.length > 0 && (
-              <div className="mt-2">
+              <div id={`d41lyr3p-bad-${r.slug}-${me.id}`} className="mt-2">
                 <h3 className="font-semibold">What went bad</h3>
                 <ul className="list-disc pl-4">
                   {r.bad.map((b, i) => (
-                    <li key={i}>{b}</li>
+                    <li key={i} id={`d41lyr3p-bad${i}-${r.slug}-${me.id}`}>
+                      {b}
+                    </li>
                   ))}
                 </ul>
               </div>
             )}
             {r.observations.length > 0 && (
-              <div className="mt-2">
+              <div id={`d41lyr3p-obs-${r.slug}-${me.id}`} className="mt-2">
                 <h3 className="font-semibold">Observations</h3>
                 <ul className="list-disc pl-4">
                   {r.observations.map((o, i) => (
-                    <li key={i}>{o}</li>
+                    <li key={i} id={`d41lyr3p-obs${i}-${r.slug}-${me.id}`}>
+                      {o}
+                    </li>
                   ))}
                 </ul>
               </div>
@@ -58,6 +81,7 @@ export default async function DailyReportsPage() {
             <Link
               href={`/progress/overview/daily/${r.slug}`}
               className="mt-2 block text-sm text-orange-600 hover:underline"
+              id={`d41lyr3p-view-${r.slug}-${me.id}`}
             >
               View details
             </Link>

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -1,15 +1,15 @@
 import { db } from './db';
 import { dailyReports } from './db/schema';
 import { eq, and, asc, sql } from 'drizzle-orm';
-import type { DailyReport, ReportContent } from '@/types/report';
+import type { DailyReport, ReportContent, ReportLine } from '@/types/report';
 
-function slugFromDate(ymd: string, version = 1): string {
+export function slugFromDate(ymd: string, version = 1): string {
   const [y, m, d] = ymd.split('-');
   const base = `${d}${m}${y}`;
   return version > 1 ? `${base}V${version}` : base;
 }
 
-function parseSlug(slug: string): { date: string; version: number } {
+export function parseSlug(slug: string): { date: string; version: number } {
   const match = /^([0-9]{2})([0-9]{2})([0-9]{4})(?:V(\d+))?$/.exec(slug);
   if (!match) return { date: slug, version: 1 };
   const [, d, m, y, v] = match;
@@ -27,11 +27,35 @@ export async function listDailyReportDates(userId: number): Promise<string[]> {
 }
 
 function parseReportContent(raw: unknown): ReportContent {
-  if (!raw) return {} as ReportContent;
   try {
-    return JSON.parse(String(raw)) as ReportContent;
+    const parsed = JSON.parse(String(raw || '{}'));
+    const wrap = (value: any, fallback = ''): ReportLine =>
+      typeof value === 'object' && value !== null
+        ? { id: String(value.id || ''), text: String(value.text || '') }
+        : { id: '', text: String(value || fallback) };
+    const arr = (value: any[]): ReportLine[] =>
+      Array.isArray(value) ? value.map((v) => wrap(v)) : [];
+    return {
+      summary: wrap(parsed.summary),
+      good: arr(parsed.good),
+      bad: arr(parsed.bad),
+      observations: arr(parsed.observations),
+      score:
+        typeof parsed.score === 'object'
+          ? {
+              id: String(parsed.score.id || ''),
+              value: Number(parsed.score.value || 0),
+            }
+          : { id: '', value: Number(parsed.score || 0) },
+    };
   } catch {
-    return {} as ReportContent;
+    return {
+      summary: { id: '', text: '' },
+      good: [],
+      bad: [],
+      observations: [],
+      score: { id: '', value: 0 },
+    };
   }
 }
 
@@ -65,11 +89,11 @@ export async function listDailyReports(userId: number): Promise<
       date: ymd,
       slug: slugFromDate(ymd, version),
       version,
-      score: r.score ?? 0,
-      summary: parsed.summary ?? '',
-      good: parsed.good ?? [],
-      bad: parsed.bad ?? [],
-      observations: parsed.observations ?? [],
+      score: parsed.score.value ?? r.score ?? 0,
+      summary: parsed.summary.text,
+      good: parsed.good.map((g) => g.text),
+      bad: parsed.bad.map((b) => b.text),
+      observations: parsed.observations.map((o) => o.text),
     };
   });
 }
@@ -101,23 +125,32 @@ export async function getDailyReport(
   };
 }
 
+export async function getNextDailyReportVersion(
+  userId: number,
+  date: string,
+): Promise<number> {
+  const [{ maxVersion }] = await db
+    .select({
+      maxVersion: sql<number>`coalesce(max(${dailyReports.version}),0)`,
+    })
+    .from(dailyReports)
+    .where(and(eq(dailyReports.userId, userId), eq(dailyReports.date, date)));
+  return (maxVersion ?? 0) + 1;
+}
+
 export async function createDailyReport(
   userId: number,
   date: string,
   content: Record<string, unknown>,
   score: number,
+  version: number,
 ) {
   const raw = JSON.stringify(content);
-  const [{ maxVersion }] = await db
-    .select({ maxVersion: sql<number>`coalesce(max(${dailyReports.version}),0)` })
-    .from(dailyReports)
-    .where(and(eq(dailyReports.userId, userId), eq(dailyReports.date, date)));
-  const nextVersion = (maxVersion ?? 0) + 1;
   await db.insert(dailyReports).values({
     userId,
     date,
     content: raw,
     score,
-    version: nextVersion,
+    version,
   });
 }

--- a/types/report.ts
+++ b/types/report.ts
@@ -1,9 +1,19 @@
+export interface ReportLine {
+  id: string;
+  text: string;
+}
+
+export interface ReportScore {
+  id: string;
+  value: number;
+}
+
 export interface ReportContent {
-  summary: string;
-  good: string[];
-  bad: string[];
-  observations: string[];
-  score: number;
+  summary: ReportLine;
+  good: ReportLine[];
+  bad: ReportLine[];
+  observations: ReportLine[];
+  score: ReportScore;
 }
 
 export interface DailyReport {


### PR DESCRIPTION
## Summary
- structure daily report entries with IDs for summary, good, bad, and score
- hardcode saving of LLM output with versioned slugs
- expose daily reports with new IDs on overview and detail pages

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68aee30ad100832aaa3f16d3f62719f5