### PR TITLE
feat: display coach tone on daily reports

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -199,6 +199,7 @@ Modal form IDs:
 - `d41lyrep-item-{slug}-{ownerId}` → single daily report entry in list.
 - `d41lyrep-date-{slug}-{ownerId}` → date heading in list entry.
 - `d41lyrep-score-{slug}-{ownerId}` → score badge in list entry.
+- `d41lyrep-tone-{slug}-{ownerId}` → coach tone label in list entry or detail.
 - `d41lyrep-sum-{slug}-{ownerId}` → summary text snippet in list entry.
 - `d41lyrep-good-{index}-{slug}-{ownerId}` → good item in list entry.
 - `d41lyrep-bad-{index}-{slug}-{ownerId}` → bad item in list entry.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -234,3 +234,4 @@
 - 2025-10-27: Centralized coach tone config, inserted full tone detail into daily report prompt, and logged system prompt.
 - 2025-10-27: Restored coach tone setting with API and schema, defaulting daily report prompts to the user's chosen tone.
 - 2025-10-27: Displayed "No Assessment" placeholders for days without daily reports and highlighted those dates red in the calendar.
+- 2025-10-27: Stored coach tone on daily reports and showed difficulty labels alongside scores in daily progress pages.

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -41,7 +41,8 @@ export async function POST(req: NextRequest) {
     .select({ coachTone: users.coachTone })
     .from(users)
     .where(eq(users.id, userId));
-  const toneId = body.toneId || body.tone || userRow?.coachTone || 'tone_medium';
+  const toneId =
+    body.toneId || body.tone || userRow?.coachTone || 'tone_medium';
 
   const { date: dateObj, tz } = resolvePlanDate('live', session?.user as any, {
     cookies: req.cookies,
@@ -269,7 +270,7 @@ export async function POST(req: NextRequest) {
         ? parsed.observations
         : [],
     };
-    await createDailyReport(userId, targetDate, content, score);
+    await createDailyReport(userId, targetDate, content, score, toneId);
     console.log('daily report saved', { userId, date: targetDate, score });
     return NextResponse.json({ report: parsed, score, context });
   } catch (e: any) {

--- a/app/progress/overview/daily/[date]/page.tsx
+++ b/app/progress/overview/daily/[date]/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { getDailyReport } from '@/lib/daily-report-store';
+import { getCoachTone } from '@/lib/ai/coach-tone';
 import { redirect, notFound } from 'next/navigation';
 
 export async function DailyReportDetailView({
@@ -12,17 +13,30 @@ export async function DailyReportDetailView({
 }) {
   const report = await getDailyReport(userId, slug);
   if (!report) notFound();
-  const { summary, good, bad, observations } = report;
+  const { summary, good, bad, observations, coachTone } = report;
   return (
     <main className="p-6">
-      <h1 className="mb-4 text-2xl font-bold" id={`d41lyrep-title-${slug}-${userId}`}>
+      <h1
+        className="mb-4 text-2xl font-bold"
+        id={`d41lyrep-title-${slug}-${userId}`}
+      >
         Report for {report.date}
-        {report.version > 1 && <span className="ml-1">(v{report.version})</span>}
+        {report.version > 1 && (
+          <span className="ml-1">(v{report.version})</span>
+        )}
       </h1>
-      <p className="mb-4 font-semibold" id={`d41lyrep-score-${slug}-${userId}`}>
-        Score: {report.score}
+      <p className="mb-4 font-semibold">
+        <span id={`d41lyrep-tone-${slug}-${userId}`}>
+          {getCoachTone(coachTone).name}
+        </span>
+        <span className="ml-2" id={`d41lyrep-score-${slug}-${userId}`}>
+          Score: {report.score}
+        </span>
       </p>
-      <pre className="whitespace-pre-wrap" id={`d41lyrep-sum-${slug}-${userId}`}>
+      <pre
+        className="whitespace-pre-wrap"
+        id={`d41lyrep-sum-${slug}-${userId}`}
+      >
         {summary}
       </pre>
       {good.length > 0 && (

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -3,6 +3,7 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { redirect } from 'next/navigation';
 import { listDailyReports } from '@/lib/daily-report-store';
+import { getCoachTone } from '@/lib/ai/coach-tone';
 import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
 
 export async function DailyReportsHome({ userId }: { userId: number }) {
@@ -33,7 +34,9 @@ export async function DailyReportsHome({ userId }: { userId: number }) {
             >
               <div className="flex items-center justify-between">
                 <h2 className="font-semibold">{r.date}</h2>
-                <span className="font-semibold text-red-600">No Assessment</span>
+                <span className="font-semibold text-red-600">
+                  No Assessment
+                </span>
               </div>
               <p className="mt-2 text-sm text-zinc-600">
                 This day the user did not generate a daily assessment.
@@ -51,14 +54,24 @@ export async function DailyReportsHome({ userId }: { userId: number }) {
                   id={`d41lyrep-date-${r.slug}-${userId}`}
                 >
                   {r.date}
-                  {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
+                  {r.version > 1 && (
+                    <span className="ml-1">(v{r.version})</span>
+                  )}
                 </h2>
-                <span
-                  className="font-semibold"
-                  id={`d41lyrep-score-${r.slug}-${userId}`}
-                >
-                  {r.score}
-                </span>
+                <div className="flex items-center gap-2">
+                  <span
+                    className="font-semibold"
+                    id={`d41lyrep-tone-${r.slug}-${userId}`}
+                  >
+                    {getCoachTone(r.coachTone).name}
+                  </span>
+                  <span
+                    className="font-semibold"
+                    id={`d41lyrep-score-${r.slug}-${userId}`}
+                  >
+                    {r.score}
+                  </span>
+                </div>
               </div>
               {r.summary && (
                 <p

--- a/lib/daily-report-store.ts
+++ b/lib/daily-report-store.ts
@@ -42,6 +42,7 @@ export async function listDailyReports(userId: number): Promise<
     slug: string;
     version: number;
     score: number;
+    coachTone: string;
     summary: string;
     good: string[];
     bad: string[];
@@ -57,6 +58,7 @@ export async function listDailyReports(userId: number): Promise<
       bad: dailyReports.bad,
       observations: dailyReports.observations,
       version: dailyReports.version,
+      coachTone: dailyReports.coachTone,
     })
     .from(dailyReports)
     .where(eq(dailyReports.userId, userId))
@@ -69,6 +71,7 @@ export async function listDailyReports(userId: number): Promise<
       slug: slugFromDate(ymd, version),
       version,
       score: r.score ?? 0,
+      coachTone: r.coachTone ?? 'tone_medium',
       summary: r.summary ?? '',
       good: parseList(r.good),
       bad: parseList(r.bad),
@@ -103,6 +106,7 @@ export async function getDailyReport(
     bad: parseList(row.bad),
     observations: parseList(row.observations),
     score: row.score ?? 0,
+    coachTone: row.coachTone ?? 'tone_medium',
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
   };
 }
@@ -112,6 +116,7 @@ export async function createDailyReport(
   date: string,
   content: ReportContent,
   score: number,
+  coachTone: string,
 ): Promise<void> {
   const ymd = new Date(date).toISOString().slice(0, 10);
   try {
@@ -129,6 +134,7 @@ export async function createDailyReport(
       good: JSON.stringify(content.good ?? []),
       bad: JSON.stringify(content.bad ?? []),
       observations: JSON.stringify(content.observations ?? []),
+      coachTone,
       score,
       version: nextVersion,
     });
@@ -137,12 +143,14 @@ export async function createDailyReport(
       date: ymd,
       version: nextVersion,
       score,
+      coachTone,
     });
   } catch (error) {
     console.error('createDailyReport failed', {
       userId,
       date: ymd,
       score,
+      coachTone,
       content,
       error,
     });

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -250,6 +250,7 @@ export const dailyReports = pgTable(
     good: text('good').notNull().default('[]'),
     bad: text('bad').notNull().default('[]'),
     observations: text('observations').notNull().default('[]'),
+    coachTone: text('coach_tone').notNull().default('tone_medium'),
     score: integer('score').notNull(),
     version: integer('version').notNull().default(1),
     createdAt: timestamp('created_at').defaultNow(),

--- a/types/report.ts
+++ b/types/report.ts
@@ -15,5 +15,6 @@ export interface DailyReport {
   bad: string[];
   observations: string[];
   score: number;
+  coachTone: string;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- persist coach tone for each daily report
- show difficulty label beside scores on daily report list and detail pages

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b019971484832aaa085c19637721e0