### PR TITLE
Refine daily report tone handling and logging

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -230,3 +230,5 @@
 - 2025-10-27: Positioned "Generate daily rapport" button centered between cake and navigation with fixed spacing.
 - 2025-10-27: Shifted "Generate daily rapport" button 60px left of center while keeping cake and navigation stationary.
 - 2025-10-27: Moved "Generate daily rapport" button ~30px further left (about 90px total) to center under the cake without moving other elements.
+- 2025-10-27: Refined daily report system prompt with flavor-cake explanation and user-selectable coach tones.
+- 2025-10-27: Centralized coach tone config, inserted full tone detail into daily report prompt, and logged system prompt.

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -7,13 +7,18 @@ import { getFlavor } from '@/lib/flavors-store';
 import { getSubflavor } from '@/lib/subflavors-store';
 import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { DEFAULT_LLM_SETUP } from '@/lib/llm/config';
+import { getCoachTone } from '@/lib/ai/coach-tone';
 
-// Assessment agent prompt distilled from user instructions
-const SYSTEM_PROMPT = `You are the Daily Assessment agent for the Piece of Cake framework. Flavors are life domains and ingredients are the habits that add them. The user's Cake—their ethos—guides direction without a fixed destination.
+function buildSystemPrompt(toneId: string) {
+  const tone = getCoachTone(toneId);
+  return `You are the Daily Assessment agent for the Piece of Cake framework. Flavors are life domains and ingredients are the habits that add them; when combined, the flavors form the user's Cake—their ethos—which guides direction without a fixed destination.
 
-Evaluate the provided day: judge the plan's difficulty and focus, then how execution aligned with it. Be firm yet fair—higher ambitions merit tougher grading, acknowledge wins, and call out self-sabotage. Keep the tone wise and constructive.
+Evaluate the provided day: judge the plan's difficulty, focus, and potential they had on the day, then how execution aligned with it. Be firm yet fair—higher ambitions merit tougher grading, acknowledge wins, and call out self-sabotage. The tone of your assessment should be:
+${JSON.stringify(tone, null, 2)}
+Keep the tone wise and constructive.
 
 Respond ONLY with JSON of the form {"summary":string,"good":string[],"bad":string[],"observations":string[],"score":0-100}.`;
+}
 
 export async function POST(req: NextRequest) {
   const session = await auth();
@@ -29,6 +34,7 @@ export async function POST(req: NextRequest) {
   }
   const reviews = body.reviews || {};
   const ethos = body.ethos || body.rational || '';
+  const toneId = body.toneId || body.tone || 'tone_medium';
 
   const { date: dateObj, tz } = resolvePlanDate('live', session?.user as any, {
     cookies: req.cookies,
@@ -204,6 +210,8 @@ export async function POST(req: NextRequest) {
   const context = lines.join('\n');
 
   const setup = DEFAULT_LLM_SETUP;
+  const systemPrompt = buildSystemPrompt(toneId);
+  console.log('daily report system prompt', systemPrompt);
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
     return NextResponse.json(
@@ -218,7 +226,7 @@ export async function POST(req: NextRequest) {
     top_p: setup.top_p,
     max_tokens: setup.maxTokens,
     messages: [
-      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'system', content: systemPrompt },
       { role: 'user', content: context },
     ],
     response_format: { type: 'json_object' },

--- a/lib/ai/coach-tone.ts
+++ b/lib/ai/coach-tone.ts
@@ -1,0 +1,72 @@
+export interface CoachTone {
+  id: string;
+  name: string;
+  intent: string;
+  comparisonStandard: string;
+  scoringPolicy: string;
+  feedbackStyle: string;
+  accountability: string;
+  sampleLine: string;
+}
+
+export const COACH_TONES: CoachTone[] = [
+  {
+    id: 'tone_soft',
+    name: 'Soft',
+    intent: 'Supportive ramp-up for beginners.',
+    comparisonStandard: 'Declared plan and current season goals.',
+    scoringPolicy:
+      'Gentle; highlight small wins, frame misses as learning opportunities.',
+    feedbackStyle:
+      'Warm, encouraging, uses positive reinforcement; suggests easy next steps.',
+    accountability: 'Minimal, optional check-ins; cheerleading tone.',
+    sampleLine:
+      '“Great start logging 15 minutes today! Tomorrow try for 20 at 09:00 and let me know how it goes.”',
+  },
+  {
+    id: 'tone_medium',
+    name: 'Medium',
+    intent: 'Keep momentum for someone already rolling.',
+    comparisonStandard: 'Declared plan and current season goals.',
+    scoringPolicy:
+      'Even-handed. Celebrate evidence, name misses plainly, suggest concrete fixes.',
+    feedbackStyle:
+      'Clear, friendly, direct; minimal hedging; 1–2 actionable next steps with time.',
+    accountability: 'Light commitments; check-back prompts.',
+    sampleLine:
+      '“Yesterday you planned 45 min and logged 30. For tomorrow, schedule 35 min at 08:30 and place the phone outside the room. Reply ‘set’ to confirm.”',
+  },
+  {
+    id: 'tone_hard',
+    name: 'Hard',
+    intent: 'High accountability without fluff.',
+    comparisonStandard: 'Declared plan and current season goals.',
+    scoringPolicy:
+      'Tough but fair. Call out gaps, demand evidence, require follow-through.',
+    feedbackStyle:
+      'Direct, uncompromising, yet constructive; sets challenging next steps.',
+    accountability: 'Firm commitments; requires confirmation and follow-up.',
+    sampleLine:
+      '“You planned 60 and gave 20. Tomorrow lock 40 min at 06:00; no phone, check in after.”',
+  },
+  {
+    id: 'tone_superhard',
+    name: 'Super Hard',
+    intent: 'Elite performance mode with tight loops.',
+    comparisonStandard: 'Declared plan and current season goals.',
+    scoringPolicy:
+      'Relentless. Zero tolerance for excuses; praises only meaningful gains.',
+    feedbackStyle:
+      'Sharp, terse, mission-critical; mandates aggressive adjustments.',
+    accountability: 'Immediate commitments; non-negotiable check-ins.',
+    sampleLine:
+      '“Plan 60, delivered 15. At 05:30 tomorrow, do 45 focused. Send proof after. No slip.”',
+  },
+];
+
+export function getCoachTone(id: string): CoachTone {
+  return (
+    COACH_TONES.find((t) => t.id === id) ||
+    COACH_TONES.find((t) => t.id === 'tone_medium')!
+  );
+}


### PR DESCRIPTION
## Summary
- Source coach tone descriptions from a shared config and embed the selected tone's full details in the daily report prompt
- Log the generated system prompt for inspection
- Document the coach tone refactor in the update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b005159184832abac8d8f4371ea4cf