### PR TITLE
feat: add coach tone setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@
    ```sh
    pnpm test
    ```
+
+## Coach Tones
+
+Users can adjust how firm the AI coach should be. Four tone IDs are available:
+
+- `tone_soft` — supportive ramp-up for beginners.
+- `tone_medium` — balanced guidance to keep momentum.
+- `tone_hard` — high accountability without fluff.
+- `tone_superhard` — elite performance mode with tight loops.
+
+Pick a tone in **Settings → Account** using the slider; the choice influences future AI feedback.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -230,3 +230,4 @@
 - 2025-10-27: Positioned "Generate daily rapport" button centered between cake and navigation with fixed spacing.
 - 2025-10-27: Shifted "Generate daily rapport" button 60px left of center while keeping cake and navigation stationary.
 - 2025-10-27: Moved "Generate daily rapport" button ~30px further left (about 90px total) to center under the cake without moving other elements.
+- 2025-10-27: Added coach tone settings with soft, medium, hard, and superhard options and API support.

--- a/app/(app)/settings/account/page.tsx
+++ b/app/(app)/settings/account/page.tsx
@@ -2,24 +2,36 @@
 
 import { useState, useEffect } from 'react';
 import { useViewContext } from '@/lib/view-context';
+import type { CoachToneId } from '@/lib/ai/coach-tone';
 
 export default function AccountSettingsPage() {
   const { editable } = useViewContext();
   const [visibility, setVisibility] = useState<'open' | 'closed' | 'private'>('open');
+  const [tone, setTone] = useState<CoachToneId>('tone_medium');
   const [saving, setSaving] = useState(false);
   useEffect(() => {
     fetch('/api/account/visibility')
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => setVisibility(data?.accountVisibility ?? 'open'));
+    fetch('/api/account/tone')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setTone(data?.coachTone ?? 'tone_medium'));
   }, []);
 
   async function save() {
     setSaving(true);
-    await fetch('/api/account/visibility', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ accountVisibility: visibility }),
-    });
+    await Promise.all([
+      fetch('/api/account/visibility', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accountVisibility: visibility }),
+      }),
+      fetch('/api/account/tone', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ coachTone: tone }),
+      }),
+    ]);
     setSaving(false);
   }
 
