### PR TITLE
feat: add yearly assessment agent

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -239,3 +239,4 @@
 - 2025-10-27: Prefixed weekly report prompts with user's rational, marked pre-account days, and ensured weeks run Monday–Sunday.
 - 2025-10-27: Displayed missing weekly assessment notice for weeks without reports after the allowed generation window.
 - 2025-10-27: Added monthly assessment agent with generation button, API route, database storage, overview pages for owners and viewers, and difficulty labels.
+- 2025-10-27: Added yearly assessment agent with generation button, API route, database storage, overview pages, and difficulty labels.

--- a/app/(view)/view/[viewId]/progress/overview/yearly/[range]/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/yearly/[range]/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { YearlyReportDetailView } from '@/app/progress/overview/yearly/[range]/page';
+
+export default async function ViewYearlyReportDetail({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string; range: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId, range } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-yearly-${range}-${user.id}`}>
+        <YearlyReportDetailView userId={user.id} slug={range} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/(view)/view/[viewId]/progress/overview/yearly/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/yearly/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { YearlyReportsHome } from '@/app/progress/overview/yearly/page';
+
+export default async function ViewYearlyReportsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-yearly-${user.id}`}>
+        <YearlyReportsHome userId={user.id} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/api/progress/yearly-report/route.ts
+++ b/app/api/progress/yearly-report/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { createYearlyReport } from '@/lib/yearly-report-store';
+import { listMonthlyReports } from '@/lib/monthly-report-store';
+import { DEFAULT_LLM_SETUP } from '@/lib/llm/config';
+import { getCoachTone } from '@/lib/ai/coach-tone';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+function toYMD(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function buildSystemPrompt(toneId: string) {
+  const tone = getCoachTone(toneId);
+  return `You are the yearly Assessment agent for the Piece of Cake framework, you will receive context from every month on how the user had performed that month, your goal is to evaluate the week and output an assessment based on it. Flavors are life domains and ingredients are the habits that add them; when combined, the flavors form the user's Cake—their ethos—which guides direction without a fixed destination.Evaluate the provided months: judge the plan's difficulty, focus, and potential they had on the day, then how execution aligned with it. Be firm yet fair—higher ambitions merit tougher grading, acknowledge wins, and call out self-sabotage, also provide an analysis how the progress was thru the year, include this in summary. The tone of your assessment should be: ${JSON.stringify(tone, null, 2)} Keep the tone wise and constructive.Respond ONLY with JSON of the form {"summary":string,"good":string[],"bad":string[],"observations":string[],"score":0-100}.`;
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  const paramUserId = Number(req.nextUrl.searchParams.get('userId'));
+  const userId = paramUserId || Number(session?.user?.id);
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  let body: any = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const start = body.startDate || body.start;
+  const end = body.endDate || body.end;
+  const ethos = body.ethos || '';
+  if (!start) return NextResponse.json({ error: 'Missing date range' }, { status: 400 });
+
+  const [userRow, monthly] = await Promise.all([
+    db
+      .select({ coachTone: users.coachTone, createdAt: users.createdAt })
+      .from(users)
+      .where(eq(users.id, userId)),
+    listMonthlyReports(userId),
+  ]);
+  const toneId = body.toneId || userRow?.[0]?.coachTone || 'tone_medium';
+  const userCreated = userRow?.[0]?.createdAt
+    ? toYMD(new Date(userRow[0].createdAt))
+    : null;
+
+  const yearStart = new Date(start);
+  const yearEnd = end ? new Date(end) : new Date(Date.UTC(yearStart.getUTCFullYear(), 11, 31));
+  const startStr = toYMD(yearStart);
+  const endStr = toYMD(yearEnd);
+
+  const monthlyMap = new Map(monthly.map((m) => [m.startDate.slice(0, 7), m]));
+
+  const lines: string[] = [];
+  lines.push(`the life ethos/goal of the person is: ${ethos}`);
+  lines.push("This is the context one which you have to base you're assessment:");
+
+  for (let i = 0; i < 12; i++) {
+    const mStart = new Date(Date.UTC(yearStart.getUTCFullYear(), i, 1));
+    const mEnd = new Date(Date.UTC(yearStart.getUTCFullYear(), i + 1, 0));
+    const key = mStart.toISOString().slice(0, 7);
+    const rpt = monthlyMap.get(key);
+    lines.push(`${toYMD(mStart)} - ${toYMD(mEnd)}`);
+    if (rpt) {
+      lines.push(`summary: ${rpt.summary}`);
+      if (rpt.good.length) lines.push(`good: ${rpt.good.join('; ')}`);
+      if (rpt.bad.length) lines.push(`bad: ${rpt.bad.join('; ')}`);
+      if (rpt.observations.length)
+        lines.push(`observations: ${rpt.observations.join('; ')}`);
+      lines.push(`score: ${rpt.score}`);
+    } else {
+      lines.push('No Assessment');
+      if (userCreated && toYMD(mEnd) < userCreated) {
+        lines.push('The user did not have an account on this month yet.');
+      } else {
+        lines.push('This month the user did not generate a monthly assessment.');
+      }
+    }
+    lines.push('-----------------');
+  }
+
+  const context = lines.join('\n');
+  const setup = DEFAULT_LLM_SETUP;
+  const systemPrompt = buildSystemPrompt(toneId);
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'Missing OpenAI API key' }, { status: 500 });
+  }
+  const reqBody = {
+    model: setup.model,
+    temperature: setup.temperature,
+    top_p: setup.top_p,
+    max_tokens: setup.maxTokens,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: context },
+    ],
+    response_format: { type: 'json_object' },
+  } as any;
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(reqBody),
+    });
+    const raw = await aiRes.text();
+    if (!aiRes.ok) {
+      return NextResponse.json({ error: raw }, { status: aiRes.status });
+    }
+    const data = JSON.parse(raw);
+    const msg = data.choices?.[0]?.message?.content ?? '{}';
+    let parsed: any = {};
+    try {
+      parsed = JSON.parse(msg);
+    } catch {
+      parsed = { summary: msg, good: [], bad: [], observations: [], score: 0 };
+    }
+    const score = Number(parsed.score) || 0;
+    const content = {
+      summary: parsed.summary || '',
+      good: Array.isArray(parsed.good) ? parsed.good : [],
+      bad: Array.isArray(parsed.bad) ? parsed.bad : [],
+      observations: Array.isArray(parsed.observations)
+        ? parsed.observations
+        : [],
+    };
+    await createYearlyReport(userId, startStr, endStr, content, score, toneId);
+    console.log('yearly report saved', { userId, start: startStr, end: endStr, score });
+    return NextResponse.json({ report: parsed, score, context });
+  } catch (e: any) {
+    console.error('yearly-report generation failed', e);
+    return NextResponse.json(
+      {
+        error: e.message || 'LLM request failed',
+        cause: e?.cause?.message,
+        context,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/app/progress/overview/yearly/[range]/page.tsx
+++ b/app/progress/overview/yearly/[range]/page.tsx
@@ -1,0 +1,93 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getYearlyReport } from '@/lib/yearly-report-store';
+import { getCoachTone } from '@/lib/ai/coach-tone';
+import { getDifficultyLabel } from '@/lib/ai/difficulty';
+import { redirect, notFound } from 'next/navigation';
+
+export async function YearlyReportDetailView({
+  userId,
+  slug,
+}: {
+  userId: number;
+  slug: string;
+}) {
+  const report = await getYearlyReport(userId, slug);
+  if (!report) notFound();
+  const { summary, good, bad, observations, coachTone } = report;
+  return (
+    <main className="p-6">
+      <h1
+        className="mb-4 text-2xl font-bold"
+        id={`y3arlyrep-title-${slug}-${userId}`}
+      >
+        Report for {report.startDate} – {report.endDate}
+        {report.version > 1 && <span className="ml-1">(v{report.version})</span>}
+      </h1>
+      <p className="mb-4 font-semibold">
+        <span id={`y3arlyrep-tone-${slug}-${userId}`}>
+          {getCoachTone(coachTone).name}
+        </span>
+        <span className="ml-2" id={`y3arlyrep-score-${slug}-${userId}`}>
+          Score: {report.score}
+        </span>
+        <span className="ml-2" id={`y3arlyrep-diff-${slug}-${userId}`}>
+          {getDifficultyLabel(report.score)}
+        </span>
+      </p>
+      <pre
+        className="whitespace-pre-wrap"
+        id={`y3arlyrep-sum-${slug}-${userId}`}
+      >
+        {summary}
+      </pre>
+      {good.length > 0 && (
+        <div className="mt-4" id={`y3arlyrep-good-${slug}-${userId}`}>
+          <h2 className="font-semibold">What went well</h2>
+          <ul className="list-disc pl-4">
+            {good.map((g: string, i: number) => (
+              <li key={i} id={`y3arlyrep-good-${i}-${slug}-${userId}`}>
+                {g}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {bad.length > 0 && (
+        <div className="mt-4" id={`y3arlyrep-bad-${slug}-${userId}`}>
+          <h2 className="font-semibold">What went bad</h2>
+          <ul className="list-disc pl-4">
+            {bad.map((g: string, i: number) => (
+              <li key={i} id={`y3arlyrep-bad-${i}-${slug}-${userId}`}>
+                {g}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {observations.length > 0 && (
+        <div className="mt-4" id={`y3arlyrep-obs-${slug}-${userId}`}>
+          <h2 className="font-semibold">Observations</h2>
+          <ul className="list-disc pl-4">
+            {observations.map((g: string, i: number) => (
+              <li key={i} id={`y3arlyrep-obs-${i}-${slug}-${userId}`}>
+                {g}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}
+
+export default async function YearlyReportDetail({
+  params,
+}: {
+  params: { range: string };
+}) {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  return <YearlyReportDetailView userId={me.id} slug={params.range} />;
+}

--- a/app/progress/overview/yearly/page.tsx
+++ b/app/progress/overview/yearly/page.tsx
@@ -1,0 +1,178 @@
+import Link from 'next/link';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { redirect } from 'next/navigation';
+import { listYearlyReports } from '@/lib/yearly-report-store';
+import { listMonthlyReports } from '@/lib/monthly-report-store';
+import { listWeeklyReports } from '@/lib/weekly-report-store';
+import { listDailyReportDates } from '@/lib/daily-report-store';
+import { getCoachTone } from '@/lib/ai/coach-tone';
+import { getDifficultyLabel } from '@/lib/ai/difficulty';
+
+function slugFromRange(start: string, end: string): string {
+  const [ys, ms, ds] = start.split('-');
+  const [ye, me, de] = end.split('-');
+  return `${ds}${ms}${ys}-${de}${me}${ye}`;
+}
+
+export async function YearlyReportsHome({ userId }: { userId: number }) {
+  const [reports, monthly, weekly, dailyDates] = await Promise.all([
+    listYearlyReports(userId),
+    listMonthlyReports(userId),
+    listWeeklyReports(userId),
+    listDailyReportDates(userId),
+  ]);
+  const reportMap = new Map(reports.map((r) => [r.startDate.slice(0, 4), r]));
+  const yearsSet = new Set<string>();
+  for (const m of monthly) yearsSet.add(m.startDate.slice(0, 4));
+  for (const w of weekly) yearsSet.add(w.startDate.slice(0, 4));
+  for (const d of dailyDates) yearsSet.add(d.slice(0, 4));
+  for (const r of reports) yearsSet.add(r.startDate.slice(0, 4));
+  const years = Array.from(yearsSet).sort();
+  if (years.length === 0)
+    return (
+      <main className="p-6">
+        <h1 className="mb-4 text-2xl font-bold">Yearly Reports</h1>
+        <p>No yearly data yet.</p>
+      </main>
+    );
+
+  const first = Number(years[0]);
+  const now = new Date();
+  const currentYear = now.getUTCFullYear();
+  const list: Array<{ start: string; end: string; report?: (typeof reports)[number] }> = [];
+  for (let y = first; y < currentYear; y++) {
+    const start = `${y}-01-01`;
+    const end = `${y}-12-31`;
+    list.push({ start, end, report: reportMap.get(String(y)) });
+  }
+
+  return (
+    <main className="p-6">
+      <h1 className="mb-4 text-2xl font-bold">Yearly Reports</h1>
+      <ul className="space-y-4" id={`y3arlyrep-list-${userId}`}>
+        {list.map((y) => {
+          if (y.report) {
+            const r = y.report;
+            return (
+              <li
+                key={r.slug}
+                className="rounded border p-4"
+                id={`y3arlyrep-item-${r.slug}-${userId}`}
+              >
+                <div className="flex items-center justify-between">
+                  <h2
+                    className="font-semibold"
+                    id={`y3arlyrep-date-${r.slug}-${userId}`}
+                  >
+                    {r.startDate} – {r.endDate}
+                    {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
+                  </h2>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="font-semibold"
+                      id={`y3arlyrep-tone-${r.slug}-${userId}`}
+                    >
+                      {getCoachTone(r.coachTone).name}
+                    </span>
+                    <span
+                      className="font-semibold"
+                      id={`y3arlyrep-score-${r.slug}-${userId}`}
+                    >
+                      {r.score}
+                    </span>
+                    <span
+                      className="ml-1 text-sm text-zinc-600"
+                      id={`y3arlyrep-diff-${r.slug}-${userId}`}
+                    >
+                      {getDifficultyLabel(r.score)}
+                    </span>
+                  </div>
+                </div>
+                {r.summary && (
+                  <p
+                    className="mt-2 whitespace-pre-wrap"
+                    id={`y3arlyrep-sum-${r.slug}-${userId}`}
+                  >
+                    {r.summary}
+                  </p>
+                )}
+                {r.good.length > 0 && (
+                  <div className="mt-2" id={`y3arlyrep-good-${r.slug}-${userId}`}>
+                    <h3 className="font-semibold">What went well</h3>
+                    <ul className="list-disc pl-4">
+                      {r.good.map((g, i) => (
+                        <li key={i} id={`y3arlyrep-good-${i}-${r.slug}-${userId}`}>
+                          {g}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {r.bad.length > 0 && (
+                  <div className="mt-2" id={`y3arlyrep-bad-${r.slug}-${userId}`}>
+                    <h3 className="font-semibold">What went bad</h3>
+                    <ul className="list-disc pl-4">
+                      {r.bad.map((b, i) => (
+                        <li key={i} id={`y3arlyrep-bad-${i}-${r.slug}-${userId}`}>
+                          {b}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {r.observations.length > 0 && (
+                  <div className="mt-2" id={`y3arlyrep-obs-${r.slug}-${userId}`}>
+                    <h3 className="font-semibold">Observations</h3>
+                    <ul className="list-disc pl-4">
+                      {r.observations.map((o, i) => (
+                        <li key={i} id={`y3arlyrep-obs-${i}-${r.slug}-${userId}`}>
+                          {o}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                <Link
+                  href={r.slug}
+                  className="mt-2 block text-sm text-orange-600 hover:underline"
+                  id={`y3arlyrep-link-${r.slug}-${userId}`}
+                >
+                  View details
+                </Link>
+              </li>
+            );
+          }
+          const year = y.start.slice(0, 4);
+          if (Number(year) === currentYear - 1 && now.getUTCMonth() === 0)
+            return null;
+          const slug = slugFromRange(y.start, y.end);
+          return (
+            <li
+              key={slug}
+              className="rounded border p-4"
+              id={`y3arlyrep-miss-${slug}-${userId}`}
+            >
+              <h2
+                className="font-semibold"
+                id={`y3arlyrep-date-${slug}-${userId}`}
+              >
+                {y.start} – {y.end}
+              </h2>
+              <p className="mt-2" id={`y3arlyrep-miss-msg-${slug}-${userId}`}>
+                This year the user did not generate a yearly assessment.
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </main>
+  );
+}
+
+export default async function YearlyReportsPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  return <YearlyReportsHome userId={me.id} />;
+}

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -11,6 +11,7 @@ import TimeMachine from '@/components/dev/time-machine';
 import { GenerateDailyReportButton } from '@/components/progress/generate-daily-report-button';
 import { GenerateWeeklyReportButton } from '@/components/progress/generate-weekly-report-button';
 import { GenerateMonthlyReportButton } from '@/components/progress/generate-monthly-report-button';
+import { GenerateYearlyReportButton } from '@/components/progress/generate-yearly-report-button';
 
 export function CakeNavigation() {
   const router = useRouter();
@@ -149,6 +150,7 @@ export function CakeNavigation() {
             <GenerateDailyReportButton userId={ctx.ownerId} />
             <GenerateWeeklyReportButton userId={ctx.ownerId} />
             <GenerateMonthlyReportButton userId={ctx.ownerId} />
+            <GenerateYearlyReportButton userId={ctx.ownerId} />
           </div>
         )}
         <nav

--- a/components/progress/generate-yearly-report-button.tsx
+++ b/components/progress/generate-yearly-report-button.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useLogs } from '@/components/dev/logs-provider';
+import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/utils';
+
+function toYMD(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function GenerateYearlyReportButton({
+  userId,
+  className,
+}: {
+  userId: number;
+  className?: string;
+}) {
+  const [loading, setLoading] = useState(false);
+  const { addLog } = useLogs();
+  const router = useRouter();
+  const [message, setMessage] = useState<string | null>(null);
+  const [needsCode, setNeedsCode] = useState(false);
+  const [visible, setVisible] = useState(false);
+  const [range, setRange] = useState<{ start: string; end: string } | null>(
+    null,
+  );
+
+  const currentDate = useCallback(() => {
+    const params = new URLSearchParams(window.location.search);
+    params.set('userId', String(userId));
+    const dateParam = params.get('apoc_date');
+    let date = dateParam || '';
+    if (!date) {
+      const match = document.cookie.match(/apoc_clock=([^;]+)/);
+      if (match) {
+        const d = new Date(decodeURIComponent(match[1]));
+        if (!isNaN(d.getTime())) date = d.toISOString().slice(0, 10);
+      }
+      if (!date) date = new Date().toISOString().slice(0, 10);
+    }
+    return { date, params };
+  }, [userId]);
+
+  useEffect(() => {
+    const { date } = currentDate();
+    const today = new Date(date);
+    let year = today.getUTCFullYear();
+    const month = today.getUTCMonth();
+    const day = today.getUTCDate();
+    let show = false;
+    if (month === 11 && day === 31) {
+      const decStart = `${year}-12-01`;
+      const dailyKey = `daily-report-generated-${userId}-${date}`;
+      const monthlyKey = `monthly-report-generated-${userId}-${decStart}`;
+      show =
+        window.localStorage.getItem(dailyKey) === 'true' &&
+        window.localStorage.getItem(monthlyKey) === 'true';
+    } else if (month === 0) {
+      year = year - 1;
+      const decStart = `${year}-12-01`;
+      const monthlyKey = `monthly-report-generated-${userId}-${decStart}`;
+      show = window.localStorage.getItem(monthlyKey) === 'true';
+    }
+    const startStr = `${year}-01-01`;
+    const endStr = `${year}-12-31`;
+    setRange({ start: startStr, end: endStr });
+    const key = `yearly-report-generated-${userId}-${startStr}`;
+    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    setVisible(show);
+  }, [currentDate, userId]);
+
+  if (!visible || !range) return null;
+
+  const onClick = async () => {
+    if (needsCode) {
+      const code = window
+        .prompt('Enter code to generate a new yearly report')
+        ?.trim();
+      if (code !== 'cake2025') return;
+    }
+    setLoading(true);
+    const { params } = currentDate();
+    const ethos = window.localStorage.getItem('review-rational') || '';
+    const body = { start: range.start, end: range.end, ethos };
+    const url = `/api/progress/yearly-report?${params.toString()}`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    addLog({
+      request: data.context || JSON.stringify(body),
+      response: JSON.stringify(data.report ?? data),
+    });
+    setLoading(false);
+    if (data.error) {
+      setMessage(data.error);
+    } else {
+      setMessage(
+        `Yearly rapport is created. Your score for this year is: ${data.score}`,
+      );
+      const key = `yearly-report-generated-${userId}-${range.start}`;
+      window.localStorage.setItem(key, 'true');
+      setNeedsCode(true);
+      router.refresh();
+    }
+  };
+
+  return (
+    <div className={cn('flex flex-col items-center', className)}>
+      <Button
+        onClick={onClick}
+        disabled={loading}
+        className={cn(
+          'flex items-center gap-2 text-white',
+          needsCode ? 'bg-orange-500 hover:bg-orange-600' : 'bg-green-500 hover:bg-green-600',
+        )}
+      >
+        {loading && (
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+        )}
+        {loading
+          ? 'Generating…'
+          : `Generate yearly rapport for ${range.start} - ${range.end}`}
+      </Button>
+      {message && <p className="mt-2 text-sm">{message}</p>}
+    </div>
+  );
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -311,3 +311,28 @@ export const monthlyReports = pgTable(
     ).on(table.userId, table.startDate, table.version),
   }),
 );
+
+export const yearlyReports = pgTable(
+  'yearly_reports',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    startDate: date('start_date').notNull(),
+    endDate: date('end_date').notNull(),
+    summary: text('summary').notNull().default(''),
+    good: text('good').notNull().default('[]'),
+    bad: text('bad').notNull().default('[]'),
+    observations: text('observations').notNull().default('[]'),
+    coachTone: text('coach_tone').notNull().default('tone_medium'),
+    score: integer('score').notNull(),
+    version: integer('version').notNull().default(1),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserYearVersion: uniqueIndex(
+      'yearly_reports_user_year_version_unique',
+    ).on(table.userId, table.startDate, table.version),
+  }),
+);

--- a/lib/yearly-report-store.ts
+++ b/lib/yearly-report-store.ts
@@ -1,0 +1,171 @@
+import { db } from './db';
+import { yearlyReports } from './db/schema';
+import { eq, and, desc, sql } from 'drizzle-orm';
+import type { YearlyReport, ReportContent } from '@/types/report';
+
+function slugFromRange(start: string, end: string, version = 1): string {
+  const [ys, ms, ds] = start.split('-');
+  const [ye, me, de] = end.split('-');
+  const base = `${ds}${ms}${ys}-${de}${me}${ye}`;
+  return version > 1 ? `${base}V${version}` : base;
+}
+
+function parseSlug(slug: string): {
+  start: string;
+  end: string;
+  version: number;
+} {
+  const match = /^(\d{2})(\d{2})(\d{4})-(\d{2})(\d{2})(\d{4})(?:V(\d+))?$/.exec(slug);
+  if (!match) return { start: '', end: '', version: 1 };
+  const [, ds, ms, ys, de, me, ye, v] = match;
+  return {
+    start: `${ys}-${ms}-${ds}`,
+    end: `${ye}-${me}-${de}`,
+    version: v ? Number(v) : 1,
+  };
+}
+
+function parseList(raw: unknown): string[] {
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(String(raw));
+    return Array.isArray(arr) ? arr.map((v) => String(v)) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function listYearlyReports(userId: number): Promise<
+  Array<{
+    startDate: string;
+    endDate: string;
+    slug: string;
+    version: number;
+    score: number;
+    coachTone: string;
+    summary: string;
+    good: string[];
+    bad: string[];
+    observations: string[];
+  }>
+> {
+  const rows = await db
+    .select({
+      startDate: yearlyReports.startDate,
+      endDate: yearlyReports.endDate,
+      score: yearlyReports.score,
+      summary: yearlyReports.summary,
+      good: yearlyReports.good,
+      bad: yearlyReports.bad,
+      observations: yearlyReports.observations,
+      version: yearlyReports.version,
+      coachTone: yearlyReports.coachTone,
+    })
+    .from(yearlyReports)
+    .where(eq(yearlyReports.userId, userId))
+    .orderBy(desc(yearlyReports.startDate), desc(yearlyReports.version));
+  return rows.map((r) => {
+    const start = r.startDate?.toString().slice(0, 10) ?? '';
+    const end = r.endDate?.toString().slice(0, 10) ?? '';
+    const version = r.version ?? 1;
+    return {
+      startDate: start,
+      endDate: end,
+      slug: slugFromRange(start, end, version),
+      version,
+      score: r.score ?? 0,
+      coachTone: r.coachTone ?? 'tone_medium',
+      summary: r.summary ?? '',
+      good: parseList(r.good),
+      bad: parseList(r.bad),
+      observations: parseList(r.observations),
+    };
+  });
+}
+
+export async function getYearlyReport(
+  userId: number,
+  slug: string,
+): Promise<YearlyReport | null> {
+  const { start, end, version } = parseSlug(slug);
+  const [row] = await db
+    .select()
+    .from(yearlyReports)
+    .where(
+      and(
+        eq(yearlyReports.userId, userId),
+        eq(yearlyReports.startDate, start),
+        eq(yearlyReports.version, version),
+      ),
+    );
+  if (!row) return null;
+  return {
+    id: row.id,
+    userId: row.userId ?? 0,
+    startDate: start,
+    endDate: row.endDate?.toString().slice(0, 10) ?? end,
+    version: row.version ?? 1,
+    summary: row.summary ?? '',
+    good: parseList(row.good),
+    bad: parseList(row.bad),
+    observations: parseList(row.observations),
+    score: row.score ?? 0,
+    coachTone: row.coachTone ?? 'tone_medium',
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+export async function createYearlyReport(
+  userId: number,
+  startDate: string,
+  endDate: string,
+  content: ReportContent,
+  score: number,
+  coachTone: string,
+): Promise<void> {
+  try {
+    const [{ maxVersion }] = await db
+      .select({
+        maxVersion: sql<number>`coalesce(max(${yearlyReports.version}),0)`,
+      })
+      .from(yearlyReports)
+      .where(
+        and(
+          eq(yearlyReports.userId, userId),
+          eq(yearlyReports.startDate, startDate),
+        ),
+      );
+    const nextVersion = (maxVersion ?? 0) + 1;
+    await db.insert(yearlyReports).values({
+      userId,
+      startDate,
+      endDate,
+      summary: content.summary ?? '',
+      good: JSON.stringify(content.good ?? []),
+      bad: JSON.stringify(content.bad ?? []),
+      observations: JSON.stringify(content.observations ?? []),
+      coachTone,
+      score,
+      version: nextVersion,
+    });
+    console.log('createYearlyReport inserted', {
+      userId,
+      startDate,
+      endDate,
+      version: nextVersion,
+      score,
+      coachTone,
+    });
+  } catch (error) {
+    console.error('createYearlyReport failed', {
+      userId,
+      startDate,
+      endDate,
+      score,
+      coachTone,
+      content,
+      error,
+    });
+    throw error;
+  }
+}

--- a/types/report.ts
+++ b/types/report.ts
@@ -48,3 +48,18 @@ export interface MonthlyReport {
   coachTone: string;
   createdAt: string;
 }
+
+export interface YearlyReport {
+  id: number;
+  userId: number;
+  startDate: string; // YYYY-01-01
+  endDate: string; // YYYY-12-31
+  version: number;
+  summary: string;
+  good: string[];
+  bad: string[];
+  observations: string[];
+  score: number;
+  coachTone: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- add yearly assessment button, API, pages, and database table
- allow viewer access to yearly reports

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` (fails: Timed out waiting 120000ms from config.webServer)


------
https://chatgpt.com/codex/tasks/task_e_68b04055a00c832aabb93d222ffee9a1