### PR TITLE
feat: add sticky headers and stats navigation

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -247,3 +247,4 @@
 - 2025-10-27: Positioned "new" indicator to the right of the daily report button and shifted the daily button left for balance.
 - 2025-10-27: Added statistics page with daily/weekly/monthly/yearly charts and removed test chat.
 - 2025-10-27: Statistics page now uses weekly/monthly/yearly report grades for corresponding charts.
+- 2025-10-27: Added sticky headers with back buttons and range navigation for daily, weekly, monthly, and yearly progress pages; headers hide in historical snapshot mode.

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -6,8 +6,16 @@ import { listDailyReports } from '@/lib/daily-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
 import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
+import StickyHeader from '@/components/sticky-header';
+import { RangeNav } from '@/components/range-nav';
 
-export async function DailyReportsHome({ userId }: { userId: number }) {
+export async function DailyReportsHome({
+  userId,
+  start,
+}: {
+  userId: number;
+  start?: string;
+}) {
   const [reports, snapshots] = await Promise.all([
     listDailyReports(userId),
     listProfileSnapshotDates(userId),
@@ -22,126 +30,155 @@ export async function DailyReportsHome({ userId }: { userId: number }) {
   const items = allDates.map(
     (date) => reportMap.get(date) ?? { date, missing: true as const },
   );
+  const startIndex = start ? items.findIndex((i) => i.date === start) : 0;
+  const slice = items.slice(startIndex, startIndex + 7);
+  const prevStart = items[startIndex + 7]?.date;
+  const nextStart = startIndex > 0 ? items[startIndex - 7]?.date : undefined;
   return (
-    <main className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">Daily Reports</h1>
-      <ul className="space-y-4" id={`d41lyrep-list-${userId}`}>
-        {items.map((r) =>
-          'missing' in r ? (
-            <li
-              key={r.date}
-              className="rounded border p-4"
-              id={`d41lyrep-miss-${r.date}-${userId}`}
-            >
-              <div className="flex items-center justify-between">
-                <h2 className="font-semibold">{r.date}</h2>
-                <span className="font-semibold text-red-600">
-                  No Assessment
-                </span>
-              </div>
-              <p className="mt-2 text-sm text-zinc-600">
-                This day the user did not generate a daily assessment.
-              </p>
-            </li>
-          ) : (
-            <li
-              key={r.slug}
-              className="rounded border p-4"
-              id={`d41lyrep-item-${r.slug}-${userId}`}
-            >
-              <div className="flex items-center justify-between">
-                <h2
-                  className="font-semibold"
-                  id={`d41lyrep-date-${r.slug}-${userId}`}
-                >
-                  {r.date}
-                  {r.version > 1 && (
-                    <span className="ml-1">(v{r.version})</span>
-                  )}
-                </h2>
-                <div className="flex items-center gap-2">
-                  <span
-                    className="font-semibold"
-                    id={`d41lyrep-tone-${r.slug}-${userId}`}
-                  >
-                    {getCoachTone(r.coachTone).name}
-                  </span>
-                  <span
-                    className="font-semibold"
-                    id={`d41lyrep-score-${r.slug}-${userId}`}
-                  >
-                    {r.score}
-                  </span>
-                  <span
-                    className="ml-1 text-sm text-zinc-600"
-                    id={`d41lyrep-diff-${r.slug}-${userId}`}
-                  >
-                    {getDifficultyLabel(r.score)}
-                  </span>
-                </div>
-              </div>
-              {r.summary && (
-                <p
-                  className="mt-2 whitespace-pre-wrap"
-                  id={`d41lyrep-sum-${r.slug}-${userId}`}
-                >
-                  {r.summary}
-                </p>
-              )}
-              {r.good.length > 0 && (
-                <div className="mt-2" id={`d41lyrep-good-${r.slug}-${userId}`}>
-                  <h3 className="font-semibold">What went well</h3>
-                  <ul className="list-disc pl-4">
-                    {r.good.map((g, i) => (
-                      <li key={i} id={`d41lyrep-good-${i}-${r.slug}-${userId}`}>
-                        {g}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {r.bad.length > 0 && (
-                <div className="mt-2" id={`d41lyrep-bad-${r.slug}-${userId}`}>
-                  <h3 className="font-semibold">What went bad</h3>
-                  <ul className="list-disc pl-4">
-                    {r.bad.map((b, i) => (
-                      <li key={i} id={`d41lyrep-bad-${i}-${r.slug}-${userId}`}>
-                        {b}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {r.observations.length > 0 && (
-                <div className="mt-2" id={`d41lyrep-obs-${r.slug}-${userId}`}>
-                  <h3 className="font-semibold">Observations</h3>
-                  <ul className="list-disc pl-4">
-                    {r.observations.map((o, i) => (
-                      <li key={i} id={`d41lyrep-obs-${i}-${r.slug}-${userId}`}>
-                        {o}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              <Link
-                href={r.slug}
-                className="mt-2 block text-sm text-orange-600 hover:underline"
-                id={`d41lyrep-link-${r.slug}-${userId}`}
+    <>
+      <StickyHeader title="Daily Reports">
+        <RangeNav
+          prev={prevStart}
+          next={nextStart}
+          prevLabel="Previous 7 days"
+          nextLabel="Next 7 days"
+        />
+      </StickyHeader>
+      <main className="p-6 pt-20">
+        <ul className="space-y-4" id={`d41lyrep-list-${userId}`}>
+          {slice.map((r) =>
+            'missing' in r ? (
+              <li
+                key={r.date}
+                className="rounded border p-4"
+                id={`d41lyrep-miss-${r.date}-${userId}`}
               >
-                View details
-              </Link>
-            </li>
-          ),
-        )}
-      </ul>
-    </main>
+                <div className="flex items-center justify-between">
+                  <h2 className="font-semibold">{r.date}</h2>
+                  <span className="font-semibold text-red-600">
+                    No Assessment
+                  </span>
+                </div>
+                <p className="mt-2 text-sm text-zinc-600">
+                  This day the user did not generate a daily assessment.
+                </p>
+              </li>
+            ) : (
+              <li
+                key={r.slug}
+                className="rounded border p-4"
+                id={`d41lyrep-item-${r.slug}-${userId}`}
+              >
+                <div className="flex items-center justify-between">
+                  <h2
+                    className="font-semibold"
+                    id={`d41lyrep-date-${r.slug}-${userId}`}
+                  >
+                    {r.date}
+                    {r.version > 1 && (
+                      <span className="ml-1">(v{r.version})</span>
+                    )}
+                  </h2>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="font-semibold"
+                      id={`d41lyrep-tone-${r.slug}-${userId}`}
+                    >
+                      {getCoachTone(r.coachTone).name}
+                    </span>
+                    <span
+                      className="font-semibold"
+                      id={`d41lyrep-score-${r.slug}-${userId}`}
+                    >
+                      {r.score}
+                    </span>
+                    <span
+                      className="ml-1 text-sm text-zinc-600"
+                      id={`d41lyrep-diff-${r.slug}-${userId}`}
+                    >
+                      {getDifficultyLabel(r.score)}
+                    </span>
+                  </div>
+                </div>
+                {r.summary && (
+                  <p
+                    className="mt-2 whitespace-pre-wrap"
+                    id={`d41lyrep-sum-${r.slug}-${userId}`}
+                  >
+                    {r.summary}
+                  </p>
+                )}
+                {r.good.length > 0 && (
+                  <div
+                    className="mt-2"
+                    id={`d41lyrep-good-${r.slug}-${userId}`}
+                  >
+                    <h3 className="font-semibold">What went well</h3>
+                    <ul className="list-disc pl-4">
+                      {r.good.map((g, i) => (
+                        <li
+                          key={i}
+                          id={`d41lyrep-good-${i}-${r.slug}-${userId}`}
+                        >
+                          {g}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {r.bad.length > 0 && (
+                  <div className="mt-2" id={`d41lyrep-bad-${r.slug}-${userId}`}>
+                    <h3 className="font-semibold">What went bad</h3>
+                    <ul className="list-disc pl-4">
+                      {r.bad.map((b, i) => (
+                        <li
+                          key={i}
+                          id={`d41lyrep-bad-${i}-${r.slug}-${userId}`}
+                        >
+                          {b}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {r.observations.length > 0 && (
+                  <div className="mt-2" id={`d41lyrep-obs-${r.slug}-${userId}`}>
+                    <h3 className="font-semibold">Observations</h3>
+                    <ul className="list-disc pl-4">
+                      {r.observations.map((o, i) => (
+                        <li
+                          key={i}
+                          id={`d41lyrep-obs-${i}-${r.slug}-${userId}`}
+                        >
+                          {o}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                <Link
+                  href={r.slug}
+                  className="mt-2 block text-sm text-orange-600 hover:underline"
+                  id={`d41lyrep-link-${r.slug}-${userId}`}
+                >
+                  View details
+                </Link>
+              </li>
+            ),
+          )}
+        </ul>
+      </main>
+    </>
   );
 }
 
-export default async function DailyReportsPage() {
+export default async function DailyReportsPage({
+  searchParams,
+}: {
+  searchParams: { start?: string };
+}) {
   const session = await auth();
   if (!session) redirect('/signin');
   const me = await ensureUser(session);
-  return <DailyReportsHome userId={me.id} />;
+  return <DailyReportsHome userId={me.id} start={searchParams.start} />;
 }

--- a/app/progress/overview/monthly/page.tsx
+++ b/app/progress/overview/monthly/page.tsx
@@ -7,6 +7,8 @@ import { listWeeklyReports } from '@/lib/weekly-report-store';
 import { listDailyReportDates } from '@/lib/daily-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
+import StickyHeader from '@/components/sticky-header';
+import { RangeNav } from '@/components/range-nav';
 
 function slugFromRange(start: string, end: string): string {
   const [ys, ms, ds] = start.split('-');
@@ -14,7 +16,13 @@ function slugFromRange(start: string, end: string): string {
   return `${ds}${ms}${ys}-${de}${me}${ye}`;
 }
 
-export async function MonthlyReportsHome({ userId }: { userId: number }) {
+export async function MonthlyReportsHome({
+  userId,
+  start,
+}: {
+  userId: number;
+  start?: string;
+}) {
   const [reports, weekly, dailyDates] = await Promise.all([
     listMonthlyReports(userId),
     listWeeklyReports(userId),
@@ -28,155 +36,207 @@ export async function MonthlyReportsHome({ userId }: { userId: number }) {
   const months = Array.from(monthsSet).sort();
   if (months.length === 0)
     return (
-      <main className="p-6">
-        <h1 className="mb-4 text-2xl font-bold">Monthly Reports</h1>
-        <p>No monthly data yet.</p>
-      </main>
+      <>
+        <StickyHeader title="Monthly Reports" />
+        <main className="p-6 pt-20">
+          <p>No monthly data yet.</p>
+        </main>
+      </>
     );
 
   const first = new Date(months[0] + '-01');
   const now = new Date();
-  const currentMonthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+  const currentMonthStart = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
+  );
   const prevMonthStart = new Date(currentMonthStart);
   prevMonthStart.setUTCMonth(prevMonthStart.getUTCMonth() - 1);
 
-  const list: Array<{ start: string; end: string; report?: (typeof reports)[number] }> = [];
+  const list: Array<{
+    start: string;
+    end: string;
+    report?: (typeof reports)[number];
+  }> = [];
   for (
     let d = new Date(first);
     d < currentMonthStart;
     d.setUTCMonth(d.getUTCMonth() + 1)
   ) {
     const start = d.toISOString().slice(0, 10);
-    const endDate = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0));
+    const endDate = new Date(
+      Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0),
+    );
     const end = endDate.toISOString().slice(0, 10);
     const key = start.slice(0, 7);
     list.push({ start, end, report: reportMap.get(key) });
   }
+  list.sort((a, b) => (a.start < b.start ? 1 : -1));
+  const startIndex = start ? list.findIndex((m) => m.start === start) : 0;
+  const slice = list.slice(startIndex, startIndex + 1);
+  const prevStart = list[startIndex + 1]?.start;
+  const nextStart = startIndex > 0 ? list[startIndex - 1]?.start : undefined;
 
   return (
-    <main className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">Monthly Reports</h1>
-      <ul className="space-y-4" id={`m0nthlyrep-list-${userId}`}>
-        {list.map((m) => {
-          if (m.report) {
-            const r = m.report;
+    <>
+      <StickyHeader title="Monthly Reports">
+        <RangeNav
+          prev={prevStart}
+          next={nextStart}
+          prevLabel="Previous month"
+          nextLabel="Next month"
+        />
+      </StickyHeader>
+      <main className="p-6 pt-20">
+        <ul className="space-y-4" id={`m0nthlyrep-list-${userId}`}>
+          {slice.map((m) => {
+            if (m.report) {
+              const r = m.report;
+              return (
+                <li
+                  key={r.slug}
+                  className="rounded border p-4"
+                  id={`m0nthlyrep-item-${r.slug}-${userId}`}
+                >
+                  <div className="flex items-center justify-between">
+                    <h2
+                      className="font-semibold"
+                      id={`m0nthlyrep-date-${r.slug}-${userId}`}
+                    >
+                      {r.startDate} – {r.endDate}
+                      {r.version > 1 && (
+                        <span className="ml-1">(v{r.version})</span>
+                      )}
+                    </h2>
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="font-semibold"
+                        id={`m0nthlyrep-tone-${r.slug}-${userId}`}
+                      >
+                        {getCoachTone(r.coachTone).name}
+                      </span>
+                      <span
+                        className="font-semibold"
+                        id={`m0nthlyrep-score-${r.slug}-${userId}`}
+                      >
+                        {r.score}
+                      </span>
+                      <span
+                        className="ml-1 text-sm text-zinc-600"
+                        id={`m0nthlyrep-diff-${r.slug}-${userId}`}
+                      >
+                        {getDifficultyLabel(r.score)}
+                      </span>
+                    </div>
+                  </div>
+                  {r.summary && (
+                    <p
+                      className="mt-2 whitespace-pre-wrap"
+                      id={`m0nthlyrep-sum-${r.slug}-${userId}`}
+                    >
+                      {r.summary}
+                    </p>
+                  )}
+                  {r.good.length > 0 && (
+                    <div
+                      className="mt-2"
+                      id={`m0nthlyrep-good-${r.slug}-${userId}`}
+                    >
+                      <h3 className="font-semibold">What went well</h3>
+                      <ul className="list-disc pl-4">
+                        {r.good.map((g, i) => (
+                          <li
+                            key={i}
+                            id={`m0nthlyrep-good-${i}-${r.slug}-${userId}`}
+                          >
+                            {g}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {r.bad.length > 0 && (
+                    <div
+                      className="mt-2"
+                      id={`m0nthlyrep-bad-${r.slug}-${userId}`}
+                    >
+                      <h3 className="font-semibold">What went bad</h3>
+                      <ul className="list-disc pl-4">
+                        {r.bad.map((b, i) => (
+                          <li
+                            key={i}
+                            id={`m0nthlyrep-bad-${i}-${r.slug}-${userId}`}
+                          >
+                            {b}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {r.observations.length > 0 && (
+                    <div
+                      className="mt-2"
+                      id={`m0nthlyrep-obs-${r.slug}-${userId}`}
+                    >
+                      <h3 className="font-semibold">Observations</h3>
+                      <ul className="list-disc pl-4">
+                        {r.observations.map((o, i) => (
+                          <li
+                            key={i}
+                            id={`m0nthlyrep-obs-${i}-${r.slug}-${userId}`}
+                          >
+                            {o}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  <Link
+                    href={r.slug}
+                    className="mt-2 block text-sm text-orange-600 hover:underline"
+                    id={`m0nthlyrep-link-${r.slug}-${userId}`}
+                  >
+                    View details
+                  </Link>
+                </li>
+              );
+            }
+            if (m.start >= prevMonthStart.toISOString().slice(0, 10))
+              return null;
+            const slug = slugFromRange(m.start, m.end);
             return (
               <li
-                key={r.slug}
+                key={slug}
                 className="rounded border p-4"
-                id={`m0nthlyrep-item-${r.slug}-${userId}`}
+                id={`m0nthlyrep-miss-${slug}-${userId}`}
               >
-                <div className="flex items-center justify-between">
-                  <h2
-                    className="font-semibold"
-                    id={`m0nthlyrep-date-${r.slug}-${userId}`}
-                  >
-                    {r.startDate} – {r.endDate}
-                    {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
-                  </h2>
-                  <div className="flex items-center gap-2">
-                    <span
-                      className="font-semibold"
-                      id={`m0nthlyrep-tone-${r.slug}-${userId}`}
-                    >
-                      {getCoachTone(r.coachTone).name}
-                    </span>
-                    <span
-                      className="font-semibold"
-                      id={`m0nthlyrep-score-${r.slug}-${userId}`}
-                    >
-                      {r.score}
-                    </span>
-                    <span
-                      className="ml-1 text-sm text-zinc-600"
-                      id={`m0nthlyrep-diff-${r.slug}-${userId}`}
-                    >
-                      {getDifficultyLabel(r.score)}
-                    </span>
-                  </div>
-                </div>
-                {r.summary && (
-                  <p
-                    className="mt-2 whitespace-pre-wrap"
-                    id={`m0nthlyrep-sum-${r.slug}-${userId}`}
-                  >
-                    {r.summary}
-                  </p>
-                )}
-                {r.good.length > 0 && (
-                  <div className="mt-2" id={`m0nthlyrep-good-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">What went well</h3>
-                    <ul className="list-disc pl-4">
-                      {r.good.map((g, i) => (
-                        <li key={i} id={`m0nthlyrep-good-${i}-${r.slug}-${userId}`}>
-                          {g}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {r.bad.length > 0 && (
-                  <div className="mt-2" id={`m0nthlyrep-bad-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">What went bad</h3>
-                    <ul className="list-disc pl-4">
-                      {r.bad.map((b, i) => (
-                        <li key={i} id={`m0nthlyrep-bad-${i}-${r.slug}-${userId}`}>
-                          {b}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {r.observations.length > 0 && (
-                  <div className="mt-2" id={`m0nthlyrep-obs-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">Observations</h3>
-                    <ul className="list-disc pl-4">
-                      {r.observations.map((o, i) => (
-                        <li key={i} id={`m0nthlyrep-obs-${i}-${r.slug}-${userId}`}>
-                          {o}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                <Link
-                  href={r.slug}
-                  className="mt-2 block text-sm text-orange-600 hover:underline"
-                  id={`m0nthlyrep-link-${r.slug}-${userId}`}
+                <h2
+                  className="font-semibold"
+                  id={`m0nthlyrep-date-${slug}-${userId}`}
                 >
-                  View details
-                </Link>
+                  {m.start} – {m.end}
+                </h2>
+                <p
+                  className="mt-2"
+                  id={`m0nthlyrep-miss-msg-${slug}-${userId}`}
+                >
+                  This month the user did not generate a monthly assessment.
+                </p>
               </li>
             );
-          }
-          if (m.start >= prevMonthStart.toISOString().slice(0, 10)) return null;
-          const slug = slugFromRange(m.start, m.end);
-          return (
-            <li
-              key={slug}
-              className="rounded border p-4"
-              id={`m0nthlyrep-miss-${slug}-${userId}`}
-            >
-              <h2
-                className="font-semibold"
-                id={`m0nthlyrep-date-${slug}-${userId}`}
-              >
-                {m.start} – {m.end}
-              </h2>
-              <p className="mt-2" id={`m0nthlyrep-miss-msg-${slug}-${userId}`}>
-                This month the user did not generate a monthly assessment.
-              </p>
-            </li>
-          );
-        })}
-      </ul>
-    </main>
+          })}
+        </ul>
+      </main>
+    </>
   );
 }
 
-export default async function MonthlyReportsPage() {
+export default async function MonthlyReportsPage({
+  searchParams,
+}: {
+  searchParams: { start?: string };
+}) {
   const session = await auth();
   if (!session) redirect('/signin');
   const me = await ensureUser(session);
-  return <MonthlyReportsHome userId={me.id} />;
+  return <MonthlyReportsHome userId={me.id} start={searchParams.start} />;
 }

--- a/app/progress/overview/page.tsx
+++ b/app/progress/overview/page.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor } from '@/lib/navigation';
+import StickyHeader from '@/components/sticky-header';
 
 const items = [
   { href: '/progress/overview/daily', label: 'Daily' },
@@ -13,20 +14,23 @@ const items = [
 export function ProgressOverviewHome() {
   const ctx = useViewContext();
   return (
-    <main className="p-6">
-      <ul className="space-y-2">
-        {items.map((i) => (
-          <li key={i.href}>
-            <Link
-              href={hrefFor(i.href, ctx)}
-              className="block rounded border p-4 hover:bg-orange-50"
-            >
-              {i.label}
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </main>
+    <>
+      <StickyHeader title="Progress Overview" />
+      <main className="p-6 pt-20">
+        <ul className="space-y-2">
+          {items.map((i) => (
+            <li key={i.href}>
+              <Link
+                href={hrefFor(i.href, ctx)}
+                className="block rounded border p-4 hover:bg-orange-50"
+              >
+                {i.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </>
   );
 }
 

--- a/app/progress/overview/weekly/page.tsx
+++ b/app/progress/overview/weekly/page.tsx
@@ -6,6 +6,8 @@ import { listWeeklyReports } from '@/lib/weekly-report-store';
 import { listDailyReportDates } from '@/lib/daily-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
+import StickyHeader from '@/components/sticky-header';
+import { RangeNav } from '@/components/range-nav';
 
 function slugFromRange(start: string, end: string): string {
   const [ys, ms, ds] = start.split('-');
@@ -13,24 +15,31 @@ function slugFromRange(start: string, end: string): string {
   return `${ds}${ms}${ys}-${de}${me}${ye}`;
 }
 
-export async function WeeklyReportsHome({ userId }: { userId: number }) {
+export async function WeeklyReportsHome({
+  userId,
+  start,
+}: {
+  userId: number;
+  start?: string;
+}) {
   const [reports, dates] = await Promise.all([
     listWeeklyReports(userId),
     listDailyReportDates(userId),
   ]);
 
   const reportMap = new Map(reports.map((r) => [r.startDate, r]));
-  const allDates = [
-    ...dates,
-    ...reports.map((r) => r.startDate),
-  ].filter(Boolean);
+  const allDates = [...dates, ...reports.map((r) => r.startDate)].filter(
+    Boolean,
+  );
 
   if (allDates.length === 0)
     return (
-      <main className="p-6">
-        <h1 className="mb-4 text-2xl font-bold">Weekly Reports</h1>
-        <p>No weekly data yet.</p>
-      </main>
+      <>
+        <StickyHeader title="Weekly Reports" />
+        <main className="p-6 pt-20">
+          <p>No weekly data yet.</p>
+        </main>
+      </>
     );
 
   // Determine earliest Monday to start listing weeks
@@ -53,142 +62,183 @@ export async function WeeklyReportsHome({ userId }: { userId: number }) {
     report?: (typeof reports)[number];
   }> = [];
 
-  for (let d = new Date(first); d < currentWeekStart; d.setUTCDate(d.getUTCDate() + 7)) {
+  for (
+    let d = new Date(first);
+    d < currentWeekStart;
+    d.setUTCDate(d.getUTCDate() + 7)
+  ) {
     const start = d.toISOString().slice(0, 10);
     const endDate = new Date(d);
     endDate.setUTCDate(d.getUTCDate() + 6);
     const end = endDate.toISOString().slice(0, 10);
     weeks.push({ start, end, report: reportMap.get(start) });
   }
+  weeks.sort((a, b) => (a.start < b.start ? 1 : -1));
+  const startIndex = start ? weeks.findIndex((w) => w.start === start) : 0;
+  const slice = weeks.slice(startIndex, startIndex + 1);
+  const prevStart = weeks[startIndex + 1]?.start;
+  const nextStart = startIndex > 0 ? weeks[startIndex - 1]?.start : undefined;
 
   return (
-    <main className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">Weekly Reports</h1>
-      <ul className="space-y-4" id={`w33klyrep-list-${userId}`}>
-        {weeks.map((w) => {
-          if (w.report) {
-            const r = w.report;
+    <>
+      <StickyHeader title="Weekly Reports">
+        <RangeNav
+          prev={prevStart}
+          next={nextStart}
+          prevLabel="Previous week"
+          nextLabel="Next week"
+        />
+      </StickyHeader>
+      <main className="p-6 pt-20">
+        <ul className="space-y-4" id={`w33klyrep-list-${userId}`}>
+          {slice.map((w) => {
+            if (w.report) {
+              const r = w.report;
+              return (
+                <li
+                  key={r.slug}
+                  className="rounded border p-4"
+                  id={`w33klyrep-item-${r.slug}-${userId}`}
+                >
+                  <div className="flex items-center justify-between">
+                    <h2
+                      className="font-semibold"
+                      id={`w33klyrep-date-${r.slug}-${userId}`}
+                    >
+                      {r.startDate} – {r.endDate}
+                      {r.version > 1 && (
+                        <span className="ml-1">(v{r.version})</span>
+                      )}
+                    </h2>
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="font-semibold"
+                        id={`w33klyrep-tone-${r.slug}-${userId}`}
+                      >
+                        {getCoachTone(r.coachTone).name}
+                      </span>
+                      <span
+                        className="font-semibold"
+                        id={`w33klyrep-score-${r.slug}-${userId}`}
+                      >
+                        {r.score}
+                      </span>
+                      <span
+                        className="ml-1 text-sm text-zinc-600"
+                        id={`w33klyrep-diff-${r.slug}-${userId}`}
+                      >
+                        {getDifficultyLabel(r.score)}
+                      </span>
+                    </div>
+                  </div>
+                  {r.summary && (
+                    <p
+                      className="mt-2 whitespace-pre-wrap"
+                      id={`w33klyrep-sum-${r.slug}-${userId}`}
+                    >
+                      {r.summary}
+                    </p>
+                  )}
+                  {r.good.length > 0 && (
+                    <div
+                      className="mt-2"
+                      id={`w33klyrep-good-${r.slug}-${userId}`}
+                    >
+                      <h3 className="font-semibold">What went well</h3>
+                      <ul className="list-disc pl-4">
+                        {r.good.map((g, i) => (
+                          <li
+                            key={i}
+                            id={`w33klyrep-good-${i}-${r.slug}-${userId}`}
+                          >
+                            {g}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {r.bad.length > 0 && (
+                    <div
+                      className="mt-2"
+                      id={`w33klyrep-bad-${r.slug}-${userId}`}
+                    >
+                      <h3 className="font-semibold">What went bad</h3>
+                      <ul className="list-disc pl-4">
+                        {r.bad.map((b, i) => (
+                          <li
+                            key={i}
+                            id={`w33klyrep-bad-${i}-${r.slug}-${userId}`}
+                          >
+                            {b}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {r.observations.length > 0 && (
+                    <div
+                      className="mt-2"
+                      id={`w33klyrep-obs-${r.slug}-${userId}`}
+                    >
+                      <h3 className="font-semibold">Observations</h3>
+                      <ul className="list-disc pl-4">
+                        {r.observations.map((o, i) => (
+                          <li
+                            key={i}
+                            id={`w33klyrep-obs-${i}-${r.slug}-${userId}`}
+                          >
+                            {o}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  <Link
+                    href={r.slug}
+                    className="mt-2 block text-sm text-orange-600 hover:underline"
+                    id={`w33klyrep-link-${r.slug}-${userId}`}
+                  >
+                    View details
+                  </Link>
+                </li>
+              );
+            }
+
+            // No report exists for this week. Only show placeholder for weeks older than previous week
+            if (w.start >= prevWeekStart.toISOString().slice(0, 10))
+              return null;
+            const slug = slugFromRange(w.start, w.end);
             return (
               <li
-                key={r.slug}
+                key={slug}
                 className="rounded border p-4"
-                id={`w33klyrep-item-${r.slug}-${userId}`}
+                id={`w33klyrep-miss-${slug}-${userId}`}
               >
-                <div className="flex items-center justify-between">
-                  <h2
-                    className="font-semibold"
-                    id={`w33klyrep-date-${r.slug}-${userId}`}
-                  >
-                    {r.startDate} – {r.endDate}
-                    {r.version > 1 && (
-                      <span className="ml-1">(v{r.version})</span>
-                    )}
-                  </h2>
-                  <div className="flex items-center gap-2">
-                    <span
-                      className="font-semibold"
-                      id={`w33klyrep-tone-${r.slug}-${userId}`}
-                    >
-                      {getCoachTone(r.coachTone).name}
-                    </span>
-                    <span
-                      className="font-semibold"
-                      id={`w33klyrep-score-${r.slug}-${userId}`}
-                    >
-                      {r.score}
-                    </span>
-                    <span
-                      className="ml-1 text-sm text-zinc-600"
-                      id={`w33klyrep-diff-${r.slug}-${userId}`}
-                    >
-                      {getDifficultyLabel(r.score)}
-                    </span>
-                  </div>
-                </div>
-                {r.summary && (
-                  <p
-                    className="mt-2 whitespace-pre-wrap"
-                    id={`w33klyrep-sum-${r.slug}-${userId}`}
-                  >
-                    {r.summary}
-                  </p>
-                )}
-                {r.good.length > 0 && (
-                  <div className="mt-2" id={`w33klyrep-good-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">What went well</h3>
-                    <ul className="list-disc pl-4">
-                      {r.good.map((g, i) => (
-                        <li key={i} id={`w33klyrep-good-${i}-${r.slug}-${userId}`}>
-                          {g}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {r.bad.length > 0 && (
-                  <div className="mt-2" id={`w33klyrep-bad-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">What went bad</h3>
-                    <ul className="list-disc pl-4">
-                      {r.bad.map((b, i) => (
-                        <li key={i} id={`w33klyrep-bad-${i}-${r.slug}-${userId}`}>
-                          {b}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {r.observations.length > 0 && (
-                  <div className="mt-2" id={`w33klyrep-obs-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">Observations</h3>
-                    <ul className="list-disc pl-4">
-                      {r.observations.map((o, i) => (
-                        <li key={i} id={`w33klyrep-obs-${i}-${r.slug}-${userId}`}>
-                          {o}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                <Link
-                  href={r.slug}
-                  className="mt-2 block text-sm text-orange-600 hover:underline"
-                  id={`w33klyrep-link-${r.slug}-${userId}`}
+                <h2
+                  className="font-semibold"
+                  id={`w33klyrep-date-${slug}-${userId}`}
                 >
-                  View details
-                </Link>
+                  {w.start} – {w.end}
+                </h2>
+                <p className="mt-2" id={`w33klyrep-miss-msg-${slug}-${userId}`}>
+                  This week the user did not generate a weekly assessment.
+                </p>
               </li>
             );
-          }
-
-          // No report exists for this week. Only show placeholder for weeks older than previous week
-          if (w.start >= prevWeekStart.toISOString().slice(0, 10)) return null;
-          const slug = slugFromRange(w.start, w.end);
-          return (
-            <li
-              key={slug}
-              className="rounded border p-4"
-              id={`w33klyrep-miss-${slug}-${userId}`}
-            >
-              <h2
-                className="font-semibold"
-                id={`w33klyrep-date-${slug}-${userId}`}
-              >
-                {w.start} – {w.end}
-              </h2>
-              <p className="mt-2" id={`w33klyrep-miss-msg-${slug}-${userId}`}>
-                This week the user did not generate a weekly assessment.
-              </p>
-            </li>
-          );
-        })}
-      </ul>
-    </main>
+          })}
+        </ul>
+      </main>
+    </>
   );
 }
 
-export default async function WeeklyReportsPage() {
+export default async function WeeklyReportsPage({
+  searchParams,
+}: {
+  searchParams: { start?: string };
+}) {
   const session = await auth();
   if (!session) redirect('/signin');
   const me = await ensureUser(session);
-  return <WeeklyReportsHome userId={me.id} />;
+  return <WeeklyReportsHome userId={me.id} start={searchParams.start} />;
 }

--- a/app/progress/overview/yearly/page.tsx
+++ b/app/progress/overview/yearly/page.tsx
@@ -8,6 +8,8 @@ import { listWeeklyReports } from '@/lib/weekly-report-store';
 import { listDailyReportDates } from '@/lib/daily-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
+import StickyHeader from '@/components/sticky-header';
+import { RangeNav } from '@/components/range-nav';
 
 function slugFromRange(start: string, end: string): string {
   const [ys, ms, ds] = start.split('-');
@@ -15,7 +17,13 @@ function slugFromRange(start: string, end: string): string {
   return `${ds}${ms}${ys}-${de}${me}${ye}`;
 }
 
-export async function YearlyReportsHome({ userId }: { userId: number }) {
+export async function YearlyReportsHome({
+  userId,
+  start,
+}: {
+  userId: number;
+  start?: string;
+}) {
   const [reports, monthly, weekly, dailyDates] = await Promise.all([
     listYearlyReports(userId),
     listMonthlyReports(userId),
@@ -31,148 +39,192 @@ export async function YearlyReportsHome({ userId }: { userId: number }) {
   const years = Array.from(yearsSet).sort();
   if (years.length === 0)
     return (
-      <main className="p-6">
-        <h1 className="mb-4 text-2xl font-bold">Yearly Reports</h1>
-        <p>No yearly data yet.</p>
-      </main>
+      <>
+        <StickyHeader title="Yearly Reports" />
+        <main className="p-6 pt-20">
+          <p>No yearly data yet.</p>
+        </main>
+      </>
     );
 
   const first = Number(years[0]);
   const now = new Date();
   const currentYear = now.getUTCFullYear();
-  const list: Array<{ start: string; end: string; report?: (typeof reports)[number] }> = [];
+  const list: Array<{
+    start: string;
+    end: string;
+    report?: (typeof reports)[number];
+  }> = [];
   for (let y = first; y < currentYear; y++) {
-    const start = `${y}-01-01`;
+    const startY = `${y}-01-01`;
     const end = `${y}-12-31`;
-    list.push({ start, end, report: reportMap.get(String(y)) });
+    list.push({ start: startY, end, report: reportMap.get(String(y)) });
   }
+  list.sort((a, b) => (a.start < b.start ? 1 : -1));
+  const startIndex = start ? list.findIndex((y) => y.start === start) : 0;
+  const slice = list.slice(startIndex, startIndex + 1);
+  const prevStart = list[startIndex + 1]?.start;
+  const nextStart = startIndex > 0 ? list[startIndex - 1]?.start : undefined;
 
   return (
-    <main className="p-6">
-      <h1 className="mb-4 text-2xl font-bold">Yearly Reports</h1>
-      <ul className="space-y-4" id={`y3arlyrep-list-${userId}`}>
-        {list.map((y) => {
-          if (y.report) {
-            const r = y.report;
+    <>
+      <StickyHeader title="Yearly Reports">
+        <RangeNav
+          prev={prevStart}
+          next={nextStart}
+          prevLabel="Previous year"
+          nextLabel="Next year"
+        />
+      </StickyHeader>
+      <main className="p-6 pt-20">
+        <ul className="space-y-4" id={`y3arlyrep-list-${userId}`}>
+          {slice.map((y) => {
+            if (y.report) {
+              const r = y.report;
+              return (
+                <li
+                  key={r.slug}
+                  className="rounded border p-4"
+                  id={`y3arlyrep-item-${r.slug}-${userId}`}
+                >
+                  <div className="flex items-center justify-between">
+                    <h2
+                      className="font-semibold"
+                      id={`y3arlyrep-date-${r.slug}-${userId}`}
+                    >
+                      {r.startDate} – {r.endDate}
+                      {r.version > 1 && (
+                        <span className="ml-1">(v{r.version})</span>
+                      )}
+                    </h2>
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="font-semibold"
+                        id={`y3arlyrep-tone-${r.slug}-${userId}`}
+                      >
+                        {getCoachTone(r.coachTone).name}
+                      </span>
+                      <span
+                        className="font-semibold"
+                        id={`y3arlyrep-score-${r.slug}-${userId}`}
+                      >
+                        {r.score}
+                      </span>
+                      <span
+                        className="ml-1 text-sm text-zinc-600"
+                        id={`y3arlyrep-diff-${r.slug}-${userId}`}
+                      >
+                        {getDifficultyLabel(r.score)}
+                      </span>
+                    </div>
+                  </div>
+                  {r.summary && (
+                    <p
+                      className="mt-2 whitespace-pre-wrap"
+                      id={`y3arlyrep-sum-${r.slug}-${userId}`}
+                    >
+                      {r.summary}
+                    </p>
+                  )}
+                  {r.good.length > 0 && (
+                    <div
+                      className="mt-2"
+                      id={`y3arlyrep-good-${r.slug}-${userId}`}
+                    >
+                      <h3 className="font-semibold">What went well</h3>
+                      <ul className="list-disc pl-4">
+                        {r.good.map((g, i) => (
+                          <li
+                            key={i}
+                            id={`y3arlyrep-good-${i}-${r.slug}-${userId}`}
+                          >
+                            {g}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {r.bad.length > 0 && (
+                    <div
+                      className="mt-2"
+                      id={`y3arlyrep-bad-${r.slug}-${userId}`}
+                    >
+                      <h3 className="font-semibold">What went bad</h3>
+                      <ul className="list-disc pl-4">
+                        {r.bad.map((b, i) => (
+                          <li
+                            key={i}
+                            id={`y3arlyrep-bad-${i}-${r.slug}-${userId}`}
+                          >
+                            {b}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  {r.observations.length > 0 && (
+                    <div
+                      className="mt-2"
+                      id={`y3arlyrep-obs-${r.slug}-${userId}`}
+                    >
+                      <h3 className="font-semibold">Observations</h3>
+                      <ul className="list-disc pl-4">
+                        {r.observations.map((o, i) => (
+                          <li
+                            key={i}
+                            id={`y3arlyrep-obs-${i}-${r.slug}-${userId}`}
+                          >
+                            {o}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                  <Link
+                    href={r.slug}
+                    className="mt-2 block text-sm text-orange-600 hover:underline"
+                    id={`y3arlyrep-link-${r.slug}-${userId}`}
+                  >
+                    View details
+                  </Link>
+                </li>
+              );
+            }
+            const year = y.start.slice(0, 4);
+            if (Number(year) === currentYear - 1 && now.getUTCMonth() === 0)
+              return null;
+            const slug = slugFromRange(y.start, y.end);
             return (
               <li
-                key={r.slug}
+                key={slug}
                 className="rounded border p-4"
-                id={`y3arlyrep-item-${r.slug}-${userId}`}
+                id={`y3arlyrep-miss-${slug}-${userId}`}
               >
-                <div className="flex items-center justify-between">
-                  <h2
-                    className="font-semibold"
-                    id={`y3arlyrep-date-${r.slug}-${userId}`}
-                  >
-                    {r.startDate} – {r.endDate}
-                    {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
-                  </h2>
-                  <div className="flex items-center gap-2">
-                    <span
-                      className="font-semibold"
-                      id={`y3arlyrep-tone-${r.slug}-${userId}`}
-                    >
-                      {getCoachTone(r.coachTone).name}
-                    </span>
-                    <span
-                      className="font-semibold"
-                      id={`y3arlyrep-score-${r.slug}-${userId}`}
-                    >
-                      {r.score}
-                    </span>
-                    <span
-                      className="ml-1 text-sm text-zinc-600"
-                      id={`y3arlyrep-diff-${r.slug}-${userId}`}
-                    >
-                      {getDifficultyLabel(r.score)}
-                    </span>
-                  </div>
-                </div>
-                {r.summary && (
-                  <p
-                    className="mt-2 whitespace-pre-wrap"
-                    id={`y3arlyrep-sum-${r.slug}-${userId}`}
-                  >
-                    {r.summary}
-                  </p>
-                )}
-                {r.good.length > 0 && (
-                  <div className="mt-2" id={`y3arlyrep-good-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">What went well</h3>
-                    <ul className="list-disc pl-4">
-                      {r.good.map((g, i) => (
-                        <li key={i} id={`y3arlyrep-good-${i}-${r.slug}-${userId}`}>
-                          {g}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {r.bad.length > 0 && (
-                  <div className="mt-2" id={`y3arlyrep-bad-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">What went bad</h3>
-                    <ul className="list-disc pl-4">
-                      {r.bad.map((b, i) => (
-                        <li key={i} id={`y3arlyrep-bad-${i}-${r.slug}-${userId}`}>
-                          {b}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {r.observations.length > 0 && (
-                  <div className="mt-2" id={`y3arlyrep-obs-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">Observations</h3>
-                    <ul className="list-disc pl-4">
-                      {r.observations.map((o, i) => (
-                        <li key={i} id={`y3arlyrep-obs-${i}-${r.slug}-${userId}`}>
-                          {o}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                <Link
-                  href={r.slug}
-                  className="mt-2 block text-sm text-orange-600 hover:underline"
-                  id={`y3arlyrep-link-${r.slug}-${userId}`}
+                <h2
+                  className="font-semibold"
+                  id={`y3arlyrep-date-${slug}-${userId}`}
                 >
-                  View details
-                </Link>
+                  {y.start} – {y.end}
+                </h2>
+                <p className="mt-2" id={`y3arlyrep-miss-msg-${slug}-${userId}`}>
+                  This year the user did not generate a yearly assessment.
+                </p>
               </li>
             );
-          }
-          const year = y.start.slice(0, 4);
-          if (Number(year) === currentYear - 1 && now.getUTCMonth() === 0)
-            return null;
-          const slug = slugFromRange(y.start, y.end);
-          return (
-            <li
-              key={slug}
-              className="rounded border p-4"
-              id={`y3arlyrep-miss-${slug}-${userId}`}
-            >
-              <h2
-                className="font-semibold"
-                id={`y3arlyrep-date-${slug}-${userId}`}
-              >
-                {y.start} – {y.end}
-              </h2>
-              <p className="mt-2" id={`y3arlyrep-miss-msg-${slug}-${userId}`}>
-                This year the user did not generate a yearly assessment.
-              </p>
-            </li>
-          );
-        })}
-      </ul>
-    </main>
+          })}
+        </ul>
+      </main>
+    </>
   );
 }
 
-export default async function YearlyReportsPage() {
+export default async function YearlyReportsPage({
+  searchParams,
+}: {
+  searchParams: { start?: string };
+}) {
   const session = await auth();
   if (!session) redirect('/signin');
   const me = await ensureUser(session);
-  return <YearlyReportsHome userId={me.id} />;
+  return <YearlyReportsHome userId={me.id} start={searchParams.start} />;
 }

--- a/components/range-nav.tsx
+++ b/components/range-nav.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export function RangeNav({
+  prev,
+  next,
+  prevLabel,
+  nextLabel,
+}: {
+  prev?: string;
+  next?: string;
+  prevLabel: string;
+  nextLabel: string;
+}) {
+  const router = useRouter();
+  const search = useSearchParams();
+  function nav(target?: string) {
+    if (!target) return;
+    const params = new URLSearchParams(search.toString());
+    params.set('start', target);
+    router.push('?' + params.toString());
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        disabled={!prev}
+        onClick={() => nav(prev)}
+        className="rounded border px-2 py-1 text-sm disabled:opacity-50"
+      >
+        {prevLabel}
+      </button>
+      <button
+        type="button"
+        disabled={!next}
+        onClick={() => nav(next)}
+        className="rounded border px-2 py-1 text-sm disabled:opacity-50"
+      >
+        {nextLabel}
+      </button>
+    </div>
+  );
+}

--- a/components/sticky-header.tsx
+++ b/components/sticky-header.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import type { ReactNode } from 'react';
+import { useViewContext } from '@/lib/view-context';
+
+export default function StickyHeader({
+  title,
+  children,
+}: {
+  title: string;
+  children?: ReactNode;
+}) {
+  const router = useRouter();
+  const ctx = useViewContext();
+  if (ctx.mode === 'historical') return null;
+  return (
+    <header className="sticky top-0 z-50 flex items-center justify-between bg-white/80 px-4 py-2 backdrop-blur dark:bg-zinc-900/80">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="rounded border px-2 py-1 text-sm"
+        >
+          Back
+        </button>
+        <h1 className="text-lg font-semibold">{title}</h1>
+      </div>
+      {children}
+    </header>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@playwright/test": "^1.44.0",
     "@types/node": "24.3.0",
     "@types/react": "19.1.10",
+    "@types/recharts": "^2.0.1",
     "babel-plugin-react-compiler": "19.1.0-rc.2",
     "drizzle-kit": "^0.31.4",
     "eslint": "^8.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@types/react':
         specifier: 19.1.10
         version: 19.1.10
+      '@types/recharts':
+        specifier: ^2.0.1
+        version: 2.0.1(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react-is@16.13.1)(react@19.1.1)(redux@5.0.1)
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.2
         version: 19.1.0-rc.2
@@ -717,6 +720,10 @@ packages:
 
   '@types/react@19.1.10':
     resolution: {integrity: sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==}
+
+  '@types/recharts@2.0.1':
+    resolution: {integrity: sha512-/cFs7oiafzByUwBSWA1IzE6FW+ppPwQAWsDTadSgVOwzveY9MESpyLHyyHY0SfPPKLW4+4qVNYHPXd0rFiC8vg==}
+    deprecated: This is a stub types definition. recharts provides its own type definitions, so you do not need this installed.
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
@@ -3079,6 +3086,16 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/recharts@2.0.1(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react-is@16.13.1)(react@19.1.1)(redux@5.0.1)':
+    dependencies:
+      recharts: 3.1.2(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react-is@16.13.1)(react@19.1.1)(redux@5.0.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react
+      - react-dom
+      - react-is
+      - redux
+
   '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)':
@@ -3777,7 +3794,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -3807,7 +3824,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3822,7 +3839,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.1(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary
- add reusable sticky header with back button hidden in historical snapshots
- support prev/next range navigation for daily, weekly, monthly and yearly progress pages
- wire progress overview to use sticky header

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b065c03da8832a9fee013ad6b6816c