### PR TITLE
feat: add animated report menu for assessments

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -241,3 +241,4 @@
 - 2025-10-27: Added monthly assessment agent with generation button, API route, database storage, overview pages for owners and viewers, and difficulty labels.
 - 2025-10-27: Added yearly assessment agent with generation button, API route, database storage, overview pages, and difficulty labels.
 - 2025-10-27: Moved yearly assessment button to the left of the daily button so it stays visible.
+- 2025-10-27: Redesigned assessment generation UI with a centered daily button and animated "new" menu for weekly, monthly, and yearly reports.

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -9,9 +9,7 @@ import { useViewContext } from '@/lib/view-context';
 import { hrefFor, type Section } from '@/lib/navigation';
 import TimeMachine from '@/components/dev/time-machine';
 import { GenerateDailyReportButton } from '@/components/progress/generate-daily-report-button';
-import { GenerateWeeklyReportButton } from '@/components/progress/generate-weekly-report-button';
-import { GenerateMonthlyReportButton } from '@/components/progress/generate-monthly-report-button';
-import { GenerateYearlyReportButton } from '@/components/progress/generate-yearly-report-button';
+import { AdditionalReportButtons } from '@/components/progress/additional-report-buttons';
 
 export function CakeNavigation() {
   const router = useRouter();
@@ -141,16 +139,16 @@ export function CakeNavigation() {
       <div className="grid w-full place-items-center relative">
         {ctx.editable && (
           <div
-            className="absolute -translate-x-1/2 flex gap-2"
-            style={{
-              top: '-66px',
-              left: '50%',
-            }}
+            className="absolute left-1/2 -translate-x-1/2"
+            style={{ top: '-66px' }}
           >
-            <GenerateYearlyReportButton userId={ctx.ownerId} />
-            <GenerateDailyReportButton userId={ctx.ownerId} />
-            <GenerateWeeklyReportButton userId={ctx.ownerId} />
-            <GenerateMonthlyReportButton userId={ctx.ownerId} />
+            <div className="relative">
+              <GenerateDailyReportButton
+                userId={ctx.ownerId}
+                className="h-14 px-8 text-lg"
+              />
+              <AdditionalReportButtons userId={ctx.ownerId} />
+            </div>
           </div>
         )}
         <nav

--- a/components/progress/additional-report-buttons.tsx
+++ b/components/progress/additional-report-buttons.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { GenerateWeeklyReportButton } from './generate-weekly-report-button';
+import { GenerateMonthlyReportButton } from './generate-monthly-report-button';
+import { GenerateYearlyReportButton } from './generate-yearly-report-button';
+
+export function AdditionalReportButtons({ userId }: { userId: number }) {
+  const [open, setOpen] = useState(false);
+  const [weekly, setWeekly] = useState({ visible: false, needsCode: false });
+  const [monthly, setMonthly] = useState({ visible: false, needsCode: false });
+  const [yearly, setYearly] = useState({ visible: false, needsCode: false });
+
+  const anyVisible = weekly.visible || monthly.visible || yearly.visible;
+  const anyGreen =
+    (weekly.visible && !weekly.needsCode) ||
+    (monthly.visible && !monthly.needsCode) ||
+    (yearly.visible && !yearly.needsCode);
+
+  if (!anyVisible) return null;
+
+  const colorClass = anyGreen
+    ? 'bg-green-500 hover:bg-green-600'
+    : 'bg-orange-500 hover:bg-orange-600';
+  const bounceClass = anyGreen ? 'animate-bounce' : '';
+
+  return (
+    <div className="absolute left-full top-1/2 -translate-y-1/2 ml-2">
+      <Button
+        onClick={() => setOpen((o) => !o)}
+        className={cn(
+          'px-3 py-1 text-xs font-bold uppercase text-white',
+          colorClass,
+          bounceClass,
+        )}
+      >
+        new
+      </Button>
+      <div
+        className={cn(
+          'absolute left-full top-1/2 -translate-y-1/2 ml-2 flex flex-col gap-2',
+          open ? 'flex' : 'hidden',
+        )}
+      >
+        <GenerateWeeklyReportButton
+          userId={userId}
+          onStatusChange={setWeekly}
+        />
+        <GenerateMonthlyReportButton
+          userId={userId}
+          onStatusChange={setMonthly}
+        />
+        <GenerateYearlyReportButton
+          userId={userId}
+          onStatusChange={setYearly}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/progress/generate-monthly-report-button.tsx
+++ b/components/progress/generate-monthly-report-button.tsx
@@ -13,9 +13,11 @@ function toYMD(d: Date): string {
 export function GenerateMonthlyReportButton({
   userId,
   className,
+  onStatusChange,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; needsCode: boolean }) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -53,23 +55,25 @@ export function GenerateMonthlyReportButton({
     let end: Date;
     let show = true;
     if (today.getUTCDate() === lastDayCurrent.getUTCDate()) {
-      start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+      start = new Date(
+        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1),
+      );
       end = lastDayCurrent;
       const dailyKey = `daily-report-generated-${userId}-${date}`;
       show = window.localStorage.getItem(dailyKey) === 'true';
     } else {
-      end = new Date(
-        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0),
-      );
+      end = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
       start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
     }
     const startStr = toYMD(start);
     const endStr = toYMD(end);
     setRange({ start: startStr, end: endStr });
     const key = `monthly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const needs = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(needs);
     setVisible(show);
-  }, [currentDate, userId]);
+    onStatusChange?.({ visible: show, needsCode: needs });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 

--- a/components/progress/generate-weekly-report-button.tsx
+++ b/components/progress/generate-weekly-report-button.tsx
@@ -13,9 +13,11 @@ function toYMD(d: Date): string {
 export function GenerateWeeklyReportButton({
   userId,
   className,
+  onStatusChange,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; needsCode: boolean }) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -55,14 +57,16 @@ export function GenerateWeeklyReportButton({
     const endStr = toYMD(end);
     setRange({ start: startStr, end: endStr });
     const key = `weekly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const needs = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(needs);
+    let show = true;
     if (day === 0) {
       const dailyKey = `daily-report-generated-${userId}-${date}`;
-      setVisible(window.localStorage.getItem(dailyKey) === 'true');
-    } else {
-      setVisible(true);
+      show = window.localStorage.getItem(dailyKey) === 'true';
     }
-  }, [currentDate, userId]);
+    setVisible(show);
+    onStatusChange?.({ visible: show, needsCode: needs });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 

--- a/components/progress/generate-yearly-report-button.tsx
+++ b/components/progress/generate-yearly-report-button.tsx
@@ -13,9 +13,11 @@ function toYMD(d: Date): string {
 export function GenerateYearlyReportButton({
   userId,
   className,
+  onStatusChange,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; needsCode: boolean }) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -67,9 +69,11 @@ export function GenerateYearlyReportButton({
     const endStr = `${year}-12-31`;
     setRange({ start: startStr, end: endStr });
     const key = `yearly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const needs = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(needs);
     setVisible(show);
-  }, [currentDate, userId]);
+    onStatusChange?.({ visible: show, needsCode: needs });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -116,7 +120,9 @@ export function GenerateYearlyReportButton({
         disabled={loading}
         className={cn(
           'flex items-center gap-2 text-white',
-          needsCode ? 'bg-orange-500 hover:bg-orange-600' : 'bg-green-500 hover:bg-green-600',
+          needsCode
+            ? 'bg-orange-500 hover:bg-orange-600'
+            : 'bg-green-500 hover:bg-green-600',
         )}
       >
         {loading && (


### PR DESCRIPTION
## Summary
- center daily report button and enlarge it
- add animated "new" menu revealing weekly, monthly, and yearly report buttons
- expose status callbacks from report buttons

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b04d8fa9f0832ab417ea329192b267