### PR TITLE
Refine daily report tone handling and logging

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -230,3 +230,6 @@
 - 2025-10-27: Positioned "Generate daily rapport" button centered between cake and navigation with fixed spacing.
 - 2025-10-27: Shifted "Generate daily rapport" button 60px left of center while keeping cake and navigation stationary.
 - 2025-10-27: Moved "Generate daily rapport" button ~30px further left (about 90px total) to center under the cake without moving other elements.
+- 2025-10-27: Refined daily report system prompt with flavor-cake explanation and user-selectable coach tones.
+- 2025-10-27: Centralized coach tone config, inserted full tone detail into daily report prompt, and logged system prompt.
+- 2025-10-27: Restored coach tone setting with API and schema, defaulting daily report prompts to the user's chosen tone.

--- a/app/(app)/settings/account/page.tsx
+++ b/app/(app)/settings/account/page.tsx
@@ -2,24 +2,36 @@
 
 import { useState, useEffect } from 'react';
 import { useViewContext } from '@/lib/view-context';
+import { COACH_TONES } from '@/lib/ai/coach-tone';
 
 export default function AccountSettingsPage() {
   const { editable } = useViewContext();
   const [visibility, setVisibility] = useState<'open' | 'closed' | 'private'>('open');
+  const [coachTone, setCoachTone] = useState('tone_medium');
   const [saving, setSaving] = useState(false);
   useEffect(() => {
     fetch('/api/account/visibility')
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => setVisibility(data?.accountVisibility ?? 'open'));
+    fetch('/api/account/coach-tone')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setCoachTone(data?.coachTone ?? 'tone_medium'));
   }, []);
 
   async function save() {
     setSaving(true);
-    await fetch('/api/account/visibility', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ accountVisibility: visibility }),
-    });
+    await Promise.all([
+      fetch('/api/account/visibility', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ accountVisibility: visibility }),
+      }),
+      fetch('/api/account/coach-tone', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ coachTone }),
+      }),
+    ]);
     setSaving(false);
   }
 
