### PR TITLE
Redesign assessment buttons with animated menu

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -241,3 +241,5 @@
 - 2025-10-27: Added monthly assessment agent with generation button, API route, database storage, overview pages for owners and viewers, and difficulty labels.
 - 2025-10-27: Added yearly assessment agent with generation button, API route, database storage, overview pages, and difficulty labels.
 - 2025-10-27: Moved yearly assessment button to the left of the daily button so it stays visible.
+- 2025-10-27: Redesigned assessment generation with a centered daily button and animated "new" toggle for weekly, monthly, and yearly reports.
+- 2025-10-27: Hid weekly/monthly/yearly report buttons inside a "new" dropdown so only the daily button shows on home.

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { slices } from './slices';
 import { Cake3D } from './cake-3d';
@@ -12,6 +12,7 @@ import { GenerateDailyReportButton } from '@/components/progress/generate-daily-
 import { GenerateWeeklyReportButton } from '@/components/progress/generate-weekly-report-button';
 import { GenerateMonthlyReportButton } from '@/components/progress/generate-monthly-report-button';
 import { GenerateYearlyReportButton } from '@/components/progress/generate-yearly-report-button';
+import { cn } from '@/lib/utils';
 
 export function CakeNavigation() {
   const router = useRouter();
@@ -26,6 +27,111 @@ export function CakeNavigation() {
   const secretTimer = useRef<NodeJS.Timeout | null>(null);
   const secretClicks = useRef(0);
   const [timeMachineOpen, setTimeMachineOpen] = useState(false);
+  const [showExtraReports, setShowExtraReports] = useState(false);
+  const [weeklyStatus, setWeeklyStatus] = useState({
+    visible: false,
+    pending: false,
+  });
+  const [monthlyStatus, setMonthlyStatus] = useState({
+    visible: false,
+    pending: false,
+  });
+  const [yearlyStatus, setYearlyStatus] = useState({
+    visible: false,
+    pending: false,
+  });
+
+  const currentDate = useCallback(() => {
+    const params = new URLSearchParams(window.location.search);
+    params.set('userId', String(ctx.ownerId));
+    const dateParam = params.get('apoc_date');
+    let date = dateParam || '';
+    if (!date) {
+      const match = document.cookie.match(/apoc_clock=([^;]+)/);
+      if (match) {
+        const d = new Date(decodeURIComponent(match[1]));
+        if (!isNaN(d.getTime())) date = d.toISOString().slice(0, 10);
+      }
+      if (!date) date = new Date().toISOString().slice(0, 10);
+    }
+    return { date };
+  }, [ctx.ownerId]);
+
+  const computeWeeklyStatus = useCallback(() => {
+    const { date } = currentDate();
+    const today = new Date(date);
+    const day = today.getUTCDay();
+    const end = new Date(today);
+    if (day !== 0) end.setUTCDate(end.getUTCDate() - day);
+    const start = new Date(end);
+    start.setUTCDate(end.getUTCDate() - 6);
+    const startStr = start.toISOString().slice(0, 10);
+    let show = true;
+    if (day === 0) {
+      const dailyKey = `daily-report-generated-${ctx.ownerId}-${date}`;
+      show = window.localStorage.getItem(dailyKey) === 'true';
+    }
+    const key = `weekly-report-generated-${ctx.ownerId}-${startStr}`;
+    const generated = window.localStorage.getItem(key) === 'true';
+    return { visible: show, pending: show && !generated };
+  }, [currentDate, ctx.ownerId]);
+
+  const computeMonthlyStatus = useCallback(() => {
+    const { date } = currentDate();
+    const today = new Date(date);
+    const lastDayCurrent = new Date(
+      Date.UTC(today.getUTCFullYear(), today.getUTCMonth() + 1, 0),
+    );
+    let start: Date;
+    let end: Date;
+    let show = true;
+    if (today.getUTCDate() === lastDayCurrent.getUTCDate()) {
+      start = new Date(
+        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1),
+      );
+      end = lastDayCurrent;
+      const dailyKey = `daily-report-generated-${ctx.ownerId}-${date}`;
+      show = window.localStorage.getItem(dailyKey) === 'true';
+    } else {
+      end = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
+      start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
+    }
+    const startStr = start.toISOString().slice(0, 10);
+    const key = `monthly-report-generated-${ctx.ownerId}-${startStr}`;
+    const generated = window.localStorage.getItem(key) === 'true';
+    return { visible: show, pending: show && !generated };
+  }, [currentDate, ctx.ownerId]);
+
+  const computeYearlyStatus = useCallback(() => {
+    const { date } = currentDate();
+    const today = new Date(date);
+    let year = today.getUTCFullYear();
+    const month = today.getUTCMonth();
+    const day = today.getUTCDate();
+    let show = false;
+    if (month === 11 && day === 31) {
+      const decStart = `${year}-12-01`;
+      const dailyKey = `daily-report-generated-${ctx.ownerId}-${date}`;
+      const monthlyKey = `monthly-report-generated-${ctx.ownerId}-${decStart}`;
+      show =
+        window.localStorage.getItem(dailyKey) === 'true' &&
+        window.localStorage.getItem(monthlyKey) === 'true';
+    } else if (month === 0) {
+      year = year - 1;
+      const decStart = `${year}-12-01`;
+      const monthlyKey = `monthly-report-generated-${ctx.ownerId}-${decStart}`;
+      show = window.localStorage.getItem(monthlyKey) === 'true';
+    }
+    const startStr = `${year}-01-01`;
+    const key = `yearly-report-generated-${ctx.ownerId}-${startStr}`;
+    const generated = window.localStorage.getItem(key) === 'true';
+    return { visible: show, pending: show && !generated };
+  }, [currentDate, ctx.ownerId]);
+
+  const indicatorVisible =
+    weeklyStatus.visible || monthlyStatus.visible || yearlyStatus.visible;
+  const indicatorPending =
+    weeklyStatus.pending || monthlyStatus.pending || yearlyStatus.pending;
 
   useEffect(() => {
     const computeOffset = () => {
@@ -60,6 +166,17 @@ export function CakeNavigation() {
     media.addEventListener('change', handler);
     return () => media.removeEventListener('change', handler);
   }, []);
+
+  useEffect(() => {
+    const compute = () => {
+      setWeeklyStatus(computeWeeklyStatus());
+      setMonthlyStatus(computeMonthlyStatus());
+      setYearlyStatus(computeYearlyStatus());
+    };
+    compute();
+    window.addEventListener('storage', compute);
+    return () => window.removeEventListener('storage', compute);
+  }, [computeWeeklyStatus, computeMonthlyStatus, computeYearlyStatus]);
 
   function handleEnter(slug: string) {
     if (clearTimer.current) {
@@ -141,16 +258,46 @@ export function CakeNavigation() {
       <div className="grid w-full place-items-center relative">
         {ctx.editable && (
           <div
-            className="absolute -translate-x-1/2 flex gap-2"
-            style={{
-              top: '-66px',
-              left: '50%',
-            }}
+            className="absolute -translate-x-1/2"
+            style={{ top: '-66px', left: '50%' }}
           >
-            <GenerateYearlyReportButton userId={ctx.ownerId} />
-            <GenerateDailyReportButton userId={ctx.ownerId} />
-            <GenerateWeeklyReportButton userId={ctx.ownerId} />
-            <GenerateMonthlyReportButton userId={ctx.ownerId} />
+            <div className="relative flex justify-center">
+              <GenerateDailyReportButton
+                userId={ctx.ownerId}
+                buttonClassName="px-8 py-4 text-lg"
+              />
+              {indicatorVisible && (
+                <div className="absolute left-full ml-4">
+                  <button
+                    onClick={() => setShowExtraReports((v) => !v)}
+                    className={cn(
+                      'rounded px-3 py-2 text-white',
+                      indicatorPending
+                        ? 'bg-green-500 hover:bg-green-600 animate-bounce'
+                        : 'bg-orange-500 hover:bg-orange-600',
+                    )}
+                  >
+                    new
+                  </button>
+                  {showExtraReports && (
+                    <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 flex flex-col gap-2">
+                      <GenerateWeeklyReportButton
+                        userId={ctx.ownerId}
+                        onStatusChange={setWeeklyStatus}
+                      />
+                      <GenerateMonthlyReportButton
+                        userId={ctx.ownerId}
+                        onStatusChange={setMonthlyStatus}
+                      />
+                      <GenerateYearlyReportButton
+                        userId={ctx.ownerId}
+                        onStatusChange={setYearlyStatus}
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
         )}
         <nav

--- a/components/progress/generate-daily-report-button.tsx
+++ b/components/progress/generate-daily-report-button.tsx
@@ -9,9 +9,11 @@ import { cn } from '@/lib/utils';
 export function GenerateDailyReportButton({
   userId,
   className,
+  buttonClassName,
 }: {
   userId: number;
   className?: string;
+  buttonClassName?: string;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -103,6 +105,7 @@ export function GenerateDailyReportButton({
           needsCode
             ? 'bg-orange-500 hover:bg-orange-600'
             : 'bg-green-500 hover:bg-green-600',
+          buttonClassName,
         )}
       >
         {loading && (

--- a/components/progress/generate-monthly-report-button.tsx
+++ b/components/progress/generate-monthly-report-button.tsx
@@ -13,9 +13,11 @@ function toYMD(d: Date): string {
 export function GenerateMonthlyReportButton({
   userId,
   className,
+  onStatusChange,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; pending: boolean }) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -53,23 +55,25 @@ export function GenerateMonthlyReportButton({
     let end: Date;
     let show = true;
     if (today.getUTCDate() === lastDayCurrent.getUTCDate()) {
-      start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+      start = new Date(
+        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1),
+      );
       end = lastDayCurrent;
       const dailyKey = `daily-report-generated-${userId}-${date}`;
       show = window.localStorage.getItem(dailyKey) === 'true';
     } else {
-      end = new Date(
-        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0),
-      );
+      end = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
       start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
     }
     const startStr = toYMD(start);
     const endStr = toYMD(end);
     setRange({ start: startStr, end: endStr });
     const key = `monthly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const generated = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(generated);
     setVisible(show);
-  }, [currentDate, userId]);
+    onStatusChange?.({ visible: show, pending: show && !generated });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -105,6 +109,7 @@ export function GenerateMonthlyReportButton({
       const key = `monthly-report-generated-${userId}-${range.start}`;
       window.localStorage.setItem(key, 'true');
       setNeedsCode(true);
+      onStatusChange?.({ visible: true, pending: false });
       router.refresh();
     }
   };

--- a/components/progress/generate-weekly-report-button.tsx
+++ b/components/progress/generate-weekly-report-button.tsx
@@ -13,9 +13,11 @@ function toYMD(d: Date): string {
 export function GenerateWeeklyReportButton({
   userId,
   className,
+  onStatusChange,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; pending: boolean }) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -55,14 +57,16 @@ export function GenerateWeeklyReportButton({
     const endStr = toYMD(end);
     setRange({ start: startStr, end: endStr });
     const key = `weekly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const generated = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(generated);
+    let show = true;
     if (day === 0) {
       const dailyKey = `daily-report-generated-${userId}-${date}`;
-      setVisible(window.localStorage.getItem(dailyKey) === 'true');
-    } else {
-      setVisible(true);
+      show = window.localStorage.getItem(dailyKey) === 'true';
     }
-  }, [currentDate, userId]);
+    setVisible(show);
+    onStatusChange?.({ visible: show, pending: show && !generated });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -98,6 +102,7 @@ export function GenerateWeeklyReportButton({
       const key = `weekly-report-generated-${userId}-${range.start}`;
       window.localStorage.setItem(key, 'true');
       setNeedsCode(true);
+      onStatusChange?.({ visible: true, pending: false });
       router.refresh();
     }
   };

--- a/components/progress/generate-yearly-report-button.tsx
+++ b/components/progress/generate-yearly-report-button.tsx
@@ -13,9 +13,11 @@ function toYMD(d: Date): string {
 export function GenerateYearlyReportButton({
   userId,
   className,
+  onStatusChange,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; pending: boolean }) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -67,9 +69,11 @@ export function GenerateYearlyReportButton({
     const endStr = `${year}-12-31`;
     setRange({ start: startStr, end: endStr });
     const key = `yearly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const generated = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(generated);
     setVisible(show);
-  }, [currentDate, userId]);
+    onStatusChange?.({ visible: show, pending: show && !generated });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -105,6 +109,7 @@ export function GenerateYearlyReportButton({
       const key = `yearly-report-generated-${userId}-${range.start}`;
       window.localStorage.setItem(key, 'true');
       setNeedsCode(true);
+      onStatusChange?.({ visible: true, pending: false });
       router.refresh();
     }
   };
@@ -116,7 +121,9 @@ export function GenerateYearlyReportButton({
         disabled={loading}
         className={cn(
           'flex items-center gap-2 text-white',
-          needsCode ? 'bg-orange-500 hover:bg-orange-600' : 'bg-green-500 hover:bg-green-600',
+          needsCode
+            ? 'bg-orange-500 hover:bg-orange-600'
+            : 'bg-green-500 hover:bg-green-600',
         )}
       >
         {loading && (


### PR DESCRIPTION
## Summary
- Compute pending status for weekly, monthly, and yearly reports
- Hide extra report buttons inside a "new" dropdown beside the daily button

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b04d8fa9f0832ab417ea329192b267