### PR TITLE
feat: add monthly assessment agent

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -238,3 +238,4 @@
 - 2025-10-27: Added weekly assessment agent with generation button, API route, database storage, and overview pages including difficulty labels.
 - 2025-10-27: Prefixed weekly report prompts with user's rational, marked pre-account days, and ensured weeks run Monday–Sunday.
 - 2025-10-27: Displayed missing weekly assessment notice for weeks without reports after the allowed generation window.
+- 2025-10-27: Added monthly assessment agent with generation button, API route, database storage, overview pages for owners and viewers, and difficulty labels.

--- a/app/(view)/view/[viewId]/progress/overview/monthly/[range]/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/monthly/[range]/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { MonthlyReportDetailView } from '@/app/progress/overview/monthly/[range]/page';
+
+export default async function ViewMonthlyReportDetail({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string; range: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId, range } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-monthly-${range}-${user.id}`}>
+        <MonthlyReportDetailView userId={user.id} slug={range} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/(view)/view/[viewId]/progress/overview/monthly/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/monthly/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { MonthlyReportsHome } from '@/app/progress/overview/monthly/page';
+
+export default async function ViewMonthlyReportsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-monthly-${user.id}`}>
+        <MonthlyReportsHome userId={user.id} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/api/progress/monthly-report/route.ts
+++ b/app/api/progress/monthly-report/route.ts
@@ -1,0 +1,216 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { createMonthlyReport } from '@/lib/monthly-report-store';
+import { listWeeklyReports } from '@/lib/weekly-report-store';
+import { listDailyReports } from '@/lib/daily-report-store';
+import { DEFAULT_LLM_SETUP } from '@/lib/llm/config';
+import { getCoachTone } from '@/lib/ai/coach-tone';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+function toYMD(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function buildSystemPrompt(toneId: string) {
+  const tone = getCoachTone(toneId);
+  return `You are the Monthly Assessment agent for the Piece of Cake framework, you will receive context from the entire month either in daily assessment or in weekly assessment rapports of how the user performed that that week or day in the month, your goal is to evaluate the week and output an assessment based on it. Flavors are life domains and ingredients are the habits that add them; when combined, the flavors form the user's Cake—their ethos—which guides direction without a fixed destination.Evaluate the provided day: judge the plan's difficulty, focus, and potential they had on the day, then how execution aligned with it. Be firm yet fair—higher ambitions merit tougher grading, acknowledge wins, and call out self-sabotage. The tone of your assessment should be: ${JSON.stringify(tone, null, 2)} Keep the tone wise and constructive. Weekly rapports summarize seven days and should be weighed seven times as heavily as individual daily rapports. Respond ONLY with JSON of the form {"summary":string,"good":string[],"bad":string[],"observations":string[],"score":0-100}.`;
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  const paramUserId = Number(req.nextUrl.searchParams.get('userId'));
+  const userId = paramUserId || Number(session?.user?.id);
+  if (!userId)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  let body: any = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const start = body.startDate || body.start;
+  const end = body.endDate || body.end;
+  const ethos = body.ethos || '';
+  if (!start)
+    return NextResponse.json({ error: 'Missing date range' }, { status: 400 });
+
+  const [userRow, weekly, daily] = await Promise.all([
+    db
+      .select({ coachTone: users.coachTone, createdAt: users.createdAt })
+      .from(users)
+      .where(eq(users.id, userId)),
+    listWeeklyReports(userId),
+    listDailyReports(userId),
+  ]);
+  const toneId = body.toneId || userRow?.[0]?.coachTone || 'tone_medium';
+  const userCreated = userRow?.[0]?.createdAt
+    ? toYMD(new Date(userRow[0].createdAt))
+    : null;
+
+  const monthStart = new Date(start);
+  const monthEnd = end ? new Date(end) : new Date(monthStart);
+  if (!end) {
+    monthEnd.setUTCMonth(monthEnd.getUTCMonth() + 1);
+    monthEnd.setUTCDate(0);
+  }
+  const startStr = toYMD(monthStart);
+  const endStr = toYMD(monthEnd);
+
+  const weeklyMap = new Map(weekly.map((w) => [w.startDate, w]));
+  const dailyMap = new Map(daily.map((d) => [d.date, d]));
+
+  const firstMonday = new Date(monthStart);
+  while (firstMonday.getUTCDay() !== 1) {
+    firstMonday.setUTCDate(firstMonday.getUTCDate() + 1);
+  }
+  const lastSunday = new Date(monthEnd);
+  while (lastSunday.getUTCDay() !== 0) {
+    lastSunday.setUTCDate(lastSunday.getUTCDate() - 1);
+  }
+
+  const lines: string[] = [];
+  lines.push(`the life ethos/goal of the person is: ${ethos}`);
+  lines.push("This is the context one which you have to base you're assessment:");
+
+  function addDaily(ymd: string) {
+    const rpt = dailyMap.get(ymd);
+    lines.push(ymd);
+    if (rpt) {
+      lines.push(`summary: ${rpt.summary}`);
+      if (rpt.good.length) lines.push(`good: ${rpt.good.join('; ')}`);
+      if (rpt.bad.length) lines.push(`bad: ${rpt.bad.join('; ')}`);
+      if (rpt.observations.length)
+        lines.push(`observations: ${rpt.observations.join('; ')}`);
+      lines.push(`score: ${rpt.score}`);
+    } else {
+      lines.push('No Assessment');
+      if (userCreated && ymd < userCreated) {
+        lines.push('The user did not have an account on this day yet.');
+      } else {
+        lines.push('This day the user did not generate a daily assessment.');
+      }
+    }
+    lines.push('-----------------');
+  }
+
+  function addWeekly(startW: string, endW: string) {
+    const rpt = weeklyMap.get(startW);
+    lines.push(`${startW} - ${endW}`);
+    if (rpt) {
+      lines.push(`summary: ${rpt.summary}`);
+      if (rpt.good.length) lines.push(`good: ${rpt.good.join('; ')}`);
+      if (rpt.bad.length) lines.push(`bad: ${rpt.bad.join('; ')}`);
+      if (rpt.observations.length)
+        lines.push(`observations: ${rpt.observations.join('; ')}`);
+      lines.push(`score: ${rpt.score}`);
+    } else {
+      lines.push('No Assessment');
+      if (userCreated && endW < userCreated) {
+        lines.push('The user did not have an account on this week yet.');
+      } else {
+        lines.push('This week the user did not generate a weekly assessment.');
+      }
+    }
+    lines.push('-----------------');
+  }
+
+  let d = new Date(monthStart);
+  while (d < firstMonday && d <= monthEnd) {
+    addDaily(toYMD(d));
+    d.setUTCDate(d.getUTCDate() + 1);
+  }
+
+  for (
+    let ws = new Date(firstMonday);
+    ws <= lastSunday;
+    ws.setUTCDate(ws.getUTCDate() + 7)
+  ) {
+    const we = new Date(ws);
+    we.setUTCDate(ws.getUTCDate() + 6);
+    if (we > monthEnd) break;
+    addWeekly(toYMD(ws), toYMD(we));
+  }
+
+  d = new Date(lastSunday);
+  d.setUTCDate(d.getUTCDate() + 1);
+  while (d <= monthEnd) {
+    addDaily(toYMD(d));
+    d.setUTCDate(d.getUTCDate() + 1);
+  }
+
+  const context = lines.join('\n');
+
+  const setup = DEFAULT_LLM_SETUP;
+  const systemPrompt = buildSystemPrompt(toneId);
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Missing OpenAI API key' },
+      { status: 500 },
+    );
+  }
+
+  const reqBody = {
+    model: setup.model,
+    temperature: setup.temperature,
+    top_p: setup.top_p,
+    max_tokens: setup.maxTokens,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: context },
+    ],
+    response_format: { type: 'json_object' },
+  } as any;
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(reqBody),
+    });
+    const raw = await aiRes.text();
+    if (!aiRes.ok) {
+      return NextResponse.json({ error: raw }, { status: aiRes.status });
+    }
+    const data = JSON.parse(raw);
+    const msg = data.choices?.[0]?.message?.content ?? '{}';
+    let parsed: any = {};
+    try {
+      parsed = JSON.parse(msg);
+    } catch {
+      parsed = { summary: msg, good: [], bad: [], observations: [], score: 0 };
+    }
+    const score = Number(parsed.score) || 0;
+    const content = {
+      summary: parsed.summary || '',
+      good: Array.isArray(parsed.good) ? parsed.good : [],
+      bad: Array.isArray(parsed.bad) ? parsed.bad : [],
+      observations: Array.isArray(parsed.observations)
+        ? parsed.observations
+        : [],
+    };
+    await createMonthlyReport(userId, startStr, endStr, content, score, toneId);
+    console.log('monthly report saved', {
+      userId,
+      start: startStr,
+      end: endStr,
+      score,
+    });
+    return NextResponse.json({ report: parsed, score, context });
+  } catch (e: any) {
+    console.error('monthly-report generation failed', e);
+    return NextResponse.json(
+      {
+        error: e.message || 'LLM request failed',
+        cause: e?.cause?.message,
+        context,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/progress/overview/monthly/[range]/page.tsx
+++ b/app/progress/overview/monthly/[range]/page.tsx
@@ -1,0 +1,93 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getMonthlyReport } from '@/lib/monthly-report-store';
+import { getCoachTone } from '@/lib/ai/coach-tone';
+import { getDifficultyLabel } from '@/lib/ai/difficulty';
+import { redirect, notFound } from 'next/navigation';
+
+export async function MonthlyReportDetailView({
+  userId,
+  slug,
+}: {
+  userId: number;
+  slug: string;
+}) {
+  const report = await getMonthlyReport(userId, slug);
+  if (!report) notFound();
+  const { summary, good, bad, observations, coachTone } = report;
+  return (
+    <main className="p-6">
+      <h1
+        className="mb-4 text-2xl font-bold"
+        id={`m0nthlyrep-title-${slug}-${userId}`}
+      >
+        Report for {report.startDate} – {report.endDate}
+        {report.version > 1 && <span className="ml-1">(v{report.version})</span>}
+      </h1>
+      <p className="mb-4 font-semibold">
+        <span id={`m0nthlyrep-tone-${slug}-${userId}`}>
+          {getCoachTone(coachTone).name}
+        </span>
+        <span className="ml-2" id={`m0nthlyrep-score-${slug}-${userId}`}>
+          Score: {report.score}
+        </span>
+        <span className="ml-2" id={`m0nthlyrep-diff-${slug}-${userId}`}>
+          {getDifficultyLabel(report.score)}
+        </span>
+      </p>
+      <pre
+        className="whitespace-pre-wrap"
+        id={`m0nthlyrep-sum-${slug}-${userId}`}
+      >
+        {summary}
+      </pre>
+      {good.length > 0 && (
+        <div className="mt-4" id={`m0nthlyrep-good-${slug}-${userId}`}>
+          <h2 className="font-semibold">What went well</h2>
+          <ul className="list-disc pl-4">
+            {good.map((g: string, i: number) => (
+              <li key={i} id={`m0nthlyrep-good-${i}-${slug}-${userId}`}>
+                {g}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {bad.length > 0 && (
+        <div className="mt-4" id={`m0nthlyrep-bad-${slug}-${userId}`}>
+          <h2 className="font-semibold">What went bad</h2>
+          <ul className="list-disc pl-4">
+            {bad.map((g: string, i: number) => (
+              <li key={i} id={`m0nthlyrep-bad-${i}-${slug}-${userId}`}>
+                {g}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {observations.length > 0 && (
+        <div className="mt-4" id={`m0nthlyrep-obs-${slug}-${userId}`}>
+          <h2 className="font-semibold">Observations</h2>
+          <ul className="list-disc pl-4">
+            {observations.map((g: string, i: number) => (
+              <li key={i} id={`m0nthlyrep-obs-${i}-${slug}-${userId}`}>
+                {g}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}
+
+export default async function MonthlyReportDetail({
+  params,
+}: {
+  params: { range: string };
+}) {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  return <MonthlyReportDetailView userId={me.id} slug={params.range} />;
+}

--- a/app/progress/overview/monthly/page.tsx
+++ b/app/progress/overview/monthly/page.tsx
@@ -1,0 +1,182 @@
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { redirect } from 'next/navigation';
+import { listMonthlyReports } from '@/lib/monthly-report-store';
+import { listWeeklyReports } from '@/lib/weekly-report-store';
+import { listDailyReportDates } from '@/lib/daily-report-store';
+import { getCoachTone } from '@/lib/ai/coach-tone';
+import { getDifficultyLabel } from '@/lib/ai/difficulty';
+
+function slugFromRange(start: string, end: string): string {
+  const [ys, ms, ds] = start.split('-');
+  const [ye, me, de] = end.split('-');
+  return `${ds}${ms}${ys}-${de}${me}${ye}`;
+}
+
+export async function MonthlyReportsHome({ userId }: { userId: number }) {
+  const [reports, weekly, dailyDates] = await Promise.all([
+    listMonthlyReports(userId),
+    listWeeklyReports(userId),
+    listDailyReportDates(userId),
+  ]);
+  const reportMap = new Map(reports.map((r) => [r.startDate.slice(0, 7), r]));
+  const monthsSet = new Set<string>();
+  for (const d of dailyDates) monthsSet.add(d.slice(0, 7));
+  for (const w of weekly) monthsSet.add(w.startDate.slice(0, 7));
+  for (const r of reports) monthsSet.add(r.startDate.slice(0, 7));
+  const months = Array.from(monthsSet).sort();
+  if (months.length === 0)
+    return (
+      <main className="p-6">
+        <h1 className="mb-4 text-2xl font-bold">Monthly Reports</h1>
+        <p>No monthly data yet.</p>
+      </main>
+    );
+
+  const first = new Date(months[0] + '-01');
+  const now = new Date();
+  const currentMonthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const prevMonthStart = new Date(currentMonthStart);
+  prevMonthStart.setUTCMonth(prevMonthStart.getUTCMonth() - 1);
+
+  const list: Array<{ start: string; end: string; report?: (typeof reports)[number] }> = [];
+  for (
+    let d = new Date(first);
+    d < currentMonthStart;
+    d.setUTCMonth(d.getUTCMonth() + 1)
+  ) {
+    const start = d.toISOString().slice(0, 10);
+    const endDate = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0));
+    const end = endDate.toISOString().slice(0, 10);
+    const key = start.slice(0, 7);
+    list.push({ start, end, report: reportMap.get(key) });
+  }
+
+  return (
+    <main className="p-6">
+      <h1 className="mb-4 text-2xl font-bold">Monthly Reports</h1>
+      <ul className="space-y-4" id={`m0nthlyrep-list-${userId}`}>
+        {list.map((m) => {
+          if (m.report) {
+            const r = m.report;
+            return (
+              <li
+                key={r.slug}
+                className="rounded border p-4"
+                id={`m0nthlyrep-item-${r.slug}-${userId}`}
+              >
+                <div className="flex items-center justify-between">
+                  <h2
+                    className="font-semibold"
+                    id={`m0nthlyrep-date-${r.slug}-${userId}`}
+                  >
+                    {r.startDate} – {r.endDate}
+                    {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
+                  </h2>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="font-semibold"
+                      id={`m0nthlyrep-tone-${r.slug}-${userId}`}
+                    >
+                      {getCoachTone(r.coachTone).name}
+                    </span>
+                    <span
+                      className="font-semibold"
+                      id={`m0nthlyrep-score-${r.slug}-${userId}`}
+                    >
+                      {r.score}
+                    </span>
+                    <span
+                      className="ml-1 text-sm text-zinc-600"
+                      id={`m0nthlyrep-diff-${r.slug}-${userId}`}
+                    >
+                      {getDifficultyLabel(r.score)}
+                    </span>
+                  </div>
+                </div>
+                {r.summary && (
+                  <p
+                    className="mt-2 whitespace-pre-wrap"
+                    id={`m0nthlyrep-sum-${r.slug}-${userId}`}
+                  >
+                    {r.summary}
+                  </p>
+                )}
+                {r.good.length > 0 && (
+                  <div className="mt-2" id={`m0nthlyrep-good-${r.slug}-${userId}`}>
+                    <h3 className="font-semibold">What went well</h3>
+                    <ul className="list-disc pl-4">
+                      {r.good.map((g, i) => (
+                        <li key={i} id={`m0nthlyrep-good-${i}-${r.slug}-${userId}`}>
+                          {g}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {r.bad.length > 0 && (
+                  <div className="mt-2" id={`m0nthlyrep-bad-${r.slug}-${userId}`}>
+                    <h3 className="font-semibold">What went bad</h3>
+                    <ul className="list-disc pl-4">
+                      {r.bad.map((b, i) => (
+                        <li key={i} id={`m0nthlyrep-bad-${i}-${r.slug}-${userId}`}>
+                          {b}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {r.observations.length > 0 && (
+                  <div className="mt-2" id={`m0nthlyrep-obs-${r.slug}-${userId}`}>
+                    <h3 className="font-semibold">Observations</h3>
+                    <ul className="list-disc pl-4">
+                      {r.observations.map((o, i) => (
+                        <li key={i} id={`m0nthlyrep-obs-${i}-${r.slug}-${userId}`}>
+                          {o}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                <Link
+                  href={r.slug}
+                  className="mt-2 block text-sm text-orange-600 hover:underline"
+                  id={`m0nthlyrep-link-${r.slug}-${userId}`}
+                >
+                  View details
+                </Link>
+              </li>
+            );
+          }
+          if (m.start >= prevMonthStart.toISOString().slice(0, 10)) return null;
+          const slug = slugFromRange(m.start, m.end);
+          return (
+            <li
+              key={slug}
+              className="rounded border p-4"
+              id={`m0nthlyrep-miss-${slug}-${userId}`}
+            >
+              <h2
+                className="font-semibold"
+                id={`m0nthlyrep-date-${slug}-${userId}`}
+              >
+                {m.start} – {m.end}
+              </h2>
+              <p className="mt-2" id={`m0nthlyrep-miss-msg-${slug}-${userId}`}>
+                This month the user did not generate a monthly assessment.
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </main>
+  );
+}
+
+export default async function MonthlyReportsPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  return <MonthlyReportsHome userId={me.id} />;
+}

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -10,6 +10,7 @@ import { hrefFor, type Section } from '@/lib/navigation';
 import TimeMachine from '@/components/dev/time-machine';
 import { GenerateDailyReportButton } from '@/components/progress/generate-daily-report-button';
 import { GenerateWeeklyReportButton } from '@/components/progress/generate-weekly-report-button';
+import { GenerateMonthlyReportButton } from '@/components/progress/generate-monthly-report-button';
 
 export function CakeNavigation() {
   const router = useRouter();
@@ -147,6 +148,7 @@ export function CakeNavigation() {
           >
             <GenerateDailyReportButton userId={ctx.ownerId} />
             <GenerateWeeklyReportButton userId={ctx.ownerId} />
+            <GenerateMonthlyReportButton userId={ctx.ownerId} />
           </div>
         )}
         <nav

--- a/components/progress/generate-monthly-report-button.tsx
+++ b/components/progress/generate-monthly-report-button.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useLogs } from '@/components/dev/logs-provider';
+import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+function toYMD(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function GenerateMonthlyReportButton({
+  userId,
+  className,
+}: {
+  userId: number;
+  className?: string;
+}) {
+  const [loading, setLoading] = useState(false);
+  const { addLog } = useLogs();
+  const router = useRouter();
+  const [message, setMessage] = useState<string | null>(null);
+  const [needsCode, setNeedsCode] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const [range, setRange] = useState<{ start: string; end: string } | null>(
+    null,
+  );
+
+  const currentDate = useCallback(() => {
+    const params = new URLSearchParams(window.location.search);
+    params.set('userId', String(userId));
+    const dateParam = params.get('apoc_date');
+    let date = dateParam || '';
+    if (!date) {
+      const match = document.cookie.match(/apoc_clock=([^;]+)/);
+      if (match) {
+        const d = new Date(decodeURIComponent(match[1]));
+        if (!isNaN(d.getTime())) date = d.toISOString().slice(0, 10);
+      }
+      if (!date) date = new Date().toISOString().slice(0, 10);
+    }
+    return { date, params };
+  }, [userId]);
+
+  useEffect(() => {
+    const { date } = currentDate();
+    const today = new Date(date);
+    const lastDayCurrent = new Date(
+      Date.UTC(today.getUTCFullYear(), today.getUTCMonth() + 1, 0),
+    );
+    let start: Date;
+    let end: Date;
+    let show = true;
+    if (today.getUTCDate() === lastDayCurrent.getUTCDate()) {
+      start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+      end = lastDayCurrent;
+      const dailyKey = `daily-report-generated-${userId}-${date}`;
+      show = window.localStorage.getItem(dailyKey) === 'true';
+    } else {
+      end = new Date(
+        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0),
+      );
+      start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
+    }
+    const startStr = toYMD(start);
+    const endStr = toYMD(end);
+    setRange({ start: startStr, end: endStr });
+    const key = `monthly-report-generated-${userId}-${startStr}`;
+    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    setVisible(show);
+  }, [currentDate, userId]);
+
+  if (!visible || !range) return null;
+
+  const onClick = async () => {
+    if (needsCode) {
+      const code = window
+        .prompt('Enter code to generate a new monthly report')
+        ?.trim();
+      if (code !== 'cake2025') return;
+    }
+    setLoading(true);
+    const { params } = currentDate();
+    const ethos = window.localStorage.getItem('review-rational') || '';
+    const body = { start: range.start, end: range.end, ethos };
+    const url = `/api/progress/monthly-report?${params.toString()}`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    addLog({
+      request: data.context || JSON.stringify(body),
+      response: JSON.stringify(data.report ?? data),
+    });
+    setLoading(false);
+    if (data.error) {
+      setMessage(data.error);
+    } else {
+      setMessage(
+        `Monthly rapport is created. Your score for this month is: ${data.score}`,
+      );
+      const key = `monthly-report-generated-${userId}-${range.start}`;
+      window.localStorage.setItem(key, 'true');
+      setNeedsCode(true);
+      router.refresh();
+    }
+  };
+
+  return (
+    <div className={cn('flex flex-col items-center', className)}>
+      <Button
+        onClick={onClick}
+        disabled={loading}
+        className={cn(
+          'flex items-center gap-2 text-white',
+          needsCode
+            ? 'bg-orange-500 hover:bg-orange-600'
+            : 'bg-green-500 hover:bg-green-600',
+        )}
+      >
+        {loading && (
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+        )}
+        {loading
+          ? 'Generating…'
+          : `Generate monthly rapport for ${range.start} - ${range.end}`}
+      </Button>
+      {message && <p className="mt-2 text-sm">{message}</p>}
+    </div>
+  );
+}

--- a/drizzle/0027_create_monthly_reports.sql
+++ b/drizzle/0027_create_monthly_reports.sql
@@ -1,0 +1,15 @@
+CREATE TABLE monthly_reports (
+  id serial PRIMARY KEY,
+  user_id integer NOT NULL REFERENCES users(id),
+  start_date date NOT NULL,
+  end_date date NOT NULL,
+  summary text NOT NULL DEFAULT '',
+  good text NOT NULL DEFAULT '[]',
+  bad text NOT NULL DEFAULT '[]',
+  observations text NOT NULL DEFAULT '[]',
+  coach_tone text NOT NULL DEFAULT 'tone_medium',
+  score integer NOT NULL,
+  version integer NOT NULL DEFAULT 1,
+  created_at timestamp DEFAULT now(),
+  CONSTRAINT monthly_reports_user_month_version_unique UNIQUE (user_id, start_date, version)
+);

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -286,3 +286,28 @@ export const weeklyReports = pgTable(
     ).on(table.userId, table.startDate, table.version),
   }),
 );
+
+export const monthlyReports = pgTable(
+  'monthly_reports',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    startDate: date('start_date').notNull(),
+    endDate: date('end_date').notNull(),
+    summary: text('summary').notNull().default(''),
+    good: text('good').notNull().default('[]'),
+    bad: text('bad').notNull().default('[]'),
+    observations: text('observations').notNull().default('[]'),
+    coachTone: text('coach_tone').notNull().default('tone_medium'),
+    score: integer('score').notNull(),
+    version: integer('version').notNull().default(1),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserMonthVersion: uniqueIndex(
+      'monthly_reports_user_month_version_unique',
+    ).on(table.userId, table.startDate, table.version),
+  }),
+);

--- a/lib/monthly-report-store.ts
+++ b/lib/monthly-report-store.ts
@@ -1,0 +1,173 @@
+import { db } from './db';
+import { monthlyReports } from './db/schema';
+import { eq, and, desc, sql } from 'drizzle-orm';
+import type { MonthlyReport, ReportContent } from '@/types/report';
+
+function slugFromRange(start: string, end: string, version = 1): string {
+  const [ys, ms, ds] = start.split('-');
+  const [ye, me, de] = end.split('-');
+  const base = `${ds}${ms}${ys}-${de}${me}${ye}`;
+  return version > 1 ? `${base}V${version}` : base;
+}
+
+function parseSlug(slug: string): {
+  start: string;
+  end: string;
+  version: number;
+} {
+  const match = /^(\d{2})(\d{2})(\d{4})-(\d{2})(\d{2})(\d{4})(?:V(\d+))?$/.exec(
+    slug,
+  );
+  if (!match) return { start: '', end: '', version: 1 };
+  const [, ds, ms, ys, de, me, ye, v] = match;
+  return {
+    start: `${ys}-${ms}-${ds}`,
+    end: `${ye}-${me}-${de}`,
+    version: v ? Number(v) : 1,
+  };
+}
+
+function parseList(raw: unknown): string[] {
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(String(raw));
+    return Array.isArray(arr) ? arr.map((v) => String(v)) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function listMonthlyReports(userId: number): Promise<
+  Array<{
+    startDate: string;
+    endDate: string;
+    slug: string;
+    version: number;
+    score: number;
+    coachTone: string;
+    summary: string;
+    good: string[];
+    bad: string[];
+    observations: string[];
+  }>
+> {
+  const rows = await db
+    .select({
+      startDate: monthlyReports.startDate,
+      endDate: monthlyReports.endDate,
+      score: monthlyReports.score,
+      summary: monthlyReports.summary,
+      good: monthlyReports.good,
+      bad: monthlyReports.bad,
+      observations: monthlyReports.observations,
+      version: monthlyReports.version,
+      coachTone: monthlyReports.coachTone,
+    })
+    .from(monthlyReports)
+    .where(eq(monthlyReports.userId, userId))
+    .orderBy(desc(monthlyReports.startDate), desc(monthlyReports.version));
+  return rows.map((r) => {
+    const start = r.startDate?.toString().slice(0, 10) ?? '';
+    const end = r.endDate?.toString().slice(0, 10) ?? '';
+    const version = r.version ?? 1;
+    return {
+      startDate: start,
+      endDate: end,
+      slug: slugFromRange(start, end, version),
+      version,
+      score: r.score ?? 0,
+      coachTone: r.coachTone ?? 'tone_medium',
+      summary: r.summary ?? '',
+      good: parseList(r.good),
+      bad: parseList(r.bad),
+      observations: parseList(r.observations),
+    };
+  });
+}
+
+export async function getMonthlyReport(
+  userId: number,
+  slug: string,
+): Promise<MonthlyReport | null> {
+  const { start, end, version } = parseSlug(slug);
+  const [row] = await db
+    .select()
+    .from(monthlyReports)
+    .where(
+      and(
+        eq(monthlyReports.userId, userId),
+        eq(monthlyReports.startDate, start),
+        eq(monthlyReports.version, version),
+      ),
+    );
+  if (!row) return null;
+  return {
+    id: row.id,
+    userId: row.userId ?? 0,
+    startDate: start,
+    endDate: row.endDate?.toString().slice(0, 10) ?? end,
+    version: row.version ?? 1,
+    summary: row.summary ?? '',
+    good: parseList(row.good),
+    bad: parseList(row.bad),
+    observations: parseList(row.observations),
+    score: row.score ?? 0,
+    coachTone: row.coachTone ?? 'tone_medium',
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+export async function createMonthlyReport(
+  userId: number,
+  startDate: string,
+  endDate: string,
+  content: ReportContent,
+  score: number,
+  coachTone: string,
+): Promise<void> {
+  try {
+    const [{ maxVersion }] = await db
+      .select({
+        maxVersion: sql<number>`coalesce(max(${monthlyReports.version}),0)`,
+      })
+      .from(monthlyReports)
+      .where(
+        and(
+          eq(monthlyReports.userId, userId),
+          eq(monthlyReports.startDate, startDate),
+        ),
+      );
+    const nextVersion = (maxVersion ?? 0) + 1;
+    await db.insert(monthlyReports).values({
+      userId,
+      startDate,
+      endDate,
+      summary: content.summary ?? '',
+      good: JSON.stringify(content.good ?? []),
+      bad: JSON.stringify(content.bad ?? []),
+      observations: JSON.stringify(content.observations ?? []),
+      coachTone,
+      score,
+      version: nextVersion,
+    });
+    console.log('createMonthlyReport inserted', {
+      userId,
+      startDate,
+      endDate,
+      version: nextVersion,
+      score,
+      coachTone,
+    });
+  } catch (error) {
+    console.error('createMonthlyReport failed', {
+      userId,
+      startDate,
+      endDate,
+      score,
+      coachTone,
+      content,
+      error,
+    });
+    throw error;
+  }
+}

--- a/types/report.ts
+++ b/types/report.ts
@@ -33,3 +33,18 @@ export interface WeeklyReport {
   coachTone: string;
   createdAt: string;
 }
+
+export interface MonthlyReport {
+  id: number;
+  userId: number;
+  startDate: string; // YYYY-MM-DD (first day)
+  endDate: string; // YYYY-MM-DD (last day)
+  version: number;
+  summary: string;
+  good: string[];
+  bad: string[];
+  observations: string[];
+  score: number;
+  coachTone: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- add monthly report generation button, API route and storage schema
- surface monthly assessments on overview pages for owners and viewers
- track monthly reports in changelog

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b02e2fce68832a9f43ccb1d3a4cc4d