### PR TITLE
Redesign assessment buttons with animated menu

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -241,3 +241,7 @@
 - 2025-10-27: Added monthly assessment agent with generation button, API route, database storage, overview pages for owners and viewers, and difficulty labels.
 - 2025-10-27: Added yearly assessment agent with generation button, API route, database storage, overview pages, and difficulty labels.
 - 2025-10-27: Moved yearly assessment button to the left of the daily button so it stays visible.
+- 2025-10-27: Redesigned assessment generation with a centered daily button and animated "new" toggle for weekly, monthly, and yearly reports.
+- 2025-10-27: Hid weekly/monthly/yearly report buttons inside a "new" dropdown so only the daily button shows on home.
+- 2025-10-27: Enlarged extra report menu into a full-screen overlay with blurred background, big buttons, and post-generation message display until closed.
+- 2025-10-27: Positioned "new" indicator to the right of the daily report button and shifted the daily button left for balance.

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { slices } from './slices';
 import { Cake3D } from './cake-3d';
@@ -12,6 +12,7 @@ import { GenerateDailyReportButton } from '@/components/progress/generate-daily-
 import { GenerateWeeklyReportButton } from '@/components/progress/generate-weekly-report-button';
 import { GenerateMonthlyReportButton } from '@/components/progress/generate-monthly-report-button';
 import { GenerateYearlyReportButton } from '@/components/progress/generate-yearly-report-button';
