### PR TITLE
feat: add weekly assessment agent

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -235,3 +235,5 @@
 - 2025-10-27: Restored coach tone setting with API and schema, defaulting daily report prompts to the user's chosen tone.
 - 2025-10-27: Displayed "No Assessment" placeholders for days without daily reports and highlighted those dates red in the calendar.
 - 2025-10-27: Stored coach tone on daily reports and showed difficulty labels alongside scores in daily progress pages.
+- 2025-10-27: Added weekly assessment agent with generation button, API route, database storage, and overview pages including difficulty labels.
+- 2025-10-27: Prefixed weekly assessment context with the user's rational, skipped days before account creation, and limited weekly generation to Monday–Sunday ranges.

--- a/app/(view)/view/[viewId]/progress/overview/weekly/[range]/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/weekly/[range]/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { WeeklyReportDetailView } from '@/app/progress/overview/weekly/[range]/page';
+
+export default async function ViewWeeklyReportDetail({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string; range: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId, range } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-weekly-${user.id}-${range}`}>
+        <WeeklyReportDetailView userId={user.id} slug={range} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/(view)/view/[viewId]/progress/overview/weekly/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/weekly/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { WeeklyReportsHome } from '@/app/progress/overview/weekly/page';
+
+export default async function ViewWeeklyReportsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-weekly-${user.id}`}>
+        <WeeklyReportsHome userId={user.id} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/api/progress/weekly-report/route.ts
+++ b/app/api/progress/weekly-report/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { createWeeklyReport } from '@/lib/weekly-report-store';
+import { listDailyReports } from '@/lib/daily-report-store';
+import { DEFAULT_LLM_SETUP } from '@/lib/llm/config';
+import { getCoachTone } from '@/lib/ai/coach-tone';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+function buildSystemPrompt(toneId: string) {
+  const tone = getCoachTone(toneId);
+  return `You are the Weekly Assessment agent for the Piece of Cake framework, you will receive from everyday of the week an assessment of how the user performed that day, your goal is to evaluate the week and output an assessment based on it. Flavors are life domains and ingredients are the habits that add them; when combined, the flavors form the user's Cake—their ethos—which guides direction without a fixed destination.Evaluate the provided day: judge the plan's difficulty, focus, and potential they had on the day, then how execution aligned with it. Be firm yet fair—higher ambitions merit tougher grading, acknowledge wins, and call out self-sabotage. The tone of your assessment should be: ${JSON.stringify(tone, null, 2)} Keep the tone wise and constructive.Respond ONLY with JSON of the form {"summary":string,"good":string[],"bad":string[],"observations":string[],"score":0-100}.`;
+}
+
+function toYMD(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  const paramUserId = Number(req.nextUrl.searchParams.get('userId'));
+  const userId = paramUserId || Number(session?.user?.id);
+  if (!userId)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  let body: any = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const start = body.startDate || body.start;
+  const end = body.endDate || body.end;
+  if (!start || !end)
+    return NextResponse.json({ error: 'Missing date range' }, { status: 400 });
+
+  const [userRow] = await db
+    .select({ coachTone: users.coachTone, createdAt: users.createdAt })
+    .from(users)
+    .where(eq(users.id, userId));
+  const toneId = body.toneId || userRow?.coachTone || 'tone_medium';
+  const accountStart = userRow?.createdAt
+    ? toYMD(new Date(userRow.createdAt))
+    : null;
+
+  const daily = await listDailyReports(userId);
+  const map = new Map(daily.map((r) => [r.date, r]));
+
+  const startDate = new Date(start);
+  const lines: string[] = [];
+  const rational = body.ethos || body.rational || '';
+  lines.push(`The life ethos/goal of the person is: ${rational}`);
+  lines.push(
+    "This is the context one which you have to base you're assessment:",
+  );
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(startDate);
+    d.setUTCDate(startDate.getUTCDate() + i);
+    const ymd = toYMD(d);
+    const rpt = map.get(ymd);
+    lines.push(ymd);
+    if (rpt) {
+      lines.push(`summary: ${rpt.summary}`);
+      if (rpt.good.length) lines.push(`good: ${rpt.good.join('; ')}`);
+      if (rpt.bad.length) lines.push(`bad: ${rpt.bad.join('; ')}`);
+      if (rpt.observations.length)
+        lines.push(`observations: ${rpt.observations.join('; ')}`);
+      lines.push(`score: ${rpt.score}`);
+    } else if (accountStart && ymd < accountStart) {
+      lines.push('No Account');
+      lines.push('The user did not have an account on this day yet.');
+    } else {
+      lines.push('No Assessment');
+      lines.push('This day the user did not generate a daily assessment.');
+    }
+    lines.push('-----------------');
+  }
+  const context = lines.join('\n');
+
+  const setup = DEFAULT_LLM_SETUP;
+  const systemPrompt = buildSystemPrompt(toneId);
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Missing OpenAI API key' },
+      { status: 500 },
+    );
+  }
+
+  const reqBody = {
+    model: setup.model,
+    temperature: setup.temperature,
+    top_p: setup.top_p,
+    max_tokens: setup.maxTokens,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: context },
+    ],
+    response_format: { type: 'json_object' },
+  } as any;
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(reqBody),
+    });
+    const raw = await aiRes.text();
+    if (!aiRes.ok) {
+      return NextResponse.json({ error: raw }, { status: aiRes.status });
+    }
+    const data = JSON.parse(raw);
+    const msg = data.choices?.[0]?.message?.content ?? '{}';
+    let parsed: any = {};
+    try {
+      parsed = JSON.parse(msg);
+    } catch {
+      parsed = { summary: msg, good: [], bad: [], observations: [], score: 0 };
+    }
+    const score = Number(parsed.score) || 0;
+    const content = {
+      summary: parsed.summary || '',
+      good: Array.isArray(parsed.good) ? parsed.good : [],
+      bad: Array.isArray(parsed.bad) ? parsed.bad : [],
+      observations: Array.isArray(parsed.observations)
+        ? parsed.observations
+        : [],
+    };
+    await createWeeklyReport(userId, start, end, content, score, toneId);
+    console.log('weekly report saved', { userId, start, end, score });
+    return NextResponse.json({ report: parsed, score, context });
+  } catch (e: any) {
+    console.error('weekly-report generation failed', e);
+    return NextResponse.json(
+      {
+        error: e.message || 'LLM request failed',
+        cause: e?.cause?.message,
+        context,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -4,6 +4,7 @@ import { ensureUser } from '@/lib/users';
 import { redirect } from 'next/navigation';
 import { listDailyReports } from '@/lib/daily-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
+import { getDifficultyLabel } from '@/lib/ai/difficulty';
 import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
 
 export async function DailyReportsHome({ userId }: { userId: number }) {
@@ -70,6 +71,12 @@ export async function DailyReportsHome({ userId }: { userId: number }) {
                     id={`d41lyrep-score-${r.slug}-${userId}`}
                   >
                     {r.score}
+                  </span>
+                  <span
+                    className="ml-1 text-sm text-zinc-600"
+                    id={`d41lyrep-diff-${r.slug}-${userId}`}
+                  >
+                    {getDifficultyLabel(r.score)}
                   </span>
                 </div>
               </div>

--- a/app/progress/overview/weekly/[range]/page.tsx
+++ b/app/progress/overview/weekly/[range]/page.tsx
@@ -1,54 +1,54 @@
 import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
-import { getDailyReport } from '@/lib/daily-report-store';
+import { getWeeklyReport } from '@/lib/weekly-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
 import { redirect, notFound } from 'next/navigation';
 
-export async function DailyReportDetailView({
+export async function WeeklyReportDetailView({
   userId,
   slug,
 }: {
   userId: number;
   slug: string;
 }) {
-  const report = await getDailyReport(userId, slug);
+  const report = await getWeeklyReport(userId, slug);
   if (!report) notFound();
   const { summary, good, bad, observations, coachTone } = report;
   return (
     <main className="p-6">
       <h1
         className="mb-4 text-2xl font-bold"
-        id={`d41lyrep-title-${slug}-${userId}`}
+        id={`w33klyrep-title-${slug}-${userId}`}
       >
-        Report for {report.date}
+        Report for {report.startDate} – {report.endDate}
         {report.version > 1 && (
           <span className="ml-1">(v{report.version})</span>
         )}
       </h1>
       <p className="mb-4 font-semibold">
-        <span id={`d41lyrep-tone-${slug}-${userId}`}>
+        <span id={`w33klyrep-tone-${slug}-${userId}`}>
           {getCoachTone(coachTone).name}
         </span>
-        <span className="ml-2" id={`d41lyrep-score-${slug}-${userId}`}>
+        <span className="ml-2" id={`w33klyrep-score-${slug}-${userId}`}>
           Score: {report.score}
         </span>
-        <span className="ml-2" id={`d41lyrep-diff-${slug}-${userId}`}>
+        <span className="ml-2" id={`w33klyrep-diff-${slug}-${userId}`}>
           {getDifficultyLabel(report.score)}
         </span>
       </p>
       <pre
         className="whitespace-pre-wrap"
-        id={`d41lyrep-sum-${slug}-${userId}`}
+        id={`w33klyrep-sum-${slug}-${userId}`}
       >
         {summary}
       </pre>
       {good.length > 0 && (
-        <div className="mt-4" id={`d41lyrep-good-${slug}-${userId}`}>
+        <div className="mt-4" id={`w33klyrep-good-${slug}-${userId}`}>
           <h2 className="font-semibold">What went well</h2>
           <ul className="list-disc pl-4">
             {good.map((g: string, i: number) => (
-              <li key={i} id={`d41lyrep-good-${i}-${slug}-${userId}`}>
+              <li key={i} id={`w33klyrep-good-${i}-${slug}-${userId}`}>
                 {g}
               </li>
             ))}
@@ -56,11 +56,11 @@ export async function DailyReportDetailView({
         </div>
       )}
       {bad.length > 0 && (
-        <div className="mt-4" id={`d41lyrep-bad-${slug}-${userId}`}>
+        <div className="mt-4" id={`w33klyrep-bad-${slug}-${userId}`}>
           <h2 className="font-semibold">What went bad</h2>
           <ul className="list-disc pl-4">
             {bad.map((g: string, i: number) => (
-              <li key={i} id={`d41lyrep-bad-${i}-${slug}-${userId}`}>
+              <li key={i} id={`w33klyrep-bad-${i}-${slug}-${userId}`}>
                 {g}
               </li>
             ))}
@@ -68,11 +68,11 @@ export async function DailyReportDetailView({
         </div>
       )}
       {observations.length > 0 && (
-        <div className="mt-4" id={`d41lyrep-obs-${slug}-${userId}`}>
+        <div className="mt-4" id={`w33klyrep-obs-${slug}-${userId}`}>
           <h2 className="font-semibold">Observations</h2>
           <ul className="list-disc pl-4">
             {observations.map((g: string, i: number) => (
-              <li key={i} id={`d41lyrep-obs-${i}-${slug}-${userId}`}>
+              <li key={i} id={`w33klyrep-obs-${i}-${slug}-${userId}`}>
                 {g}
               </li>
             ))}
@@ -83,13 +83,13 @@ export async function DailyReportDetailView({
   );
 }
 
-export default async function DailyReportDetail({
+export default async function WeeklyReportDetail({
   params,
 }: {
-  params: { date: string };
+  params: { range: string };
 }) {
   const session = await auth();
   if (!session) redirect('/signin');
   const me = await ensureUser(session);
-  return <DailyReportDetailView userId={me.id} slug={params.date} />;
+  return <WeeklyReportDetailView userId={me.id} slug={params.range} />;
 }

--- a/app/progress/overview/weekly/page.tsx
+++ b/app/progress/overview/weekly/page.tsx
@@ -1,0 +1,113 @@
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { redirect } from 'next/navigation';
+import { listWeeklyReports } from '@/lib/weekly-report-store';
+import { getCoachTone } from '@/lib/ai/coach-tone';
+import { getDifficultyLabel } from '@/lib/ai/difficulty';
+
+export async function WeeklyReportsHome({ userId }: { userId: number }) {
+  const reports = await listWeeklyReports(userId);
+  return (
+    <main className="p-6">
+      <h1 className="mb-4 text-2xl font-bold">Weekly Reports</h1>
+      <ul className="space-y-4" id={`w33klyrep-list-${userId}`}>
+        {reports.map((r) => (
+          <li
+            key={r.slug}
+            className="rounded border p-4"
+            id={`w33klyrep-item-${r.slug}-${userId}`}
+          >
+            <div className="flex items-center justify-between">
+              <h2
+                className="font-semibold"
+                id={`w33klyrep-date-${r.slug}-${userId}`}
+              >
+                {r.startDate} – {r.endDate}
+                {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
+              </h2>
+              <div className="flex items-center gap-2">
+                <span
+                  className="font-semibold"
+                  id={`w33klyrep-tone-${r.slug}-${userId}`}
+                >
+                  {getCoachTone(r.coachTone).name}
+                </span>
+                <span
+                  className="font-semibold"
+                  id={`w33klyrep-score-${r.slug}-${userId}`}
+                >
+                  {r.score}
+                </span>
+                <span
+                  className="ml-1 text-sm text-zinc-600"
+                  id={`w33klyrep-diff-${r.slug}-${userId}`}
+                >
+                  {getDifficultyLabel(r.score)}
+                </span>
+              </div>
+            </div>
+            {r.summary && (
+              <p
+                className="mt-2 whitespace-pre-wrap"
+                id={`w33klyrep-sum-${r.slug}-${userId}`}
+              >
+                {r.summary}
+              </p>
+            )}
+            {r.good.length > 0 && (
+              <div className="mt-2" id={`w33klyrep-good-${r.slug}-${userId}`}>
+                <h3 className="font-semibold">What went well</h3>
+                <ul className="list-disc pl-4">
+                  {r.good.map((g, i) => (
+                    <li key={i} id={`w33klyrep-good-${i}-${r.slug}-${userId}`}>
+                      {g}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {r.bad.length > 0 && (
+              <div className="mt-2" id={`w33klyrep-bad-${r.slug}-${userId}`}>
+                <h3 className="font-semibold">What went bad</h3>
+                <ul className="list-disc pl-4">
+                  {r.bad.map((b, i) => (
+                    <li key={i} id={`w33klyrep-bad-${i}-${r.slug}-${userId}`}>
+                      {b}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {r.observations.length > 0 && (
+              <div className="mt-2" id={`w33klyrep-obs-${r.slug}-${userId}`}>
+                <h3 className="font-semibold">Observations</h3>
+                <ul className="list-disc pl-4">
+                  {r.observations.map((o, i) => (
+                    <li key={i} id={`w33klyrep-obs-${i}-${r.slug}-${userId}`}>
+                      {o}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <Link
+              href={r.slug}
+              className="mt-2 block text-sm text-orange-600 hover:underline"
+              id={`w33klyrep-link-${r.slug}-${userId}`}
+            >
+              View details
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+
+export default async function WeeklyReportsPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  return <WeeklyReportsHome userId={me.id} />;
+}

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -9,6 +9,7 @@ import { useViewContext } from '@/lib/view-context';
 import { hrefFor, type Section } from '@/lib/navigation';
 import TimeMachine from '@/components/dev/time-machine';
 import { GenerateDailyReportButton } from '@/components/progress/generate-daily-report-button';
+import { GenerateWeeklyReportButton } from '@/components/progress/generate-weekly-report-button';
 
 export function CakeNavigation() {
   const router = useRouter();
@@ -138,13 +139,14 @@ export function CakeNavigation() {
       <div className="grid w-full place-items-center relative">
         {ctx.editable && (
           <div
-            className="absolute -translate-x-1/2"
+            className="absolute -translate-x-1/2 flex gap-2"
             style={{
               top: '-66px',
-              left: 'calc(50% - 90px)', // nudge left ~90px from center
+              left: '50%',
             }}
           >
             <GenerateDailyReportButton userId={ctx.ownerId} />
+            <GenerateWeeklyReportButton userId={ctx.ownerId} />
           </div>
         )}
         <nav

--- a/components/progress/generate-weekly-report-button.tsx
+++ b/components/progress/generate-weekly-report-button.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useLogs } from '@/components/dev/logs-provider';
+import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+function toYMD(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function GenerateWeeklyReportButton({
+  userId,
+  className,
+}: {
+  userId: number;
+  className?: string;
+}) {
+  const [loading, setLoading] = useState(false);
+  const { addLog } = useLogs();
+  const router = useRouter();
+  const [message, setMessage] = useState<string | null>(null);
+  const [needsCode, setNeedsCode] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const [range, setRange] = useState<{ start: string; end: string } | null>(
+    null,
+  );
+
+  const currentDate = useCallback(() => {
+    const params = new URLSearchParams(window.location.search);
+    params.set('userId', String(userId));
+    const dateParam = params.get('apoc_date');
+    let date = dateParam || '';
+    if (!date) {
+      const match = document.cookie.match(/apoc_clock=([^;]+)/);
+      if (match) {
+        const d = new Date(decodeURIComponent(match[1]));
+        if (!isNaN(d.getTime())) date = d.toISOString().slice(0, 10);
+      }
+      if (!date) date = new Date().toISOString().slice(0, 10);
+    }
+    return { date, params };
+  }, [userId]);
+
+  useEffect(() => {
+    const { date } = currentDate();
+    const today = new Date(date);
+    const day = today.getUTCDay();
+    let end = new Date(today);
+    let show = false;
+    if (day === 0) {
+      // Sunday: allow generation only if daily report for today exists
+      const dailyKey = `daily-report-generated-${userId}-${date}`;
+      show = window.localStorage.getItem(dailyKey) === 'true';
+    } else if (day === 1) {
+      // Monday: allow generation regardless of Sunday's daily status
+      end.setUTCDate(end.getUTCDate() - 1);
+      show = true;
+    } else {
+      // Other days: compute last Sunday range but hide button
+      end.setUTCDate(end.getUTCDate() - day);
+    }
+    const start = new Date(end);
+    start.setUTCDate(end.getUTCDate() - 6);
+    const startStr = toYMD(start);
+    const endStr = toYMD(end);
+    setRange({ start: startStr, end: endStr });
+    const key = `weekly-report-generated-${userId}-${startStr}`;
+    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    setVisible(show);
+  }, [currentDate, userId]);
+
+  if (!visible || !range) return null;
+
+  const onClick = async () => {
+    if (needsCode) {
+      const code = window
+        .prompt('Enter code to generate a new weekly report')
+        ?.trim();
+      if (code !== 'cake2025') return;
+    }
+    setLoading(true);
+    const { params } = currentDate();
+    const ethos = window.localStorage.getItem('review-rational') || '';
+    const body = { start: range.start, end: range.end, ethos };
+    const url = `/api/progress/weekly-report?${params.toString()}`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    addLog({
+      request: data.context || JSON.stringify(body),
+      response: JSON.stringify(data.report ?? data),
+    });
+    setLoading(false);
+    if (data.error) {
+      setMessage(data.error);
+    } else {
+      setMessage(
+        `Weekly rapport is created. Your score for this week is: ${data.score}`,
+      );
+      const key = `weekly-report-generated-${userId}-${range.start}`;
+      window.localStorage.setItem(key, 'true');
+      setNeedsCode(true);
+      router.refresh();
+    }
+  };
+
+  return (
+    <div className={cn('flex flex-col items-center', className)}>
+      <Button
+        onClick={onClick}
+        disabled={loading}
+        className={cn(
+          'flex items-center gap-2 text-white',
+          needsCode
+            ? 'bg-orange-500 hover:bg-orange-600'
+            : 'bg-green-500 hover:bg-green-600',
+        )}
+      >
+        {loading && (
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+        )}
+        {loading
+          ? 'Generating…'
+          : `Generate weekly rapport for ${range.start} - ${range.end}`}
+      </Button>
+      {message && <p className="mt-2 text-sm">{message}</p>}
+    </div>
+  );
+}

--- a/lib/ai/difficulty.ts
+++ b/lib/ai/difficulty.ts
@@ -1,0 +1,5 @@
+export function getDifficultyLabel(score: number): string {
+  if (score >= 70) return 'Hard';
+  if (score >= 40) return 'Medium';
+  return 'Easy';
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -261,3 +261,28 @@ export const dailyReports = pgTable(
     ).on(table.userId, table.date, table.version),
   }),
 );
+
+export const weeklyReports = pgTable(
+  'weekly_reports',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    startDate: date('start_date').notNull(),
+    endDate: date('end_date').notNull(),
+    summary: text('summary').notNull().default(''),
+    good: text('good').notNull().default('[]'),
+    bad: text('bad').notNull().default('[]'),
+    observations: text('observations').notNull().default('[]'),
+    coachTone: text('coach_tone').notNull().default('tone_medium'),
+    score: integer('score').notNull(),
+    version: integer('version').notNull().default(1),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserWeekVersion: uniqueIndex(
+      'weekly_reports_user_week_version_unique',
+    ).on(table.userId, table.startDate, table.version),
+  }),
+);

--- a/lib/weekly-report-store.ts
+++ b/lib/weekly-report-store.ts
@@ -1,0 +1,173 @@
+import { db } from './db';
+import { weeklyReports } from './db/schema';
+import { eq, and, desc, sql } from 'drizzle-orm';
+import type { WeeklyReport, ReportContent } from '@/types/report';
+
+function slugFromRange(start: string, end: string, version = 1): string {
+  const [ys, ms, ds] = start.split('-');
+  const [ye, me, de] = end.split('-');
+  const base = `${ds}${ms}${ys}-${de}${me}${ye}`;
+  return version > 1 ? `${base}V${version}` : base;
+}
+
+function parseSlug(slug: string): {
+  start: string;
+  end: string;
+  version: number;
+} {
+  const match = /^(\d{2})(\d{2})(\d{4})-(\d{2})(\d{2})(\d{4})(?:V(\d+))?$/.exec(
+    slug,
+  );
+  if (!match) return { start: '', end: '', version: 1 };
+  const [, ds, ms, ys, de, me, ye, v] = match;
+  return {
+    start: `${ys}-${ms}-${ds}`,
+    end: `${ye}-${me}-${de}`,
+    version: v ? Number(v) : 1,
+  };
+}
+
+function parseList(raw: unknown): string[] {
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(String(raw));
+    return Array.isArray(arr) ? arr.map((v) => String(v)) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function listWeeklyReports(userId: number): Promise<
+  Array<{
+    startDate: string;
+    endDate: string;
+    slug: string;
+    version: number;
+    score: number;
+    coachTone: string;
+    summary: string;
+    good: string[];
+    bad: string[];
+    observations: string[];
+  }>
+> {
+  const rows = await db
+    .select({
+      startDate: weeklyReports.startDate,
+      endDate: weeklyReports.endDate,
+      score: weeklyReports.score,
+      summary: weeklyReports.summary,
+      good: weeklyReports.good,
+      bad: weeklyReports.bad,
+      observations: weeklyReports.observations,
+      version: weeklyReports.version,
+      coachTone: weeklyReports.coachTone,
+    })
+    .from(weeklyReports)
+    .where(eq(weeklyReports.userId, userId))
+    .orderBy(desc(weeklyReports.startDate), desc(weeklyReports.version));
+  return rows.map((r) => {
+    const start = r.startDate?.toString().slice(0, 10) ?? '';
+    const end = r.endDate?.toString().slice(0, 10) ?? '';
+    const version = r.version ?? 1;
+    return {
+      startDate: start,
+      endDate: end,
+      slug: slugFromRange(start, end, version),
+      version,
+      score: r.score ?? 0,
+      coachTone: r.coachTone ?? 'tone_medium',
+      summary: r.summary ?? '',
+      good: parseList(r.good),
+      bad: parseList(r.bad),
+      observations: parseList(r.observations),
+    };
+  });
+}
+
+export async function getWeeklyReport(
+  userId: number,
+  slug: string,
+): Promise<WeeklyReport | null> {
+  const { start, end, version } = parseSlug(slug);
+  const [row] = await db
+    .select()
+    .from(weeklyReports)
+    .where(
+      and(
+        eq(weeklyReports.userId, userId),
+        eq(weeklyReports.startDate, start),
+        eq(weeklyReports.version, version),
+      ),
+    );
+  if (!row) return null;
+  return {
+    id: row.id,
+    userId: row.userId ?? 0,
+    startDate: start,
+    endDate: row.endDate?.toString().slice(0, 10) ?? end,
+    version: row.version ?? 1,
+    summary: row.summary ?? '',
+    good: parseList(row.good),
+    bad: parseList(row.bad),
+    observations: parseList(row.observations),
+    score: row.score ?? 0,
+    coachTone: row.coachTone ?? 'tone_medium',
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+export async function createWeeklyReport(
+  userId: number,
+  startDate: string,
+  endDate: string,
+  content: ReportContent,
+  score: number,
+  coachTone: string,
+): Promise<void> {
+  try {
+    const [{ maxVersion }] = await db
+      .select({
+        maxVersion: sql<number>`coalesce(max(${weeklyReports.version}),0)`,
+      })
+      .from(weeklyReports)
+      .where(
+        and(
+          eq(weeklyReports.userId, userId),
+          eq(weeklyReports.startDate, startDate),
+        ),
+      );
+    const nextVersion = (maxVersion ?? 0) + 1;
+    await db.insert(weeklyReports).values({
+      userId,
+      startDate,
+      endDate,
+      summary: content.summary ?? '',
+      good: JSON.stringify(content.good ?? []),
+      bad: JSON.stringify(content.bad ?? []),
+      observations: JSON.stringify(content.observations ?? []),
+      coachTone,
+      score,
+      version: nextVersion,
+    });
+    console.log('createWeeklyReport inserted', {
+      userId,
+      startDate,
+      endDate,
+      version: nextVersion,
+      score,
+      coachTone,
+    });
+  } catch (error) {
+    console.error('createWeeklyReport failed', {
+      userId,
+      startDate,
+      endDate,
+      score,
+      coachTone,
+      content,
+      error,
+    });
+    throw error;
+  }
+}

--- a/types/report.ts
+++ b/types/report.ts
@@ -18,3 +18,18 @@ export interface DailyReport {
   coachTone: string;
   createdAt: string;
 }
+
+export interface WeeklyReport {
+  id: number;
+  userId: number;
+  startDate: string; // YYYY-MM-DD (Monday)
+  endDate: string; // YYYY-MM-DD (Sunday)
+  version: number;
+  summary: string;
+  good: string[];
+  bad: string[];
+  observations: string[];
+  score: number;
+  coachTone: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- store weekly reports in new table and expose CRUD helpers
- add API route and button to generate weekly assessments from daily report context
- display weekly assessments with difficulty labels alongside scores
- include user's rational in weekly context and avoid penalizing pre-account days

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b01ead7bf4832aac527df3fce12ff4