### PR TITLE
Enable viewer progress access and restrict daily report regeneration

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -225,3 +225,4 @@
 - 2025-10-27: Canonicalized daily report dates, allowed multiple versions per day, and added IDs for summary, good, bad, and score displays.
 - 2025-10-27: Added detailed logging for daily report inserts and stripped score from stored content to fix query failures.
 - 2025-10-27: Split daily report fields into separate columns, switched detail view IDs to slug-based patterns, and passed userId in report generation requests.
+- 2025-10-27: Added viewer progress routes, daily report regeneration code check, calendar highlight, and sorted daily reports descending with per-day generation limit.

--- a/app/(view)/view/[viewId]/progress/overview/daily/[date]/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/daily/[date]/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { DailyReportDetailView } from '@/app/progress/overview/daily/[date]/page';
+
+export default async function ViewDailyReportDetail({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string; date: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId, date } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-daily-${user.id}-${date}`}>
+        <DailyReportDetailView userId={user.id} slug={date} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/(view)/view/[viewId]/progress/overview/daily/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/daily/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { DailyReportsHome } from '@/app/progress/overview/daily/page';
+
+export default async function ViewDailyReportsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-daily-${user.id}`}>
+        <DailyReportsHome userId={user.id} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/(view)/view/[viewId]/progress/overview/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { ProgressOverviewHome } from '@/app/progress/overview/page';
+
+export default async function ViewProgressOverviewPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-ov-${user.id}`}>
+        <ProgressOverviewHome />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/(view)/view/[viewId]/progress/page.tsx
+++ b/app/(view)/view/[viewId]/progress/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { ProgressHome } from '@/app/progress/page';
+
+export default async function ViewProgressPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-${user.id}`}>
+        <ProgressHome />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/(view)/view/[viewId]/progress/testchat/page.tsx
+++ b/app/(view)/view/[viewId]/progress/testchat/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import TestChatPage from '@/app/progress/testchat/page';
+
+export default async function ViewTestChatPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-testchat-${user.id}`}>
+        <TestChatPage />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/progress/overview/daily/[date]/page.tsx
+++ b/app/progress/overview/daily/[date]/page.tsx
@@ -3,38 +3,34 @@ import { ensureUser } from '@/lib/users';
 import { getDailyReport } from '@/lib/daily-report-store';
 import { redirect, notFound } from 'next/navigation';
 
-export default async function DailyReportDetail({
-  params,
+export async function DailyReportDetailView({
+  userId,
+  slug,
 }: {
-  params: { date: string };
+  userId: number;
+  slug: string;
 }) {
-  const session = await auth();
-  if (!session) redirect('/signin');
-  const me = await ensureUser(session);
-  const slug = params.date;
-  const report = await getDailyReport(me.id, slug);
+  const report = await getDailyReport(userId, slug);
   if (!report) notFound();
   const { summary, good, bad, observations } = report;
   return (
     <main className="p-6">
-      <h1 className="mb-4 text-2xl font-bold" id={`d41lyrep-title-${slug}-${me.id}`}>
+      <h1 className="mb-4 text-2xl font-bold" id={`d41lyrep-title-${slug}-${userId}`}>
         Report for {report.date}
-        {report.version > 1 && (
-          <span className="ml-1">(v{report.version})</span>
-        )}
+        {report.version > 1 && <span className="ml-1">(v{report.version})</span>}
       </h1>
-      <p className="mb-4 font-semibold" id={`d41lyrep-score-${slug}-${me.id}`}>
+      <p className="mb-4 font-semibold" id={`d41lyrep-score-${slug}-${userId}`}>
         Score: {report.score}
       </p>
-      <pre className="whitespace-pre-wrap" id={`d41lyrep-sum-${slug}-${me.id}`}>
+      <pre className="whitespace-pre-wrap" id={`d41lyrep-sum-${slug}-${userId}`}>
         {summary}
       </pre>
       {good.length > 0 && (
-        <div className="mt-4" id={`d41lyrep-good-${slug}-${me.id}`}>
+        <div className="mt-4" id={`d41lyrep-good-${slug}-${userId}`}>
           <h2 className="font-semibold">What went well</h2>
           <ul className="list-disc pl-4">
             {good.map((g: string, i: number) => (
-              <li key={i} id={`d41lyrep-good-${i}-${slug}-${me.id}`}>
+              <li key={i} id={`d41lyrep-good-${i}-${slug}-${userId}`}>
                 {g}
               </li>
             ))}
@@ -42,11 +38,11 @@ export default async function DailyReportDetail({
         </div>
       )}
       {bad.length > 0 && (
-        <div className="mt-4" id={`d41lyrep-bad-${slug}-${me.id}`}>
+        <div className="mt-4" id={`d41lyrep-bad-${slug}-${userId}`}>
           <h2 className="font-semibold">What went bad</h2>
           <ul className="list-disc pl-4">
             {bad.map((g: string, i: number) => (
-              <li key={i} id={`d41lyrep-bad-${i}-${slug}-${me.id}`}>
+              <li key={i} id={`d41lyrep-bad-${i}-${slug}-${userId}`}>
                 {g}
               </li>
             ))}
@@ -54,11 +50,11 @@ export default async function DailyReportDetail({
         </div>
       )}
       {observations.length > 0 && (
-        <div className="mt-4" id={`d41lyrep-obs-${slug}-${me.id}`}>
+        <div className="mt-4" id={`d41lyrep-obs-${slug}-${userId}`}>
           <h2 className="font-semibold">Observations</h2>
           <ul className="list-disc pl-4">
             {observations.map((g: string, i: number) => (
-              <li key={i} id={`d41lyrep-obs-${i}-${slug}-${me.id}`}>
+              <li key={i} id={`d41lyrep-obs-${i}-${slug}-${userId}`}>
                 {g}
               </li>
             ))}
@@ -67,4 +63,15 @@ export default async function DailyReportDetail({
       )}
     </main>
   );
+}
+
+export default async function DailyReportDetail({
+  params,
+}: {
+  params: { date: string };
+}) {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  return <DailyReportDetailView userId={me.id} slug={params.date} />;
 }

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -4,32 +4,29 @@ import { ensureUser } from '@/lib/users';
 import { redirect } from 'next/navigation';
 import { listDailyReports } from '@/lib/daily-report-store';
 
-export default async function DailyReportsPage() {
-  const session = await auth();
-  if (!session) redirect('/signin');
-  const me = await ensureUser(session);
-  const reports = await listDailyReports(me.id);
+export async function DailyReportsHome({ userId }: { userId: number }) {
+  const reports = await listDailyReports(userId);
   return (
     <main className="p-6">
       <h1 className="mb-4 text-2xl font-bold">Daily Reports</h1>
-      <ul className="space-y-4" id={`d41lyrep-list-${me.id}`}>
+      <ul className="space-y-4" id={`d41lyrep-list-${userId}`}>
         {reports.map((r) => (
           <li
             key={r.slug}
             className="rounded border p-4"
-            id={`d41lyrep-item-${r.slug}-${me.id}`}
+            id={`d41lyrep-item-${r.slug}-${userId}`}
           >
             <div className="flex items-center justify-between">
               <h2
                 className="font-semibold"
-                id={`d41lyrep-date-${r.slug}-${me.id}`}
+                id={`d41lyrep-date-${r.slug}-${userId}`}
               >
                 {r.date}
                 {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
               </h2>
               <span
                 className="font-semibold"
-                id={`d41lyrep-score-${r.slug}-${me.id}`}
+                id={`d41lyrep-score-${r.slug}-${userId}`}
               >
                 {r.score}
               </span>
@@ -37,17 +34,17 @@ export default async function DailyReportsPage() {
             {r.summary && (
               <p
                 className="mt-2 whitespace-pre-wrap"
-                id={`d41lyrep-sum-${r.slug}-${me.id}`}
+                id={`d41lyrep-sum-${r.slug}-${userId}`}
               >
                 {r.summary}
               </p>
             )}
             {r.good.length > 0 && (
-              <div className="mt-2" id={`d41lyrep-good-${r.slug}-${me.id}`}>
+              <div className="mt-2" id={`d41lyrep-good-${r.slug}-${userId}`}>
                 <h3 className="font-semibold">What went well</h3>
                 <ul className="list-disc pl-4">
                   {r.good.map((g, i) => (
-                    <li key={i} id={`d41lyrep-good-${i}-${r.slug}-${me.id}`}>
+                    <li key={i} id={`d41lyrep-good-${i}-${r.slug}-${userId}`}>
                       {g}
                     </li>
                   ))}
@@ -55,11 +52,11 @@ export default async function DailyReportsPage() {
               </div>
             )}
             {r.bad.length > 0 && (
-              <div className="mt-2" id={`d41lyrep-bad-${r.slug}-${me.id}`}>
+              <div className="mt-2" id={`d41lyrep-bad-${r.slug}-${userId}`}>
                 <h3 className="font-semibold">What went bad</h3>
                 <ul className="list-disc pl-4">
                   {r.bad.map((b, i) => (
-                    <li key={i} id={`d41lyrep-bad-${i}-${r.slug}-${me.id}`}>
+                    <li key={i} id={`d41lyrep-bad-${i}-${r.slug}-${userId}`}>
                       {b}
                     </li>
                   ))}
@@ -67,11 +64,11 @@ export default async function DailyReportsPage() {
               </div>
             )}
             {r.observations.length > 0 && (
-              <div className="mt-2" id={`d41lyrep-obs-${r.slug}-${me.id}`}>
+              <div className="mt-2" id={`d41lyrep-obs-${r.slug}-${userId}`}>
                 <h3 className="font-semibold">Observations</h3>
                 <ul className="list-disc pl-4">
                   {r.observations.map((o, i) => (
-                    <li key={i} id={`d41lyrep-obs-${i}-${r.slug}-${me.id}`}>
+                    <li key={i} id={`d41lyrep-obs-${i}-${r.slug}-${userId}`}>
                       {o}
                     </li>
                   ))}
@@ -79,9 +76,9 @@ export default async function DailyReportsPage() {
               </div>
             )}
             <Link
-              href={`/progress/overview/daily/${r.slug}`}
+              href={r.slug}
               className="mt-2 block text-sm text-orange-600 hover:underline"
-              id={`d41lyrep-link-${r.slug}-${me.id}`}
+              id={`d41lyrep-link-${r.slug}-${userId}`}
             >
               View details
             </Link>
@@ -90,4 +87,11 @@ export default async function DailyReportsPage() {
       </ul>
     </main>
   );
+}
+
+export default async function DailyReportsPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  return <DailyReportsHome userId={me.id} />;
 }

--- a/app/progress/overview/page.tsx
+++ b/app/progress/overview/page.tsx
@@ -1,4 +1,7 @@
+'use client';
 import Link from 'next/link';
+import { useViewContext } from '@/lib/view-context';
+import { hrefFor } from '@/lib/navigation';
 
 const items = [
   { href: '/progress/overview/daily', label: 'Daily' },
@@ -7,14 +10,15 @@ const items = [
   { href: '/progress/overview/yearly', label: 'Yearly' },
 ];
 
-export default function ProgressOverviewPage() {
+export function ProgressOverviewHome() {
+  const ctx = useViewContext();
   return (
     <main className="p-6">
       <ul className="space-y-2">
         {items.map((i) => (
           <li key={i.href}>
             <Link
-              href={i.href}
+              href={hrefFor(i.href, ctx)}
               className="block rounded border p-4 hover:bg-orange-50"
             >
               {i.label}
@@ -24,4 +28,8 @@ export default function ProgressOverviewPage() {
       </ul>
     </main>
   );
+}
+
+export default function ProgressOverviewPage() {
+  return <ProgressOverviewHome />;
 }

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -1,20 +1,28 @@
+'use client';
 import Link from 'next/link';
+import { useViewContext } from '@/lib/view-context';
+import { hrefFor } from '@/lib/navigation';
 
-export default function ProgressPage() {
+export function ProgressHome() {
+  const ctx = useViewContext();
   return (
     <main className="p-6 space-x-4">
       <Link
-        href="/progress/testchat"
+        href={hrefFor('/progress/testchat', ctx)}
         className="bg-orange-500 text-white px-4 py-2 rounded"
       >
         Chat with LLM
       </Link>
       <Link
-        href="/progress/overview"
+        href={hrefFor('/progress/overview', ctx)}
         className="bg-orange-500 text-white px-4 py-2 rounded"
       >
         Overview
       </Link>
     </main>
   );
+}
+
+export default function ProgressPage() {
+  return <ProgressHome />;
 }

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -22,17 +22,19 @@ export function AppNav() {
   const pathname = usePathname();
   const sections: Section[] =
     ctx.mode === 'viewer'
-      ? ['cake', 'planning', 'flavors', 'ingredients', 'review', 'people']
-      : [
-          'cake',
-          'planning',
-          'flavors',
-          'ingredients',
-          'review',
-          'people',
-          'visibility',
-          'progress',
-        ];
+      ? ['cake', 'planning', 'flavors', 'ingredients', 'review', 'people', 'progress']
+      : ctx.mode === 'historical'
+        ? ['cake', 'planning', 'flavors', 'ingredients', 'review', 'people', 'visibility']
+        : [
+            'cake',
+            'planning',
+            'flavors',
+            'ingredients',
+            'review',
+            'people',
+            'visibility',
+            'progress',
+          ];
 
   return (
     <nav className="flex items-center justify-between border-b p-4">

--- a/components/cake/cake-home.tsx
+++ b/components/cake/cake-home.tsx
@@ -2,7 +2,6 @@ import { SideCalendar } from '@/components/calendar/side-calendar';
 import { CakeNavigation } from './cake-navigation';
 import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
 import { listDailyReportDates } from '@/lib/daily-report-store';
-import { GenerateDailyReportButton } from '@/components/progress/generate-daily-report-button';
 
 export async function CakeHome({ ownerId }: { ownerId: number }) {
   const snapshotDates = await listProfileSnapshotDates(ownerId);
@@ -12,7 +11,6 @@ export async function CakeHome({ ownerId }: { ownerId: number }) {
       <h1 className="sr-only">Cake</h1>
       <SideCalendar snapshotDates={snapshotDates} reportDates={reportDates} />
       <CakeNavigation />
-      <GenerateDailyReportButton userId={ownerId} />
     </section>
   );
 }

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -8,6 +8,7 @@ import { SettingsButton } from './settings-button';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor, type Section } from '@/lib/navigation';
 import TimeMachine from '@/components/dev/time-machine';
+import { GenerateDailyReportButton } from '@/components/progress/generate-daily-report-button';
 
 export function CakeNavigation() {
   const router = useRouter();
@@ -134,7 +135,13 @@ export function CakeNavigation() {
           userId={userId}
         />
       </div>
-      <div className="grid w-full place-items-center">
+      <div className="grid w-full place-items-center relative">
+        <div className="absolute bottom-full mb-4">
+          <GenerateDailyReportButton
+            userId={ctx.ownerId}
+            className="mt-0"
+          />
+        </div>
         <nav
           className="grid grid-cols-2 place-items-center gap-3 sm:grid-cols-3 xl:grid-cols-6"
           style={{

--- a/components/progress/generate-daily-report-button.tsx
+++ b/components/progress/generate-daily-report-button.tsx
@@ -1,22 +1,25 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { useLogs } from '@/components/dev/logs-provider';
 import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/utils';
 
 export function GenerateDailyReportButton({
   userId,
+  className,
 }: {
   userId: number;
+  className?: string;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
   const router = useRouter();
   const [message, setMessage] = useState<string | null>(null);
+  const [needsCode, setNeedsCode] = useState(false);
 
-  const onClick = async () => {
-    setLoading(true);
+  const currentDate = useCallback(() => {
     const params = new URLSearchParams(window.location.search);
     params.set('userId', String(userId));
     const dateParam = params.get('apoc_date');
@@ -29,6 +32,25 @@ export function GenerateDailyReportButton({
       }
       if (!date) date = new Date().toISOString().slice(0, 10);
     }
+    return { date, params };
+  }, [userId]);
+
+  useEffect(() => {
+    const { date } = currentDate();
+    const key = `daily-report-generated-${userId}-${date}`;
+    setNeedsCode(window.localStorage.getItem(key) === 'true');
+  }, [currentDate, userId]);
+
+  const onClick = async () => {
+    const { date, params } = currentDate();
+    if (needsCode) {
+      const code = window.prompt('Enter code to generate a new daily report');
+      if (code !== 'cake') {
+        setMessage('Incorrect code');
+        return;
+      }
+    }
+    setLoading(true);
     const reviewKey = `review-${userId}-${date}`;
     const planKey = `live-plan-${userId}-${date}`;
     let reviews: Record<string, any> = {};
@@ -65,6 +87,9 @@ export function GenerateDailyReportButton({
       setMessage(
         `Daily report is created. Your score for today is: ${data.score}`,
       );
+      const key = `daily-report-generated-${userId}-${date}`;
+      window.localStorage.setItem(key, 'true');
+      setNeedsCode(true);
       router.refresh();
     }
   };
@@ -77,7 +102,11 @@ export function GenerateDailyReportButton({
     <Button
       onClick={onClick}
       disabled={loading}
-      className="mt-4 flex items-center gap-2"
+      className={cn(
+        'flex items-center gap-2',
+        needsCode && 'bg-white text-black hover:bg-white',
+        className,
+      )}
     >
       {loading && (
         <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -1,6 +1,6 @@
 import { db } from './db';
 import { dailyReports } from './db/schema';
-import { eq, and, asc, sql } from 'drizzle-orm';
+import { eq, and, desc, sql } from 'drizzle-orm';
 import type { DailyReport, ReportContent } from '@/types/report';
 
 function slugFromDate(ymd: string, version = 1): string {
@@ -60,7 +60,7 @@ export async function listDailyReports(userId: number): Promise<
     })
     .from(dailyReports)
     .where(eq(dailyReports.userId, userId))
-    .orderBy(asc(dailyReports.date), asc(dailyReports.version));
+    .orderBy(desc(dailyReports.date), desc(dailyReports.version));
   return rows.map((r) => {
     const ymd = r.date?.toString().slice(0, 10) ?? '';
     const version = r.version ?? 1;

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -58,7 +58,7 @@ export function hrefFor(
       case 'visibility':
         return base; // no visibility route for viewers/historical
       case 'progress':
-        return base; // progress hidden in viewer/historical
+        return ctx.mode === 'viewer' ? `${base}/progress` : base;
     }
   }
   switch (sectionOrPath) {


### PR DESCRIPTION
## Summary
- Position daily report button between cake and navigation without shifting layout and require code for multiple generations per day
- Sort daily report overview by newest first and highlight generated days in calendar
- Allow viewers to access progress pages while hiding them in historical snapshots

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` (fails: Timed out waiting 120000ms from config.webServer)


------
https://chatgpt.com/codex/tasks/task_e_68af0eb9886c832abced599ddea5bfb1