### PR TITLE
Handle missing daily assessments with red calendar highlight

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -233,3 +233,4 @@
 - 2025-10-27: Refined daily report system prompt with flavor-cake explanation and user-selectable coach tones.
 - 2025-10-27: Centralized coach tone config, inserted full tone detail into daily report prompt, and logged system prompt.
 - 2025-10-27: Restored coach tone setting with API and schema, defaulting daily report prompts to the user's chosen tone.
+- 2025-10-27: Displayed "No Assessment" placeholders for days without daily reports and highlighted those dates red in the calendar.

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -3,87 +3,117 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { redirect } from 'next/navigation';
 import { listDailyReports } from '@/lib/daily-report-store';
+import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
 
 export async function DailyReportsHome({ userId }: { userId: number }) {
-  const reports = await listDailyReports(userId);
+  const [reports, snapshots] = await Promise.all([
+    listDailyReports(userId),
+    listProfileSnapshotDates(userId),
+  ]);
+  const reportMap = new Map<string, (typeof reports)[number]>();
+  for (const r of reports) {
+    if (!reportMap.has(r.date)) reportMap.set(r.date, r);
+  }
+  const allDates = Array.from(
+    new Set([...snapshots, ...reports.map((r) => r.date)]),
+  ).sort((a, b) => (a < b ? 1 : -1));
+  const items = allDates.map(
+    (date) => reportMap.get(date) ?? { date, missing: true as const },
+  );
   return (
     <main className="p-6">
       <h1 className="mb-4 text-2xl font-bold">Daily Reports</h1>
       <ul className="space-y-4" id={`d41lyrep-list-${userId}`}>
-        {reports.map((r) => (
-          <li
-            key={r.slug}
-            className="rounded border p-4"
-            id={`d41lyrep-item-${r.slug}-${userId}`}
-          >
-            <div className="flex items-center justify-between">
-              <h2
-                className="font-semibold"
-                id={`d41lyrep-date-${r.slug}-${userId}`}
-              >
-                {r.date}
-                {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
-              </h2>
-              <span
-                className="font-semibold"
-                id={`d41lyrep-score-${r.slug}-${userId}`}
-              >
-                {r.score}
-              </span>
-            </div>
-            {r.summary && (
-              <p
-                className="mt-2 whitespace-pre-wrap"
-                id={`d41lyrep-sum-${r.slug}-${userId}`}
-              >
-                {r.summary}
-              </p>
-            )}
-            {r.good.length > 0 && (
-              <div className="mt-2" id={`d41lyrep-good-${r.slug}-${userId}`}>
-                <h3 className="font-semibold">What went well</h3>
-                <ul className="list-disc pl-4">
-                  {r.good.map((g, i) => (
-                    <li key={i} id={`d41lyrep-good-${i}-${r.slug}-${userId}`}>
-                      {g}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            {r.bad.length > 0 && (
-              <div className="mt-2" id={`d41lyrep-bad-${r.slug}-${userId}`}>
-                <h3 className="font-semibold">What went bad</h3>
-                <ul className="list-disc pl-4">
-                  {r.bad.map((b, i) => (
-                    <li key={i} id={`d41lyrep-bad-${i}-${r.slug}-${userId}`}>
-                      {b}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            {r.observations.length > 0 && (
-              <div className="mt-2" id={`d41lyrep-obs-${r.slug}-${userId}`}>
-                <h3 className="font-semibold">Observations</h3>
-                <ul className="list-disc pl-4">
-                  {r.observations.map((o, i) => (
-                    <li key={i} id={`d41lyrep-obs-${i}-${r.slug}-${userId}`}>
-                      {o}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <Link
-              href={r.slug}
-              className="mt-2 block text-sm text-orange-600 hover:underline"
-              id={`d41lyrep-link-${r.slug}-${userId}`}
+        {items.map((r) =>
+          'missing' in r ? (
+            <li
+              key={r.date}
+              className="rounded border p-4"
+              id={`d41lyrep-miss-${r.date}-${userId}`}
             >
-              View details
-            </Link>
-          </li>
-        ))}
+              <div className="flex items-center justify-between">
+                <h2 className="font-semibold">{r.date}</h2>
+                <span className="font-semibold text-red-600">No Assessment</span>
+              </div>
+              <p className="mt-2 text-sm text-zinc-600">
+                This day the user did not generate a daily assessment.
+              </p>
+            </li>
+          ) : (
+            <li
+              key={r.slug}
+              className="rounded border p-4"
+              id={`d41lyrep-item-${r.slug}-${userId}`}
+            >
+              <div className="flex items-center justify-between">
+                <h2
+                  className="font-semibold"
+                  id={`d41lyrep-date-${r.slug}-${userId}`}
+                >
+                  {r.date}
+                  {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
+                </h2>
+                <span
+                  className="font-semibold"
+                  id={`d41lyrep-score-${r.slug}-${userId}`}
+                >
+                  {r.score}
+                </span>
+              </div>
+              {r.summary && (
+                <p
+                  className="mt-2 whitespace-pre-wrap"
+                  id={`d41lyrep-sum-${r.slug}-${userId}`}
+                >
+                  {r.summary}
+                </p>
+              )}
+              {r.good.length > 0 && (
+                <div className="mt-2" id={`d41lyrep-good-${r.slug}-${userId}`}>
+                  <h3 className="font-semibold">What went well</h3>
+                  <ul className="list-disc pl-4">
+                    {r.good.map((g, i) => (
+                      <li key={i} id={`d41lyrep-good-${i}-${r.slug}-${userId}`}>
+                        {g}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {r.bad.length > 0 && (
+                <div className="mt-2" id={`d41lyrep-bad-${r.slug}-${userId}`}>
+                  <h3 className="font-semibold">What went bad</h3>
+                  <ul className="list-disc pl-4">
+                    {r.bad.map((b, i) => (
+                      <li key={i} id={`d41lyrep-bad-${i}-${r.slug}-${userId}`}>
+                        {b}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {r.observations.length > 0 && (
+                <div className="mt-2" id={`d41lyrep-obs-${r.slug}-${userId}`}>
+                  <h3 className="font-semibold">Observations</h3>
+                  <ul className="list-disc pl-4">
+                    {r.observations.map((o, i) => (
+                      <li key={i} id={`d41lyrep-obs-${i}-${r.slug}-${userId}`}>
+                        {o}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              <Link
+                href={r.slug}
+                className="mt-2 block text-sm text-orange-600 hover:underline"
+                id={`d41lyrep-link-${r.slug}-${userId}`}
+              >
+                View details
+              </Link>
+            </li>
+          ),
+        )}
       </ul>
     </main>
   );

--- a/components/calendar/side-calendar.tsx
+++ b/components/calendar/side-calendar.tsx
@@ -105,7 +105,9 @@ export function SideCalendar({
                       : 'text-zinc-400 cursor-default',
                     hasReport
                       ? 'bg-green-500 text-white'
-                      : isToday && 'bg-orange-500 text-white font-bold',
+                      : hasSnap
+                        ? 'bg-red-500 text-white'
+                        : isToday && 'bg-orange-500 text-white font-bold',
                   )}
                 >
                   {date.getDate()}


### PR DESCRIPTION
## Summary
- show "No Assessment" card when a day lacks a daily report
- mark calendar dates without reports in red

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*
- `pnpm format` *(fails: Command "format" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0105c9e20832ab700aea5db1e30a8