### PR TITLE
Redesign assessment buttons with animated menu

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -241,3 +241,4 @@
 - 2025-10-27: Added monthly assessment agent with generation button, API route, database storage, overview pages for owners and viewers, and difficulty labels.
 - 2025-10-27: Added yearly assessment agent with generation button, API route, database storage, overview pages, and difficulty labels.
 - 2025-10-27: Moved yearly assessment button to the left of the daily button so it stays visible.
+- 2025-10-27: Redesigned assessment generation with a centered daily button and animated "new" toggle for weekly, monthly, and yearly reports.

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -12,6 +12,7 @@ import { GenerateDailyReportButton } from '@/components/progress/generate-daily-
 import { GenerateWeeklyReportButton } from '@/components/progress/generate-weekly-report-button';
 import { GenerateMonthlyReportButton } from '@/components/progress/generate-monthly-report-button';
 import { GenerateYearlyReportButton } from '@/components/progress/generate-yearly-report-button';
+import { cn } from '@/lib/utils';
 
 export function CakeNavigation() {
   const router = useRouter();
@@ -26,6 +27,24 @@ export function CakeNavigation() {
   const secretTimer = useRef<NodeJS.Timeout | null>(null);
   const secretClicks = useRef(0);
   const [timeMachineOpen, setTimeMachineOpen] = useState(false);
+  const [showExtraReports, setShowExtraReports] = useState(false);
+  const [weeklyStatus, setWeeklyStatus] = useState({
+    visible: false,
+    pending: false,
+  });
+  const [monthlyStatus, setMonthlyStatus] = useState({
+    visible: false,
+    pending: false,
+  });
+  const [yearlyStatus, setYearlyStatus] = useState({
+    visible: false,
+    pending: false,
+  });
+
+  const indicatorVisible =
+    weeklyStatus.visible || monthlyStatus.visible || yearlyStatus.visible;
+  const indicatorPending =
+    weeklyStatus.pending || monthlyStatus.pending || yearlyStatus.pending;
 
   useEffect(() => {
     const computeOffset = () => {
@@ -141,16 +160,47 @@ export function CakeNavigation() {
       <div className="grid w-full place-items-center relative">
         {ctx.editable && (
           <div
-            className="absolute -translate-x-1/2 flex gap-2"
-            style={{
-              top: '-66px',
-              left: '50%',
-            }}
+            className="absolute -translate-x-1/2"
+            style={{ top: '-66px', left: '50%' }}
           >
-            <GenerateYearlyReportButton userId={ctx.ownerId} />
-            <GenerateDailyReportButton userId={ctx.ownerId} />
-            <GenerateWeeklyReportButton userId={ctx.ownerId} />
-            <GenerateMonthlyReportButton userId={ctx.ownerId} />
+            <div className="relative flex justify-center">
+              <GenerateDailyReportButton
+                userId={ctx.ownerId}
+                buttonClassName="px-8 py-4 text-lg"
+              />
+              {indicatorVisible && (
+                <button
+                  onClick={() => setShowExtraReports((v) => !v)}
+                  className={cn(
+                    'absolute left-full ml-4 rounded px-3 py-2 text-white',
+                    indicatorPending
+                      ? 'bg-green-500 hover:bg-green-600 animate-bounce'
+                      : 'bg-orange-500 hover:bg-orange-600',
+                  )}
+                >
+                  new
+                </button>
+              )}
+              <div
+                className={cn(
+                  'absolute left-1/2 -translate-x-1/2 mt-4 flex flex-col gap-2',
+                  showExtraReports ? '' : 'hidden',
+                )}
+              >
+                <GenerateWeeklyReportButton
+                  userId={ctx.ownerId}
+                  onStatusChange={setWeeklyStatus}
+                />
+                <GenerateMonthlyReportButton
+                  userId={ctx.ownerId}
+                  onStatusChange={setMonthlyStatus}
+                />
+                <GenerateYearlyReportButton
+                  userId={ctx.ownerId}
+                  onStatusChange={setYearlyStatus}
+                />
+              </div>
+            </div>
           </div>
         )}
         <nav

--- a/components/progress/generate-daily-report-button.tsx
+++ b/components/progress/generate-daily-report-button.tsx
@@ -9,9 +9,11 @@ import { cn } from '@/lib/utils';
 export function GenerateDailyReportButton({
   userId,
   className,
+  buttonClassName,
 }: {
   userId: number;
   className?: string;
+  buttonClassName?: string;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -103,6 +105,7 @@ export function GenerateDailyReportButton({
           needsCode
             ? 'bg-orange-500 hover:bg-orange-600'
             : 'bg-green-500 hover:bg-green-600',
+          buttonClassName,
         )}
       >
         {loading && (

--- a/components/progress/generate-monthly-report-button.tsx
+++ b/components/progress/generate-monthly-report-button.tsx
@@ -13,9 +13,11 @@ function toYMD(d: Date): string {
 export function GenerateMonthlyReportButton({
   userId,
   className,
+  onStatusChange,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; pending: boolean }) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -53,23 +55,25 @@ export function GenerateMonthlyReportButton({
     let end: Date;
     let show = true;
     if (today.getUTCDate() === lastDayCurrent.getUTCDate()) {
-      start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+      start = new Date(
+        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1),
+      );
       end = lastDayCurrent;
       const dailyKey = `daily-report-generated-${userId}-${date}`;
       show = window.localStorage.getItem(dailyKey) === 'true';
     } else {
-      end = new Date(
-        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0),
-      );
+      end = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
       start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
     }
     const startStr = toYMD(start);
     const endStr = toYMD(end);
     setRange({ start: startStr, end: endStr });
     const key = `monthly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const generated = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(generated);
     setVisible(show);
-  }, [currentDate, userId]);
+    onStatusChange?.({ visible: show, pending: show && !generated });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -105,6 +109,7 @@ export function GenerateMonthlyReportButton({
       const key = `monthly-report-generated-${userId}-${range.start}`;
       window.localStorage.setItem(key, 'true');
       setNeedsCode(true);
+      onStatusChange?.({ visible: true, pending: false });
       router.refresh();
     }
   };

--- a/components/progress/generate-weekly-report-button.tsx
+++ b/components/progress/generate-weekly-report-button.tsx
@@ -13,9 +13,11 @@ function toYMD(d: Date): string {
 export function GenerateWeeklyReportButton({
   userId,
   className,
+  onStatusChange,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; pending: boolean }) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -55,14 +57,16 @@ export function GenerateWeeklyReportButton({
     const endStr = toYMD(end);
     setRange({ start: startStr, end: endStr });
     const key = `weekly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const generated = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(generated);
+    let show = true;
     if (day === 0) {
       const dailyKey = `daily-report-generated-${userId}-${date}`;
-      setVisible(window.localStorage.getItem(dailyKey) === 'true');
-    } else {
-      setVisible(true);
+      show = window.localStorage.getItem(dailyKey) === 'true';
     }
-  }, [currentDate, userId]);
+    setVisible(show);
+    onStatusChange?.({ visible: show, pending: show && !generated });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -98,6 +102,7 @@ export function GenerateWeeklyReportButton({
       const key = `weekly-report-generated-${userId}-${range.start}`;
       window.localStorage.setItem(key, 'true');
       setNeedsCode(true);
+      onStatusChange?.({ visible: true, pending: false });
       router.refresh();
     }
   };

--- a/components/progress/generate-yearly-report-button.tsx
+++ b/components/progress/generate-yearly-report-button.tsx
@@ -13,9 +13,11 @@ function toYMD(d: Date): string {
 export function GenerateYearlyReportButton({
   userId,
   className,
+  onStatusChange,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; pending: boolean }) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -67,9 +69,11 @@ export function GenerateYearlyReportButton({
     const endStr = `${year}-12-31`;
     setRange({ start: startStr, end: endStr });
     const key = `yearly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const generated = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(generated);
     setVisible(show);
-  }, [currentDate, userId]);
+    onStatusChange?.({ visible: show, pending: show && !generated });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -105,6 +109,7 @@ export function GenerateYearlyReportButton({
       const key = `yearly-report-generated-${userId}-${range.start}`;
       window.localStorage.setItem(key, 'true');
       setNeedsCode(true);
+      onStatusChange?.({ visible: true, pending: false });
       router.refresh();
     }
   };
@@ -116,7 +121,9 @@ export function GenerateYearlyReportButton({
         disabled={loading}
         className={cn(
           'flex items-center gap-2 text-white',
-          needsCode ? 'bg-orange-500 hover:bg-orange-600' : 'bg-green-500 hover:bg-green-600',
+          needsCode
+            ? 'bg-orange-500 hover:bg-orange-600'
+            : 'bg-green-500 hover:bg-green-600',
         )}
       >
         {loading && (


### PR DESCRIPTION
## Summary
- Center and enlarge the daily assessment button
- Add animated "new" toggle that reveals weekly, monthly and yearly assessment buttons
- Expose status from weekly/monthly/yearly generators so the toggle reflects pending reports

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b04d8fa9f0832ab417ea329192b267