+import { cn } from '@/lib/utils';
 
 export function CakeNavigation() {
   const router = useRouter();
@@ -26,6 +27,112 @@ export function CakeNavigation() {
   const secretTimer = useRef<NodeJS.Timeout | null>(null);
   const secretClicks = useRef(0);
   const [timeMachineOpen, setTimeMachineOpen] = useState(false);
+  const [showExtraReports, setShowExtraReports] = useState(false);
+  const [overlayMessage, setOverlayMessage] = useState<string | null>(null);
+  const [weeklyStatus, setWeeklyStatus] = useState({
+    visible: false,
+    pending: false,
+  });
+  const [monthlyStatus, setMonthlyStatus] = useState({
+    visible: false,
+    pending: false,
+  });
+  const [yearlyStatus, setYearlyStatus] = useState({
+    visible: false,
+    pending: false,
+  });
+
+  const currentDate = useCallback(() => {
+    const params = new URLSearchParams(window.location.search);
+    params.set('userId', String(ctx.ownerId));
+    const dateParam = params.get('apoc_date');
+    let date = dateParam || '';
+    if (!date) {
+      const match = document.cookie.match(/apoc_clock=([^;]+)/);
+      if (match) {
+        const d = new Date(decodeURIComponent(match[1]));
+        if (!isNaN(d.getTime())) date = d.toISOString().slice(0, 10);
+      }
+      if (!date) date = new Date().toISOString().slice(0, 10);
+    }
+    return { date };
+  }, [ctx.ownerId]);
+
+  const computeWeeklyStatus = useCallback(() => {
+    const { date } = currentDate();
+    const today = new Date(date);
+    const day = today.getUTCDay();
+    const end = new Date(today);
+    if (day !== 0) end.setUTCDate(end.getUTCDate() - day);
+    const start = new Date(end);
+    start.setUTCDate(end.getUTCDate() - 6);
+    const startStr = start.toISOString().slice(0, 10);
+    let show = true;
+    if (day === 0) {
+      const dailyKey = `daily-report-generated-${ctx.ownerId}-${date}`;
+      show = window.localStorage.getItem(dailyKey) === 'true';
+    }
+    const key = `weekly-report-generated-${ctx.ownerId}-${startStr}`;
+    const generated = window.localStorage.getItem(key) === 'true';
+    return { visible: show, pending: show && !generated };
+  }, [currentDate, ctx.ownerId]);
+
+  const computeMonthlyStatus = useCallback(() => {
+    const { date } = currentDate();
+    const today = new Date(date);
+    const lastDayCurrent = new Date(
+      Date.UTC(today.getUTCFullYear(), today.getUTCMonth() + 1, 0),
+    );
+    let start: Date;
+    let end: Date;
+    let show = true;
+    if (today.getUTCDate() === lastDayCurrent.getUTCDate()) {
+      start = new Date(
+        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1),
+      );
+      end = lastDayCurrent;
+      const dailyKey = `daily-report-generated-${ctx.ownerId}-${date}`;
+      show = window.localStorage.getItem(dailyKey) === 'true';
+    } else {
+      end = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
+      start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
+    }
+    const startStr = start.toISOString().slice(0, 10);
+    const key = `monthly-report-generated-${ctx.ownerId}-${startStr}`;
+    const generated = window.localStorage.getItem(key) === 'true';
+    return { visible: show, pending: show && !generated };
+  }, [currentDate, ctx.ownerId]);
+
+  const computeYearlyStatus = useCallback(() => {
+    const { date } = currentDate();
+    const today = new Date(date);
+    let year = today.getUTCFullYear();
+    const month = today.getUTCMonth();
+    const day = today.getUTCDate();
+    let show = false;
+    if (month === 11 && day === 31) {
+      const decStart = `${year}-12-01`;
+      const dailyKey = `daily-report-generated-${ctx.ownerId}-${date}`;
+      const monthlyKey = `monthly-report-generated-${ctx.ownerId}-${decStart}`;
+      show =
+        window.localStorage.getItem(dailyKey) === 'true' &&
+        window.localStorage.getItem(monthlyKey) === 'true';
+    } else if (month === 0) {
+      year = year - 1;
+      const decStart = `${year}-12-01`;
+      const monthlyKey = `monthly-report-generated-${ctx.ownerId}-${decStart}`;
+      show = window.localStorage.getItem(monthlyKey) === 'true';
+    }
+    const startStr = `${year}-01-01`;
+    const key = `yearly-report-generated-${ctx.ownerId}-${startStr}`;
+    const generated = window.localStorage.getItem(key) === 'true';
+    return { visible: show, pending: show && !generated };
+  }, [currentDate, ctx.ownerId]);
+
+  const indicatorVisible =
+    weeklyStatus.visible || monthlyStatus.visible || yearlyStatus.visible;
+  const indicatorPending =
+    weeklyStatus.pending || monthlyStatus.pending || yearlyStatus.pending;
 
   useEffect(() => {
     const computeOffset = () => {
@@ -60,6 +167,17 @@ export function CakeNavigation() {
     media.addEventListener('change', handler);
     return () => media.removeEventListener('change', handler);
   }, []);
+
+  useEffect(() => {
+    const compute = () => {
+      setWeeklyStatus(computeWeeklyStatus());
+      setMonthlyStatus(computeMonthlyStatus());
+      setYearlyStatus(computeYearlyStatus());
+    };
+    compute();
+    window.addEventListener('storage', compute);
+    return () => window.removeEventListener('storage', compute);
+  }, [computeWeeklyStatus, computeMonthlyStatus, computeYearlyStatus]);
 
   function handleEnter(slug: string) {
     if (clearTimer.current) {
@@ -141,16 +259,31 @@ export function CakeNavigation() {
       <div className="grid w-full place-items-center relative">
         {ctx.editable && (
           <div
-            className="absolute -translate-x-1/2 flex gap-2"
-            style={{
-              top: '-66px',
-              left: '50%',
-            }}
+            className="absolute -translate-x-1/2"
+            style={{ top: '-66px', left: '50%' }}
           >
-            <GenerateYearlyReportButton userId={ctx.ownerId} />
-            <GenerateDailyReportButton userId={ctx.ownerId} />
-            <GenerateWeeklyReportButton userId={ctx.ownerId} />
-            <GenerateMonthlyReportButton userId={ctx.ownerId} />
+            <div className="flex items-center justify-center gap-4">
+              <GenerateDailyReportButton
+                userId={ctx.ownerId}
+                buttonClassName="px-8 py-4 text-lg"
+              />
+              {indicatorVisible && (
+                <button
+                  onClick={() => {
+                    setOverlayMessage(null);
+                    setShowExtraReports(true);
+                  }}
+                  className={cn(
+                    'rounded px-8 py-4 text-lg text-white',
+                    indicatorPending
+                      ? 'bg-green-500 hover:bg-green-600 animate-bounce'
+                      : 'bg-orange-500 hover:bg-orange-600',
+                  )}
+                >
+                  new
+                </button>
+              )}
+            </div>
           </div>
         )}
         <nav
@@ -200,6 +333,51 @@ export function CakeNavigation() {
       <p className="sr-only" aria-live="polite">
         {hoveredLabel}
       </p>
+      {showExtraReports && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          {overlayMessage ? (
+            <div className="mx-4 w-full max-w-md rounded bg-white p-6 text-center text-black shadow-lg space-y-4">
+              <p>{overlayMessage}</p>
+              <button
+                onClick={() => {
+                  setShowExtraReports(false);
+                  setOverlayMessage(null);
+                }}
+                className="rounded bg-orange-500 px-4 py-2 text-white hover:bg-orange-600"
+              >
+                Close
+              </button>
+            </div>
+          ) : (
+            <div className="mx-4 flex w-full max-w-md flex-col gap-6">
+              <GenerateWeeklyReportButton
+                userId={ctx.ownerId}
+                onStatusChange={setWeeklyStatus}
+                onComplete={setOverlayMessage}
+                className="w-full px-8 py-8 text-xl"
+              />
+              <GenerateMonthlyReportButton
+                userId={ctx.ownerId}
+                onStatusChange={setMonthlyStatus}
+                onComplete={setOverlayMessage}
+                className="w-full px-8 py-8 text-xl"
+              />
+              <GenerateYearlyReportButton
+                userId={ctx.ownerId}
+                onStatusChange={setYearlyStatus}
+                onComplete={setOverlayMessage}
+                className="w-full px-8 py-8 text-xl"
+              />
+              <button
+                onClick={() => setShowExtraReports(false)}
+                className="rounded bg-gray-200 px-4 py-2 text-gray-800 hover:bg-gray-300"
+              >
+                Close
+              </button>
+            </div>
+          )}
+        </div>
+      )}
       <TimeMachine
         open={timeMachineOpen}
         onClose={() => setTimeMachineOpen(false)}

--- a/components/progress/generate-daily-report-button.tsx
+++ b/components/progress/generate-daily-report-button.tsx
@@ -9,9 +9,11 @@ import { cn } from '@/lib/utils';
 export function GenerateDailyReportButton({
   userId,
   className,
+  buttonClassName,
 }: {
   userId: number;
   className?: string;
+  buttonClassName?: string;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
@@ -103,6 +105,7 @@ export function GenerateDailyReportButton({
           needsCode
             ? 'bg-orange-500 hover:bg-orange-600'
             : 'bg-green-500 hover:bg-green-600',
+          buttonClassName,
         )}
       >
         {loading && (

--- a/components/progress/generate-monthly-report-button.tsx
+++ b/components/progress/generate-monthly-report-button.tsx
@@ -13,14 +13,17 @@ function toYMD(d: Date): string {
 export function GenerateMonthlyReportButton({
   userId,
   className,
+  onStatusChange,
+  onComplete,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; pending: boolean }) => void;
+  onComplete?: (message: string) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
   const router = useRouter();
-  const [message, setMessage] = useState<string | null>(null);
   const [needsCode, setNeedsCode] = useState(false);
   const [visible, setVisible] = useState(false);
   const [range, setRange] = useState<{ start: string; end: string } | null>(
@@ -53,23 +56,25 @@ export function GenerateMonthlyReportButton({
     let end: Date;
     let show = true;
     if (today.getUTCDate() === lastDayCurrent.getUTCDate()) {
-      start = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+      start = new Date(
+        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1),
+      );
       end = lastDayCurrent;
       const dailyKey = `daily-report-generated-${userId}-${date}`;
       show = window.localStorage.getItem(dailyKey) === 'true';
     } else {
-      end = new Date(
-        Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0),
-      );
+      end = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 0));
       start = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), 1));
     }
     const startStr = toYMD(start);
     const endStr = toYMD(end);
     setRange({ start: startStr, end: endStr });
     const key = `monthly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const generated = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(generated);
     setVisible(show);
-  }, [currentDate, userId]);
+    onStatusChange?.({ visible: show, pending: show && !generated });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -97,38 +102,36 @@ export function GenerateMonthlyReportButton({
     });
     setLoading(false);
     if (data.error) {
-      setMessage(data.error);
+      onComplete?.(data.error);
     } else {
-      setMessage(
-        `Monthly rapport is created. Your score for this month is: ${data.score}`,
-      );
+      const msg = `Monthly rapport is created. Your score for this month is: ${data.score}`;
+      onComplete?.(msg);
       const key = `monthly-report-generated-${userId}-${range.start}`;
       window.localStorage.setItem(key, 'true');
       setNeedsCode(true);
+      onStatusChange?.({ visible: true, pending: false });
       router.refresh();
     }
   };
 
   return (
-    <div className={cn('flex flex-col items-center', className)}>
-      <Button
-        onClick={onClick}
-        disabled={loading}
-        className={cn(
-          'flex items-center gap-2 text-white',
-          needsCode
-            ? 'bg-orange-500 hover:bg-orange-600'
-            : 'bg-green-500 hover:bg-green-600',
-        )}
-      >
-        {loading && (
-          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
-        )}
-        {loading
-          ? 'Generating…'
-          : `Generate monthly rapport for ${range.start} - ${range.end}`}
-      </Button>
-      {message && <p className="mt-2 text-sm">{message}</p>}
-    </div>
+    <Button
+      onClick={onClick}
+      disabled={loading}
+      className={cn(
+        'flex h-auto items-center justify-center gap-2 whitespace-normal text-center text-white',
+        needsCode
+          ? 'bg-orange-500 hover:bg-orange-600'
+          : 'bg-green-500 hover:bg-green-600',
+        className,
+      )}
+    >
+      {loading && (
+        <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+      )}
+      {loading
+        ? 'Generating…'
+        : `Generate monthly rapport for ${range.start} - ${range.end}`}
+    </Button>
   );
 }

--- a/components/progress/generate-weekly-report-button.tsx
+++ b/components/progress/generate-weekly-report-button.tsx
@@ -13,14 +13,17 @@ function toYMD(d: Date): string {
 export function GenerateWeeklyReportButton({
   userId,
   className,
+  onStatusChange,
+  onComplete,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; pending: boolean }) => void;
+  onComplete?: (message: string) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
   const router = useRouter();
-  const [message, setMessage] = useState<string | null>(null);
   const [needsCode, setNeedsCode] = useState(false);
   const [visible, setVisible] = useState(false);
   const [range, setRange] = useState<{ start: string; end: string } | null>(
@@ -55,14 +58,16 @@ export function GenerateWeeklyReportButton({
     const endStr = toYMD(end);
     setRange({ start: startStr, end: endStr });
     const key = `weekly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const generated = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(generated);
+    let show = true;
     if (day === 0) {
       const dailyKey = `daily-report-generated-${userId}-${date}`;
-      setVisible(window.localStorage.getItem(dailyKey) === 'true');
-    } else {
-      setVisible(true);
+      show = window.localStorage.getItem(dailyKey) === 'true';
     }
-  }, [currentDate, userId]);
+    setVisible(show);
+    onStatusChange?.({ visible: show, pending: show && !generated });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -90,38 +95,36 @@ export function GenerateWeeklyReportButton({
     });
     setLoading(false);
     if (data.error) {
-      setMessage(data.error);
+      onComplete?.(data.error);
     } else {
-      setMessage(
-        `Weekly rapport is created. Your score for this week is: ${data.score}`,
-      );
+      const msg = `Weekly rapport is created. Your score for this week is: ${data.score}`;
+      onComplete?.(msg);
       const key = `weekly-report-generated-${userId}-${range.start}`;
       window.localStorage.setItem(key, 'true');
       setNeedsCode(true);
+      onStatusChange?.({ visible: true, pending: false });
       router.refresh();
     }
   };
 
   return (
-    <div className={cn('flex flex-col items-center', className)}>
-      <Button
-        onClick={onClick}
-        disabled={loading}
-        className={cn(
-          'flex items-center gap-2 text-white',
-          needsCode
-            ? 'bg-orange-500 hover:bg-orange-600'
-            : 'bg-green-500 hover:bg-green-600',
-        )}
-      >
-        {loading && (
-          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
-        )}
-        {loading
-          ? 'Generating…'
-          : `Generate weekly rapport for ${range.start} - ${range.end}`}
-      </Button>
-      {message && <p className="mt-2 text-sm">{message}</p>}
-    </div>
+    <Button
+      onClick={onClick}
+      disabled={loading}
+      className={cn(
+        'flex h-auto items-center justify-center gap-2 whitespace-normal text-center text-white',
+        needsCode
+          ? 'bg-orange-500 hover:bg-orange-600'
+          : 'bg-green-500 hover:bg-green-600',
+        className,
+      )}
+    >
+      {loading && (
+        <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+      )}
+      {loading
+        ? 'Generating…'
+        : `Generate weekly rapport for ${range.start} - ${range.end}`}
+    </Button>
   );
 }

--- a/components/progress/generate-yearly-report-button.tsx
+++ b/components/progress/generate-yearly-report-button.tsx
@@ -13,14 +13,17 @@ function toYMD(d: Date): string {
 export function GenerateYearlyReportButton({
   userId,
   className,
+  onStatusChange,
+  onComplete,
 }: {
   userId: number;
   className?: string;
+  onStatusChange?: (status: { visible: boolean; pending: boolean }) => void;
+  onComplete?: (message: string) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const { addLog } = useLogs();
   const router = useRouter();
-  const [message, setMessage] = useState<string | null>(null);
   const [needsCode, setNeedsCode] = useState(false);
   const [visible, setVisible] = useState(false);
   const [range, setRange] = useState<{ start: string; end: string } | null>(
@@ -67,9 +70,11 @@ export function GenerateYearlyReportButton({
     const endStr = `${year}-12-31`;
     setRange({ start: startStr, end: endStr });
     const key = `yearly-report-generated-${userId}-${startStr}`;
-    setNeedsCode(window.localStorage.getItem(key) === 'true');
+    const generated = window.localStorage.getItem(key) === 'true';
+    setNeedsCode(generated);
     setVisible(show);
-  }, [currentDate, userId]);
+    onStatusChange?.({ visible: show, pending: show && !generated });
+  }, [currentDate, userId, onStatusChange]);
 
   if (!visible || !range) return null;
 
@@ -97,36 +102,36 @@ export function GenerateYearlyReportButton({
     });
     setLoading(false);
     if (data.error) {
-      setMessage(data.error);
+      onComplete?.(data.error);
     } else {
-      setMessage(
-        `Yearly rapport is created. Your score for this year is: ${data.score}`,
-      );
+      const msg = `Yearly rapport is created. Your score for this year is: ${data.score}`;
+      onComplete?.(msg);
       const key = `yearly-report-generated-${userId}-${range.start}`;
       window.localStorage.setItem(key, 'true');
       setNeedsCode(true);
+      onStatusChange?.({ visible: true, pending: false });
       router.refresh();
     }
   };
 
   return (
-    <div className={cn('flex flex-col items-center', className)}>
-      <Button
-        onClick={onClick}
-        disabled={loading}
-        className={cn(
-          'flex items-center gap-2 text-white',
-          needsCode ? 'bg-orange-500 hover:bg-orange-600' : 'bg-green-500 hover:bg-green-600',
-        )}
-      >
-        {loading && (
-          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
-        )}
-        {loading
-          ? 'Generating…'
-          : `Generate yearly rapport for ${range.start} - ${range.end}`}
-      </Button>
-      {message && <p className="mt-2 text-sm">{message}</p>}
-    </div>
+    <Button
+      onClick={onClick}
+      disabled={loading}
+      className={cn(
+        'flex h-auto items-center justify-center gap-2 whitespace-normal text-center text-white',
+        needsCode
+          ? 'bg-orange-500 hover:bg-orange-600'
+          : 'bg-green-500 hover:bg-green-600',
+        className,
+      )}
+    >
+      {loading && (
+        <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+      )}
+      {loading
+        ? 'Generating…'
+        : `Generate yearly rapport for ${range.start} - ${range.end}`}
+    </Button>
   );
 }


### PR DESCRIPTION
## Summary
- Compute pending status for weekly, monthly, and yearly reports
- Hide extra report buttons inside a "new" dropdown beside the daily button
- Align bouncing "new" indicator to the right of the daily button and shift the daily button left for balance

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b04d8fa9f0832ab417ea329192b267