### PR TITLE
feat: position generate daily rapport button

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -227,3 +227,4 @@
 - 2025-10-27: Split daily report fields into separate columns, switched detail view IDs to slug-based patterns, and passed userId in report generation requests.
 - 2025-10-27: Added viewer progress routes, daily report regeneration code check, calendar highlight, and sorted daily reports descending with per-day generation limit.
 - 2025-10-27: Raised daily report button between cake and navigation, turned green-to-orange with code "cake2025" for repeat generation, and hid it for viewers.
+- 2025-10-27: Positioned "Generate daily rapport" button centered between cake and navigation with fixed spacing.

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -137,7 +137,10 @@ export function CakeNavigation() {
       </div>
       <div className="grid w-full place-items-center relative">
         {ctx.editable && (
-          <div className="absolute left-1/2 -translate-x-1/2 -top-12">
+          <div
+            className="absolute left-1/2 -translate-x-1/2"
+            style={{ top: '-66px' }}
+          >
             <GenerateDailyReportButton userId={ctx.ownerId} />
           </div>
         )}

--- a/components/progress/generate-daily-report-button.tsx
+++ b/components/progress/generate-daily-report-button.tsx
@@ -84,7 +84,7 @@ export function GenerateDailyReportButton({
       setMessage(data.error);
     } else {
       setMessage(
-        `Daily report is created. Your score for today is: ${data.score}`,
+        `Daily rapport is created. Your score for today is: ${data.score}`,
       );
       const key = `daily-report-generated-${userId}-${date}`;
       window.localStorage.setItem(key, 'true');
@@ -108,7 +108,7 @@ export function GenerateDailyReportButton({
         {loading && (
           <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
         )}
-        {loading ? 'Generating…' : 'Generate daily report'}
+        {loading ? 'Generating…' : 'Generate daily rapport'}
       </Button>
       {message && <p className="mt-2 text-sm">{message}</p>}
     </div>


### PR DESCRIPTION
## Summary
- center "Generate daily rapport" button between cake and navigation
- rename button text to "Generate daily rapport" and update message
- log changelog entry for button placement

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68af170bcec4832a8c98e120a6762a21