### PR TITLE
fix: support multiple daily report versions

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -192,3 +192,20 @@ Modal form IDs:
 - `hist-cake-{ownerId}-{date}` → historical cake page.
 - `hist-flav-{ownerId}-{date}` → historical flavors page.
 - `hist-subflav-{ownerId}-{flavorId}-{date}` → historical subflavors page.
+
+## Daily Reports
+
+- `d41lyrep-list-{ownerId}` → daily reports list container.
+- `d41lyrep-item-{slug}-{ownerId}` → single daily report entry in list.
+- `d41lyrep-date-{slug}-{ownerId}` → date heading in list entry.
+- `d41lyrep-score-{slug}-{ownerId}` → score badge in list entry.
+- `d41lyrep-sum-{slug}-{ownerId}` → summary text snippet in list entry.
+- `d41lyrep-good-{index}-{slug}-{ownerId}` → good item in list entry.
+- `d41lyrep-bad-{index}-{slug}-{ownerId}` → bad item in list entry.
+- `d41lyrep-link-{slug}-{ownerId}` → details link in list entry.
+- `d41lyrep-title-{reportId}-{ownerId}` → detail page title.
+- `d41lyrep-score-{reportId}-{ownerId}` → score on detail page.
+- `d41lyrep-sum-{reportId}-{ownerId}` → summary on detail page.
+- `d41lyrep-good-{index}-{reportId}-{ownerId}` → good item on detail page.
+- `d41lyrep-bad-{index}-{reportId}-{ownerId}` → bad item on detail page.
+- `d41lyrep-obs-{index}-{reportId}-{ownerId}` → observation item on detail page.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -222,3 +222,4 @@
 - 2025-10-27: Cast daily report content to text to fix insert failure and display observations on daily overview.
 - 2025-10-27: Stringified daily report content before upsert to resolve insert errors.
 - 2025-10-27: Added versioned daily reports so multiple saves per date keep unique IDs and display in the overview.
+- 2025-10-27: Canonicalized daily report dates, allowed multiple versions per day, and added IDs for summary, good, bad, and score displays.

