### PR TITLE
Redesign assessment buttons with animated menu

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -241,3 +241,6 @@
 - 2025-10-27: Added monthly assessment agent with generation button, API route, database storage, overview pages for owners and viewers, and difficulty labels.
 - 2025-10-27: Added yearly assessment agent with generation button, API route, database storage, overview pages, and difficulty labels.
 - 2025-10-27: Moved yearly assessment button to the left of the daily button so it stays visible.
+- 2025-10-27: Redesigned assessment generation with a centered daily button and animated "new" toggle for weekly, monthly, and yearly reports.
+- 2025-10-27: Hid weekly/monthly/yearly report buttons inside a "new" dropdown so only the daily button shows on home.
+- 2025-10-27: Placed "new" button beside daily, opened blurred full-screen menu with large weekly/monthly/yearly buttons and close action.

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { slices } from './slices';
 import { Cake3D } from './cake-3d';
@@ -12,6 +12,7 @@ import { GenerateDailyReportButton } from '@/components/progress/generate-daily-
 import { GenerateWeeklyReportButton } from '@/components/progress/generate-weekly-report-button';
 import { GenerateMonthlyReportButton } from '@/components/progress/generate-monthly-report-button';
 import { GenerateYearlyReportButton } from '@/components/progress/generate-yearly-report-button';