@@ -30,12 +42,30 @@ export default function AccountSettingsPage() {
         <span>Account visibility</span>
         <select
           value={visibility}
-          onChange={(e) => setVisibility(e.target.value as 'open' | 'closed' | 'private')}
+          onChange={(e) =>
+            setVisibility(e.target.value as 'open' | 'closed' | 'private')
+          }
+          disabled={!editable}
           className="rounded border px-2 py-1"
         >
           <option value="open">open</option>
           <option value="closed">closed</option>
           <option value="private">private</option>
+        </select>
+      </label>
+      <label className="flex items-center justify-between">
+        <span>Coach tone</span>
+        <select
+          value={coachTone}
+          onChange={(e) => setCoachTone(e.target.value)}
+          disabled={!editable}
+          className="rounded border px-2 py-1"
+        >
+          {COACH_TONES.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
         </select>
       </label>
       <button

--- a/app/api/account/coach-tone/route.ts
+++ b/app/api/account/coach-tone/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { COACH_TONES } from '@/lib/ai/coach-tone';
+
+export async function GET() {
+  const session = await auth();
+  const self = await ensureUser(session);
+  const userId = self.id;
+  const [user] = await db
+    .select({ coachTone: users.coachTone })
+    .from(users)
+    .where(eq(users.id, userId));
+  return NextResponse.json({ coachTone: user?.coachTone ?? 'tone_medium' });
+}
+
+export async function POST(req: Request) {
+  const session = await auth();
+  const self = await ensureUser(session);
+  const userId = self.id;
+  const body = await req.json();
+  const toneId = typeof body.coachTone === 'string' ? body.coachTone : '';
+  if (!COACH_TONES.some((t) => t.id === toneId)) {
+    return NextResponse.json({ error: 'Invalid coach tone' }, { status: 400 });
+  }
+  await db
+    .update(users)
+    .set({ coachTone: toneId, updatedAt: new Date() })
+    .where(eq(users.id, userId));
+  return NextResponse.json({ coachTone: toneId });
+}

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -7,13 +7,21 @@ import { getFlavor } from '@/lib/flavors-store';
 import { getSubflavor } from '@/lib/subflavors-store';
 import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { DEFAULT_LLM_SETUP } from '@/lib/llm/config';
+import { getCoachTone } from '@/lib/ai/coach-tone';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
 
-// Assessment agent prompt distilled from user instructions
-const SYSTEM_PROMPT = `You are the Daily Assessment agent for the Piece of Cake framework. Flavors are life domains and ingredients are the habits that add them. The user's Cake—their ethos—guides direction without a fixed destination.
+function buildSystemPrompt(toneId: string) {
+  const tone = getCoachTone(toneId);
+  return `You are the Daily Assessment agent for the Piece of Cake framework. Flavors are life domains and ingredients are the habits that add them; when combined, the flavors form the user's Cake—their ethos—which guides direction without a fixed destination.
 
-Evaluate the provided day: judge the plan's difficulty and focus, then how execution aligned with it. Be firm yet fair—higher ambitions merit tougher grading, acknowledge wins, and call out self-sabotage. Keep the tone wise and constructive.
+Evaluate the provided day: judge the plan's difficulty, focus, and potential they had on the day, then how execution aligned with it. Be firm yet fair—higher ambitions merit tougher grading, acknowledge wins, and call out self-sabotage. The tone of your assessment should be:
+${JSON.stringify(tone, null, 2)}
+Keep the tone wise and constructive.
 
 Respond ONLY with JSON of the form {"summary":string,"good":string[],"bad":string[],"observations":string[],"score":0-100}.`;
+}
 
 export async function POST(req: NextRequest) {
   const session = await auth();
@@ -29,6 +37,11 @@ export async function POST(req: NextRequest) {
   }
   const reviews = body.reviews || {};
   const ethos = body.ethos || body.rational || '';
+  const [userRow] = await db
+    .select({ coachTone: users.coachTone })
+    .from(users)
+    .where(eq(users.id, userId));
+  const toneId = body.toneId || body.tone || userRow?.coachTone || 'tone_medium';
 
   const { date: dateObj, tz } = resolvePlanDate('live', session?.user as any, {
     cookies: req.cookies,
@@ -204,6 +217,8 @@ export async function POST(req: NextRequest) {
   const context = lines.join('\n');
 
   const setup = DEFAULT_LLM_SETUP;
+  const systemPrompt = buildSystemPrompt(toneId);
+  console.log('daily report system prompt', systemPrompt);
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
     return NextResponse.json(
@@ -218,7 +233,7 @@ export async function POST(req: NextRequest) {
     top_p: setup.top_p,
     max_tokens: setup.maxTokens,
     messages: [
-      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'system', content: systemPrompt },
       { role: 'user', content: context },
     ],
     response_format: { type: 'json_object' },

--- a/drizzle/0026_add_users_coach_tone.sql
+++ b/drizzle/0026_add_users_coach_tone.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "coach_tone" text NOT NULL DEFAULT 'tone_medium';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -177,6 +177,20 @@
       "when": 1756284819557,
       "tag": "0024_add_daily_report_version",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1756284819558,
+      "tag": "0025_split_daily_report_fields",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1756284819559,
+      "tag": "0026_add_users_coach_tone",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/ai/coach-tone.ts
+++ b/lib/ai/coach-tone.ts
@@ -1,0 +1,72 @@
+export interface CoachTone {
+  id: string;
+  name: string;
+  intent: string;
+  comparisonStandard: string;
+  scoringPolicy: string;
+  feedbackStyle: string;
+  accountability: string;
+  sampleLine: string;
+}
+
+export const COACH_TONES: CoachTone[] = [
+  {
+    id: 'tone_soft',
+    name: 'Soft',
+    intent: 'Supportive ramp-up for beginners.',
+    comparisonStandard: 'Declared plan and current season goals.',
+    scoringPolicy:
+      'Gentle; highlight small wins, frame misses as learning opportunities.',
+    feedbackStyle:
+      'Warm, encouraging, uses positive reinforcement; suggests easy next steps.',
+    accountability: 'Minimal, optional check-ins; cheerleading tone.',
+    sampleLine:
+      '“Great start logging 15 minutes today! Tomorrow try for 20 at 09:00 and let me know how it goes.”',
+  },
+  {
+    id: 'tone_medium',
+    name: 'Medium',
+    intent: 'Keep momentum for someone already rolling.',
+    comparisonStandard: 'Declared plan and current season goals.',
+    scoringPolicy:
+      'Even-handed. Celebrate evidence, name misses plainly, suggest concrete fixes.',
+    feedbackStyle:
+      'Clear, friendly, direct; minimal hedging; 1–2 actionable next steps with time.',
+    accountability: 'Light commitments; check-back prompts.',
+    sampleLine:
+      '“Yesterday you planned 45 min and logged 30. For tomorrow, schedule 35 min at 08:30 and place the phone outside the room. Reply ‘set’ to confirm.”',
+  },
+  {
+    id: 'tone_hard',
+    name: 'Hard',
+    intent: 'High accountability without fluff.',
+    comparisonStandard: 'Declared plan and current season goals.',
+    scoringPolicy:
+      'Tough but fair. Call out gaps, demand evidence, require follow-through.',
+    feedbackStyle:
+      'Direct, uncompromising, yet constructive; sets challenging next steps.',
+    accountability: 'Firm commitments; requires confirmation and follow-up.',
+    sampleLine:
+      '“You planned 60 and gave 20. Tomorrow lock 40 min at 06:00; no phone, check in after.”',
+  },
+  {
+    id: 'tone_superhard',
+    name: 'Super Hard',
+    intent: 'Elite performance mode with tight loops.',
+    comparisonStandard: 'Declared plan and current season goals.',
+    scoringPolicy:
+      'Relentless. Zero tolerance for excuses; praises only meaningful gains.',
+    feedbackStyle:
+      'Sharp, terse, mission-critical; mandates aggressive adjustments.',
+    accountability: 'Immediate commitments; non-negotiable check-ins.',
+    sampleLine:
+      '“Plan 60, delivered 15. At 05:30 tomorrow, do 45 focused. Send proof after. No slip.”',
+  },
+];
+
+export function getCoachTone(id: string): CoachTone {
+  return (
+    COACH_TONES.find((t) => t.id === id) ||
+    COACH_TONES.find((t) => t.id === 'tone_medium')!
+  );
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -44,6 +44,7 @@ export const users = pgTable('users', {
   accountVisibility: accountVisibilityEnum('account_visibility')
     .notNull()
     .default('open'),
+  coachTone: text('coach_tone').notNull().default('tone_medium'),
   email: text('email').notNull().unique(),
   name: text('name'),
   passwordHash: text('password_hash').notNull(),

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -37,6 +37,7 @@ export async function createUser(input: NewUser) {
       displayName: input.displayName ?? input.name,
       avatarUrl: input.avatarUrl,
       accountVisibility: input.accountVisibility ?? 'open',
+      coachTone: 'tone_medium',
       name: input.name,
       passwordHash,
       viewId: randomUUID(),


### PR DESCRIPTION
## Summary
- Preserve users.coach_tone column with a migration and default schema
- Expose coach tone selection in account settings and API, persisting user preference
- Default daily report system prompt to the stored coach tone

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b005159184832abac8d8f4371ea4cf