@@ -37,6 +49,41 @@ export default function AccountSettingsPage() {
           <option value="closed">closed</option>
           <option value="private">private</option>
         </select>
+      </label>
+      <label className="flex items-center justify-between">
+        <span>Coach tone</span>
+        <div className="flex flex-col items-center">
+          <input
+            type="range"
+            min={0}
+            max={3}
+            step={1}
+            value={
+              ['tone_soft', 'tone_medium', 'tone_hard', 'tone_superhard'].indexOf(
+                tone,
+              )
+            }
+            onChange={(e) =>
+              setTone(
+                ['tone_soft', 'tone_medium', 'tone_hard', 'tone_superhard'][
+                  Number(e.target.value)
+                ] as CoachToneId,
+              )
+            }
+            disabled={!editable}
+            className="w-40"
+          />
+          <span className="mt-1 text-sm">
+            {
+              {
+                tone_soft: 'Soft',
+                tone_medium: 'Medium',
+                tone_hard: 'Hard',
+                tone_superhard: 'Superhard',
+              }[tone]
+            }
+          </span>
+        </div>
       </label>
       <button
         onClick={editable ? save : undefined}

--- a/app/api/account/tone/route.ts
+++ b/app/api/account/tone/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { ensureUser } from '@/lib/users';
+import type { CoachToneId } from '@/lib/ai/coach-tone';
+
+const tones: CoachToneId[] = [
+  'tone_soft',
+  'tone_medium',
+  'tone_hard',
+  'tone_superhard',
+];
+
+export async function GET() {
+  const session = await auth();
+  const self = await ensureUser(session);
+  const userId = self.id;
+  const [user] = await db
+    .select({ coachTone: users.coachTone })
+    .from(users)
+    .where(eq(users.id, userId));
+  return NextResponse.json({
+    coachTone: (user?.coachTone as CoachToneId) ?? 'tone_medium',
+  });
+}
+
+export async function POST(req: Request) {
+  const session = await auth();
+  const self = await ensureUser(session);
+  const userId = self.id;
+  const body = await req.json();
+  const tone = tones.includes(body.coachTone)
+    ? (body.coachTone as CoachToneId)
+    : null;
+  if (!tone) {
+    return NextResponse.json({ error: 'Invalid tone' }, { status: 400 });
+  }
+  await db
+    .update(users)
+    .set({ coachTone: tone, updatedAt: new Date() })
+    .where(eq(users.id, userId));
+  return NextResponse.json({ coachTone: tone });
+}

--- a/drizzle/0026_add_coach_tone.sql
+++ b/drizzle/0026_add_coach_tone.sql
@@ -1,0 +1,7 @@
+-- Coach tone enum
+DO $$ BEGIN
+  CREATE TYPE "coach_tone" AS ENUM ('tone_soft','tone_medium','tone_hard','tone_superhard');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "coach_tone" "coach_tone" NOT NULL DEFAULT 'tone_medium';

--- a/lib/ai/coach-tone.ts
+++ b/lib/ai/coach-tone.ts
@@ -1,0 +1,82 @@
+export type CoachToneId =
+  | 'tone_soft'
+  | 'tone_medium'
+  | 'tone_hard'
+  | 'tone_superhard';
+
+export interface CoachTone {
+  /** Unique identifier for the tone. */
+  id: CoachToneId;
+  /** Friendly label. */
+  name: string;
+  /** Goal of this tone. */
+  intent: string;
+  /** Benchmark used for comparison. */
+  comparisonStandard: string;
+  /** How the AI should score performance. */
+  scoringPolicy: string;
+  /** Style of voice and wording. */
+  feedbackStyle: string;
+  /** Accountability expectations. */
+  accountability: string;
+  /** Example snippet in this tone. */
+  sampleLine: string;
+}
+
+export const coachTones: Record<CoachToneId, CoachTone> = {
+  tone_soft: {
+    id: 'tone_soft',
+    name: 'Soft',
+    intent: 'Help a beginner stick with it; build confidence and consistency.',
+    comparisonStandard:
+      'Beginner baselines and personal trajectory (last 2–6 weeks), not experts.',
+    scoringPolicy:
+      "Fair but compassionate. Prioritize adherence and small wins. Avoid extreme lows unless there’s a safety issue.",
+    feedbackStyle:
+      'Warm, encouraging, high empathy; uses “could/consider/might”; asks permission before pushing.',
+    accountability: 'Gentle nudges; one clear next step.',
+    sampleLine:
+      '“Yesterday you logged 2/3 ingredients—great start. For tomorrow, let’s keep it simple: just the morning anchor; I’ll queue it for 09:00. Want me to set it?”',
+  },
+  tone_medium: {
+    id: 'tone_medium',
+    name: 'Medium',
+    intent: 'Keep momentum for someone already rolling.',
+    comparisonStandard: 'Declared plan and current season goals.',
+    scoringPolicy:
+      'Even-handed. Celebrate evidence, name misses plainly, suggest concrete fixes.',
+    feedbackStyle:
+      'Clear, friendly, direct; minimal hedging; 1–2 actionable next steps with time.',
+    accountability: 'Light commitments; check-back prompts.',
+    sampleLine:
+      '“Yesterday you planned 45 min and logged 30. For tomorrow, schedule 35 min at 08:30 and place the phone outside the room. Reply ‘set’ to confirm.”',
+  },
+  tone_hard: {
+    id: 'tone_hard',
+    name: 'Hard',
+    intent: 'Hold a motivated user to their own standard.',
+    comparisonStandard: 'Personal bests and stated caps/floors; no excuses.',
+    scoringPolicy:
+      'Strict but fair. Penalize avoidable misses; require evidence of completion.',
+    feedbackStyle:
+      'Concise, no sugarcoating, still respectful. Names trade-offs and opportunity costs.',
+    accountability: 'Firm deadlines; “reply with proof” requests; Miss-Once protocol enforced.',
+    sampleLine:
+      '“Yesterday you missed the 21:30 plan twice. Tomorrow at 21:30: write your three bullets for the day and post them here. Miss-once rule applies.”',
+  },
+  tone_superhard: {
+    id: 'tone_superhard',
+    name: 'Superhard',
+    intent: 'Serve a user who wants top-tier pressure and benchmarking.',
+    comparisonStandard:
+      'Top performers’ standards (elite habits), not average. User opted in.',
+    scoringPolicy:
+      'Demanding but fair. Grade as if coaching a high performer; minimal credit for half-measures; outcomes and adherence both count.',
+    feedbackStyle:
+      'Command style, zero fluff, consequence framing; never demeaning.',
+    accountability:
+      'Tight loops; immediate actions; proof required; automatic reschedules on fail.',
+    sampleLine:
+      '“Yesterday fell short of target. Tomorrow: start a 25-minute deep-work block at 08:30, phone out of the room; deliver output by 08:55. If missed, I’ll auto-schedule a second block at 14:00.”',
+  },
+};

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -31,6 +31,13 @@ export const notificationTypeEnum = pgEnum('notification_type', [
   'unfollow',
 ]);
 
+export const coachToneEnum = pgEnum('coach_tone', [
+  'tone_soft',
+  'tone_medium',
+  'tone_hard',
+  'tone_superhard',
+]);
+
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
   handle: varchar('handle', { length: 50 }).notNull().unique(),
@@ -44,6 +51,9 @@ export const users = pgTable('users', {
   accountVisibility: accountVisibilityEnum('account_visibility')
     .notNull()
     .default('open'),
+  coachTone: coachToneEnum('coach_tone')
+    .notNull()
+    .default('tone_medium'),
   email: text('email').notNull().unique(),
   name: text('name'),
   passwordHash: text('password_hash').notNull(),

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -3,6 +3,7 @@ import { users } from './db/schema';
 import { eq } from 'drizzle-orm';
 import { randomBytes, scryptSync, timingSafeEqual, randomUUID } from 'crypto';
 import type { Session } from 'next-auth';
+import type { CoachToneId } from './ai/coach-tone';
 
 export interface NewUser {
   email: string;
@@ -11,6 +12,7 @@ export interface NewUser {
   displayName?: string;
   avatarUrl?: string;
   accountVisibility?: 'open' | 'closed' | 'private';
+  coachTone?: CoachToneId;
   name?: string;
 }
 
@@ -37,6 +39,7 @@ export async function createUser(input: NewUser) {
       displayName: input.displayName ?? input.name,
       avatarUrl: input.avatarUrl,
       accountVisibility: input.accountVisibility ?? 'open',
+      coachTone: input.coachTone ?? 'tone_medium',
       name: input.name,
       passwordHash,
       viewId: randomUUID(),


### PR DESCRIPTION
## Summary
- define AI coach tone presets and metadata
- store coach tone preference per user
- allow selecting tone via account settings slider

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b0001f6c90832a920cf3da459fd207