+import { cn } from '@/lib/utils';
 
 export function CakeNavigation() {
   const router = useRouter();
@@ -26,6 +27,111 @@ export function CakeNavigation() {
   const secretTimer = useRef<NodeJS.Timeout | null>(null);
   const secretClicks = useRef(0);
   const [timeMachineOpen, setTimeMachineOpen] = useState(false);
+  const [showExtraReports, setShowExtraReports] = useState(false);
+  const [weeklyStatus, setWeeklyStatus] = useState({
+    visible: false,
+    pending: false,
+  });
+  const [monthlyStatus, setMonthlyStatus] = useState({
+    visible: false,
+    pending: false,
+  });
+  const [yearlyStatus, setYearlyStatus] = useState({
+    visible: false,
+    pending: false,
+  });
+
+  const currentDate = useCallback(() => {
+    const params = new URLSearchParams(window.location.search);
+    params.set('userId', String(ctx.ownerId));
+    const dateParam = params.get('apoc_date');
+    let date = dateParam || '';
+    if (!date) {
+      const match = document.cookie.match(/apoc_clock=([^;]+)/);
+      if (match) {
+        const d = new Date(decodeURIComponent(match[1]));
+        if (!isNaN(d.getTime())) date = d.toISOString().slice(0, 10);
+      }
+      if (!date) date = new Date().toISOString().slice(0, 10);
+    }
+    return { date };
+  }, [ctx.ownerId]);
+
+  const computeWeeklyStatus = useCallback(() => {
+    const { date } = currentDate();
+    const today = new Date(date);
+    const day = today.getUTCDay();
+    const end = new Date(today);
+    if (day !== 0) end.setUTCDate(end.getUTCDate() - day);
+    const start = new Date(end);
+    start.setUTCDate(end.getUTCDate() - 6);
+    const startStr = start.toISOString().slice(0, 10);
+    let show = true;
+    if (day === 0) {
+      const dailyKey = `daily-report-generated-${ctx.ownerId}-${date}`;
+      show = window.localStorage.getItem(dailyKey) === 'true';
+    }
+    const key = `weekly-report-generated-${ctx.ownerId}-${startStr}`;
+    const generated = window.localStorage.getItem(key) === 'true';
+    return { visible: show, pending: show && !generated };
+  }, [currentDate, ctx.ownerId]);
+
+  const computeMonthlyStatus = useCallback(() => {
+    const { date } = currentDate();
+    const today = new Date(date);
+    const lastDayCurrent = new Date(
+      Date.UTC(today.getUTCFullYear(), today.getUTCMonth() + 1, 0),
+    );
+    let start: Date;
+    let end: Date;
+    let show = true;
+    if (today.getUTCDate() === lastDayCurrent.getUTCDate()) {
+      start = new Date(
+        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1),
+      );
+      end = lastDayCurrent;
+      const dailyKey = `daily-report-generated-${ctx.ownerId}-${date}`;
+      show = window.localStorage.getItem(dailyKey) === 'true';
+    } else {
+      end = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
+      start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
+    }
+    const startStr = start.toISOString().slice(0, 10);
+    const key = `monthly-report-generated-${ctx.ownerId}-${startStr}`;
+    const generated = window.localStorage.getItem(key) === 'true';
+    return { visible: show, pending: show && !generated };
+  }, [currentDate, ctx.ownerId]);
+
+  const computeYearlyStatus = useCallback(() => {
+    const { date } = currentDate();
+    const today = new Date(date);
+    let year = today.getUTCFullYear();
+    const month = today.getUTCMonth();
+    const day = today.getUTCDate();
+    let show = false;
+    if (month === 11 && day === 31) {
+      const decStart = `${year}-12-01`;
+      const dailyKey = `daily-report-generated-${ctx.ownerId}-${date}`;
+      const monthlyKey = `monthly-report-generated-${ctx.ownerId}-${decStart}`;
+      show =
+        window.localStorage.getItem(dailyKey) === 'true' &&
+        window.localStorage.getItem(monthlyKey) === 'true';
+    } else if (month === 0) {
+      year = year - 1;
+      const decStart = `${year}-12-01`;
+      const monthlyKey = `monthly-report-generated-${ctx.ownerId}-${decStart}`;
+      show = window.localStorage.getItem(monthlyKey) === 'true';
+    }
+    const startStr = `${year}-01-01`;
+    const key = `yearly-report-generated-${ctx.ownerId}-${startStr}`;
+    const generated = window.localStorage.getItem(key) === 'true';
+    return { visible: show, pending: show && !generated };
+  }, [currentDate, ctx.ownerId]);
+
+  const indicatorVisible =
+    weeklyStatus.visible || monthlyStatus.visible || yearlyStatus.visible;
+  const indicatorPending =
+    weeklyStatus.pending || monthlyStatus.pending || yearlyStatus.pending;
 
   useEffect(() => {
     const computeOffset = () => {
@@ -60,6 +166,17 @@ export function CakeNavigation() {
     media.addEventListener('change', handler);
     return () => media.removeEventListener('change', handler);
   }, []);
+
+  useEffect(() => {
+    const compute = () => {
+      setWeeklyStatus(computeWeeklyStatus());
+      setMonthlyStatus(computeMonthlyStatus());
+      setYearlyStatus(computeYearlyStatus());
+    };
+    compute();
+    window.addEventListener('storage', compute);
+    return () => window.removeEventListener('storage', compute);
+  }, [computeWeeklyStatus, computeMonthlyStatus, computeYearlyStatus]);
 
   function handleEnter(slug: string) {
     if (clearTimer.current) {
@@ -140,18 +257,66 @@ export function CakeNavigation() {
       </div>
       <div className="grid w-full place-items-center relative">
         {ctx.editable && (
-          <div
-            className="absolute -translate-x-1/2 flex gap-2"
-            style={{
-              top: '-66px',
-              left: '50%',
-            }}
-          >
-            <GenerateYearlyReportButton userId={ctx.ownerId} />
-            <GenerateDailyReportButton userId={ctx.ownerId} />
-            <GenerateWeeklyReportButton userId={ctx.ownerId} />
-            <GenerateMonthlyReportButton userId={ctx.ownerId} />
-          </div>
+          <>
+            <div
+              className="absolute -translate-x-1/2"
+              style={{ top: '-66px', left: '50%' }}
+            >
+              <div className="relative flex justify-center">
+                <GenerateDailyReportButton
+                  userId={ctx.ownerId}
+                  buttonClassName="px-8 py-4 text-lg"
+                />
+                {indicatorVisible && (
+                  <div className="absolute left-full ml-4">
+                    <button
+                      onClick={() => setShowExtraReports(true)}
+                      className={cn(
+                        'rounded px-6 py-4 text-lg text-white',
+                        indicatorPending
+                          ? 'bg-green-500 hover:bg-green-600 animate-bounce'
+                          : 'bg-orange-500 hover:bg-orange-600',
+                      )}
+                    >
+                      new
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+            {showExtraReports && (
+              <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+                <div className="relative w-full max-w-lg p-4">
+                  <button
+                    onClick={() => setShowExtraReports(false)}
+                    className="absolute right-4 top-4 rounded bg-orange-500 px-4 py-2 text-white hover:bg-orange-600"
+                  >
+                    Close
+                  </button>
+                  <div className="flex flex-col items-center gap-6 pt-10">
+                    <GenerateWeeklyReportButton
+                      userId={ctx.ownerId}
+                      onStatusChange={setWeeklyStatus}
+                      className="w-full"
+                      buttonClassName="w-full py-6 text-lg whitespace-normal"
+                    />
+                    <GenerateMonthlyReportButton
+                      userId={ctx.ownerId}
+                      onStatusChange={setMonthlyStatus}
+                      className="w-full"
+                      buttonClassName="w-full py-6 text-lg whitespace-normal"
+                    />
+                    <GenerateYearlyReportButton
+                      userId={ctx.ownerId}
+                      onStatusChange={setYearlyStatus}
+                      className="w-full"
+                      buttonClassName="w-full py-6 text-lg whitespace-normal"
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+          </>
         )}
         <nav
           className="grid grid-cols-2 place-items-center gap-3 sm:grid-cols-3 xl:grid-cols-6"

--- a/components/progress/generate-daily-report-button.tsx
+++ b/components/progress/generate-daily-report-button.tsx
@@ -9,9 +9,11 @@ import { cn } from '@/lib/utils';
 export function GenerateDailyReportButton({
   userId,
   className,
+  buttonClassName,
 }: {
   userId: number;
   className?: string;
+  buttonClassName?: string;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -103,6 +105,7 @@ export function GenerateDailyReportButton({
           needsCode
             ? 'bg-orange-500 hover:bg-orange-600'
             : 'bg-green-500 hover:bg-green-600',
+          buttonClassName,
         )}
       >
         {loading && (

--- a/components/progress/generate-monthly-report-button.tsx
+++ b/components/progress/generate-monthly-report-button.tsx
@@ -13,9 +13,13 @@ function toYMD(d: Date): string {
 export function GenerateMonthlyReportButton({
   userId,
   className,
+  onStatusChange,
+  buttonClassName,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; pending: boolean }) => void;
+  buttonClassName?: string;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -53,23 +57,25 @@ export function GenerateMonthlyReportButton({
     let end: Date;
     let show = true;
     if (today.getUTCDate() === lastDayCurrent.getUTCDate()) {
-      start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+      start = new Date(
+        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1),
+      );
       end = lastDayCurrent;
       const dailyKey = `daily-report-generated-${userId}-${date}`;
       show = window.localStorage.getItem(dailyKey) === 'true';
     } else {
-      end = new Date(
-        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0),
-      );
+      end = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
       start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
     }
     const startStr = toYMD(start);
     const endStr = toYMD(end);
     setRange({ start: startStr, end: endStr });
     const key = `monthly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const generated = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(generated);
     setVisible(show);
-  }, [currentDate, userId]);
+    onStatusChange?.({ visible: show, pending: show && !generated });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -105,6 +111,7 @@ export function GenerateMonthlyReportButton({
       const key = `monthly-report-generated-${userId}-${range.start}`;
       window.localStorage.setItem(key, 'true');
       setNeedsCode(true);
+      onStatusChange?.({ visible: true, pending: false });
       router.refresh();
     }
   };
@@ -115,10 +122,11 @@ export function GenerateMonthlyReportButton({
         onClick={onClick}
         disabled={loading}
         className={cn(
-          'flex items-center gap-2 text-white',
+          'flex w-full items-center justify-center gap-2 text-white',
           needsCode
             ? 'bg-orange-500 hover:bg-orange-600'
             : 'bg-green-500 hover:bg-green-600',
+          buttonClassName,
         )}
       >
         {loading && (
@@ -128,7 +136,9 @@ export function GenerateMonthlyReportButton({
           ? 'Generating…'
           : `Generate monthly rapport for ${range.start} - ${range.end}`}
       </Button>
-      {message && <p className="mt-2 text-sm">{message}</p>}
+      {message && (
+        <p className="mt-4 text-center text-lg">{message}</p>
+      )}
     </div>
   );
 }

--- a/components/progress/generate-weekly-report-button.tsx
+++ b/components/progress/generate-weekly-report-button.tsx
@@ -13,9 +13,13 @@ function toYMD(d: Date): string {
 export function GenerateWeeklyReportButton({
   userId,
   className,
+  onStatusChange,
+  buttonClassName,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; pending: boolean }) => void;
+  buttonClassName?: string;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -55,14 +59,16 @@ export function GenerateWeeklyReportButton({
     const endStr = toYMD(end);
     setRange({ start: startStr, end: endStr });
     const key = `weekly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const generated = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(generated);
+    let show = true;
     if (day === 0) {
       const dailyKey = `daily-report-generated-${userId}-${date}`;
-      setVisible(window.localStorage.getItem(dailyKey) === 'true');
-    } else {
-      setVisible(true);
+      show = window.localStorage.getItem(dailyKey) === 'true';
     }
-  }, [currentDate, userId]);
+    setVisible(show);
+    onStatusChange?.({ visible: show, pending: show && !generated });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -98,6 +104,7 @@ export function GenerateWeeklyReportButton({
       const key = `weekly-report-generated-${userId}-${range.start}`;
       window.localStorage.setItem(key, 'true');
       setNeedsCode(true);
+      onStatusChange?.({ visible: true, pending: false });
       router.refresh();
     }
   };
@@ -108,10 +115,11 @@ export function GenerateWeeklyReportButton({
         onClick={onClick}
         disabled={loading}
         className={cn(
-          'flex items-center gap-2 text-white',
+          'flex w-full items-center justify-center gap-2 text-white',
           needsCode
             ? 'bg-orange-500 hover:bg-orange-600'
             : 'bg-green-500 hover:bg-green-600',
+          buttonClassName,
         )}
       >
         {loading && (
@@ -121,7 +129,9 @@ export function GenerateWeeklyReportButton({
           ? 'Generating…'
           : `Generate weekly rapport for ${range.start} - ${range.end}`}
       </Button>
-      {message && <p className="mt-2 text-sm">{message}</p>}
+      {message && (
+        <p className="mt-4 text-center text-lg">{message}</p>
+      )}
     </div>
   );
 }

--- a/components/progress/generate-yearly-report-button.tsx
+++ b/components/progress/generate-yearly-report-button.tsx
@@ -13,9 +13,13 @@ function toYMD(d: Date): string {
 export function GenerateYearlyReportButton({
   userId,
   className,
+  onStatusChange,
+  buttonClassName,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; pending: boolean }) => void;
+  buttonClassName?: string;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -67,9 +71,11 @@ export function GenerateYearlyReportButton({
     const endStr = `${year}-12-31`;
     setRange({ start: startStr, end: endStr });
     const key = `yearly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const generated = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(generated);
     setVisible(show);
-  }, [currentDate, userId]);
+    onStatusChange?.({ visible: show, pending: show && !generated });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -105,6 +111,7 @@ export function GenerateYearlyReportButton({
       const key = `yearly-report-generated-${userId}-${range.start}`;
       window.localStorage.setItem(key, 'true');
       setNeedsCode(true);
+      onStatusChange?.({ visible: true, pending: false });
       router.refresh();
     }
   };
@@ -115,8 +122,11 @@ export function GenerateYearlyReportButton({
         onClick={onClick}
         disabled={loading}
         className={cn(
-          'flex items-center gap-2 text-white',
-          needsCode ? 'bg-orange-500 hover:bg-orange-600' : 'bg-green-500 hover:bg-green-600',
+          'flex w-full items-center justify-center gap-2 text-white',
+          needsCode
+            ? 'bg-orange-500 hover:bg-orange-600'
+            : 'bg-green-500 hover:bg-green-600',
+          buttonClassName,
         )}
       >
         {loading && (
@@ -126,7 +136,9 @@ export function GenerateYearlyReportButton({
           ? 'Generating…'
           : `Generate yearly rapport for ${range.start} - ${range.end}`}
       </Button>
-      {message && <p className="mt-2 text-sm">{message}</p>}
+      {message && (
+        <p className="mt-4 text-center text-lg">{message}</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Move "new" assessment toggle beside the daily button and match its size
- Replace dropdown with full-screen blurred overlay presenting weekly, monthly, and yearly options
- Expand assessment buttons and keep overlay visible to show completion messages until closed

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b04d8fa9f0832ab417ea329192b267