--- a/app/progress/overview/daily/[date]/page.tsx
+++ b/app/progress/overview/daily/[date]/page.tsx
@@ -16,38 +16,59 @@ export default async function DailyReportDetail({
   const parsed = report.content;
   return (
     <main className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">
+      <h1
+        className="mb-4 text-2xl font-bold"
+        id={`d41lyrep-title-${report.id}-${me.id}`}
+      >
         Report for {report.date}
-        {report.version > 1 && <span className="ml-1">(v{report.version})</span>}
+        {report.version > 1 && (
+          <span className="ml-1">(v{report.version})</span>
+        )}
       </h1>
-      <p className="mb-4 font-semibold">Score: {report.score}</p>
-      <pre className="whitespace-pre-wrap">{parsed.summary ?? ''}</pre>
-      {parsed.good && (
-        <div className="mt-4">
+      <p
+        className="mb-4 font-semibold"
+        id={`d41lyrep-score-${report.id}-${me.id}`}
+      >
+        Score: {report.score}
+      </p>
+      <pre
+        className="whitespace-pre-wrap"
+        id={`d41lyrep-sum-${report.id}-${me.id}`}
+      >
+        {parsed.summary ?? ''}
+      </pre>
+      {Array.isArray(parsed.good) && parsed.good.length > 0 && (
+        <div className="mt-4" id={`d41lyrep-good-${report.id}-${me.id}`}>
           <h2 className="font-semibold">What went well</h2>
           <ul className="list-disc pl-4">
             {parsed.good.map((g: string, i: number) => (
-              <li key={i}>{g}</li>
+              <li key={i} id={`d41lyrep-good-${i}-${report.id}-${me.id}`}>
+                {g}
+              </li>
             ))}
           </ul>
         </div>
       )}
-      {parsed.bad && (
-        <div className="mt-4">
+      {Array.isArray(parsed.bad) && parsed.bad.length > 0 && (
+        <div className="mt-4" id={`d41lyrep-bad-${report.id}-${me.id}`}>
           <h2 className="font-semibold">What went bad</h2>
           <ul className="list-disc pl-4">
             {parsed.bad.map((g: string, i: number) => (
-              <li key={i}>{g}</li>
+              <li key={i} id={`d41lyrep-bad-${i}-${report.id}-${me.id}`}>
+                {g}
+              </li>
             ))}
           </ul>
         </div>
       )}
-      {parsed.observations && (
-        <div className="mt-4">
+      {Array.isArray(parsed.observations) && parsed.observations.length > 0 && (
+        <div className="mt-4" id={`d41lyrep-obs-${report.id}-${me.id}`}>
           <h2 className="font-semibold">Observations</h2>
           <ul className="list-disc pl-4">
             {parsed.observations.map((g: string, i: number) => (
-              <li key={i}>{g}</li>
+              <li key={i} id={`d41lyrep-obs-${i}-${report.id}-${me.id}`}>
+                {g}
+              </li>
             ))}
           </ul>
         </div>

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -12,45 +12,68 @@ export default async function DailyReportsPage() {
   return (
     <main className="p-6">
       <h1 className="mb-4 text-2xl font-bold">Daily Reports</h1>
-      <ul className="space-y-4">
+      <ul className="space-y-4" id={`d41lyrep-list-${me.id}`}>
         {reports.map((r) => (
-          <li key={r.slug} className="rounded border p-4">
+          <li
+            key={r.slug}
+            className="rounded border p-4"
+            id={`d41lyrep-item-${r.slug}-${me.id}`}
+          >
             <div className="flex items-center justify-between">
-              <h2 className="font-semibold">
+              <h2
+                className="font-semibold"
+                id={`d41lyrep-date-${r.slug}-${me.id}`}
+              >
                 {r.date}
                 {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
               </h2>
-              <span className="font-semibold">{r.score}</span>
+              <span
+                className="font-semibold"
+                id={`d41lyrep-score-${r.slug}-${me.id}`}
+              >
+                {r.score}
+              </span>
             </div>
             {r.summary && (
-              <p className="mt-2 whitespace-pre-wrap">{r.summary}</p>
+              <p
+                className="mt-2 whitespace-pre-wrap"
+                id={`d41lyrep-sum-${r.slug}-${me.id}`}
+              >
+                {r.summary}
+              </p>
             )}
             {r.good.length > 0 && (
-              <div className="mt-2">
+              <div className="mt-2" id={`d41lyrep-good-${r.slug}-${me.id}`}>
                 <h3 className="font-semibold">What went well</h3>
                 <ul className="list-disc pl-4">
                   {r.good.map((g, i) => (
-                    <li key={i}>{g}</li>
+                    <li key={i} id={`d41lyrep-good-${i}-${r.slug}-${me.id}`}>
+                      {g}
+                    </li>
                   ))}
                 </ul>
               </div>
             )}
             {r.bad.length > 0 && (
-              <div className="mt-2">
+              <div className="mt-2" id={`d41lyrep-bad-${r.slug}-${me.id}`}>
                 <h3 className="font-semibold">What went bad</h3>
                 <ul className="list-disc pl-4">
                   {r.bad.map((b, i) => (
-                    <li key={i}>{b}</li>
+                    <li key={i} id={`d41lyrep-bad-${i}-${r.slug}-${me.id}`}>
+                      {b}
+                    </li>
                   ))}
                 </ul>
               </div>
             )}
             {r.observations.length > 0 && (
-              <div className="mt-2">
+              <div className="mt-2" id={`d41lyrep-obs-${r.slug}-${me.id}`}>
                 <h3 className="font-semibold">Observations</h3>
                 <ul className="list-disc pl-4">
                   {r.observations.map((o, i) => (
-                    <li key={i}>{o}</li>
+                    <li key={i} id={`d41lyrep-obs-${i}-${r.slug}-${me.id}`}>
+                      {o}
+                    </li>
                   ))}
                 </ul>
               </div>
@@ -58,6 +81,7 @@ export default async function DailyReportsPage() {
             <Link
               href={`/progress/overview/daily/${r.slug}`}
               className="mt-2 block text-sm text-orange-600 hover:underline"
+              id={`d41lyrep-link-${r.slug}-${me.id}`}
             >
               View details
             </Link>

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -108,14 +108,17 @@ export async function createDailyReport(
   score: number,
 ) {
   const raw = JSON.stringify(content);
+  const ymd = new Date(date).toISOString().slice(0, 10);
   const [{ maxVersion }] = await db
-    .select({ maxVersion: sql<number>`coalesce(max(${dailyReports.version}),0)` })
+    .select({
+      maxVersion: sql<number>`coalesce(max(${dailyReports.version}),0)`,
+    })
     .from(dailyReports)
-    .where(and(eq(dailyReports.userId, userId), eq(dailyReports.date, date)));
+    .where(and(eq(dailyReports.userId, userId), eq(dailyReports.date, ymd)));
   const nextVersion = (maxVersion ?? 0) + 1;
   await db.insert(dailyReports).values({
     userId,
-    date,
+    date: ymd,
     content: raw,
     score,
     version: nextVersion,


### PR DESCRIPTION
## Summary
- normalize daily report dates before saving so multiple versions can be stored per day
- expose daily report summary, good, bad and score with stable DOM IDs
- document new daily report ID patterns

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68aee30ad100832aaa3f16d3f62719f5