### PR TITLE
feat: add period navigation to statistics

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -247,3 +247,6 @@
 - 2025-10-27: Positioned "new" indicator to the right of the daily report button and shifted the daily button left for balance.
 - 2025-10-27: Added statistics page with daily/weekly/monthly/yearly charts and removed test chat.
 - 2025-10-27: Statistics page now uses weekly/monthly/yearly report grades for corresponding charts.
+- 2025-10-27: Added sticky statistics header with period navigation and hid controls in historical snapshot mode.
+- 2025-10-27: Made top navigation sticky, added back buttons across progress pages, and removed white statistics header.
+- 2025-10-27: Added home back button on progress landing and let BackButton navigate to explicit routes.

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -6,6 +6,7 @@ import { listDailyReports } from '@/lib/daily-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
 import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
+import BackButton from '@/components/back-button';
 
 export async function DailyReportsHome({ userId }: { userId: number }) {
   const [reports, snapshots] = await Promise.all([
@@ -24,6 +25,7 @@ export async function DailyReportsHome({ userId }: { userId: number }) {
   );
   return (
     <main className="p-6">
+      <BackButton />
       <h1 className="mb-4 text-2xl font-bold">Daily Reports</h1>
       <ul className="space-y-4" id={`d41lyrep-list-${userId}`}>
         {items.map((r) =>

--- a/app/progress/overview/monthly/page.tsx
+++ b/app/progress/overview/monthly/page.tsx
@@ -7,6 +7,7 @@ import { listWeeklyReports } from '@/lib/weekly-report-store';
 import { listDailyReportDates } from '@/lib/daily-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
+import BackButton from '@/components/back-button';
 
 function slugFromRange(start: string, end: string): string {
   const [ys, ms, ds] = start.split('-');
@@ -29,6 +30,7 @@ export async function MonthlyReportsHome({ userId }: { userId: number }) {
   if (months.length === 0)
     return (
       <main className="p-6">
+        <BackButton />
         <h1 className="mb-4 text-2xl font-bold">Monthly Reports</h1>
         <p>No monthly data yet.</p>
       </main>
@@ -55,6 +57,7 @@ export async function MonthlyReportsHome({ userId }: { userId: number }) {
 
   return (
     <main className="p-6">
+      <BackButton />
       <h1 className="mb-4 text-2xl font-bold">Monthly Reports</h1>
       <ul className="space-y-4" id={`m0nthlyrep-list-${userId}`}>
         {list.map((m) => {

--- a/app/progress/overview/page.tsx
+++ b/app/progress/overview/page.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor } from '@/lib/navigation';
+import BackButton from '@/components/back-button';
 
 const items = [
   { href: '/progress/overview/daily', label: 'Daily' },
@@ -14,6 +15,7 @@ export function ProgressOverviewHome() {
   const ctx = useViewContext();
   return (
     <main className="p-6">
+      <BackButton />
       <ul className="space-y-2">
         {items.map((i) => (
           <li key={i.href}>

--- a/app/progress/overview/weekly/page.tsx
+++ b/app/progress/overview/weekly/page.tsx
@@ -6,6 +6,7 @@ import { listWeeklyReports } from '@/lib/weekly-report-store';
 import { listDailyReportDates } from '@/lib/daily-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
+import BackButton from '@/components/back-button';
 
 function slugFromRange(start: string, end: string): string {
   const [ys, ms, ds] = start.split('-');
@@ -28,6 +29,7 @@ export async function WeeklyReportsHome({ userId }: { userId: number }) {
   if (allDates.length === 0)
     return (
       <main className="p-6">
+        <BackButton />
         <h1 className="mb-4 text-2xl font-bold">Weekly Reports</h1>
         <p>No weekly data yet.</p>
       </main>
@@ -63,6 +65,7 @@ export async function WeeklyReportsHome({ userId }: { userId: number }) {
 
   return (
     <main className="p-6">
+      <BackButton />
       <h1 className="mb-4 text-2xl font-bold">Weekly Reports</h1>
       <ul className="space-y-4" id={`w33klyrep-list-${userId}`}>
         {weeks.map((w) => {

--- a/app/progress/overview/yearly/page.tsx
+++ b/app/progress/overview/yearly/page.tsx
@@ -8,6 +8,7 @@ import { listWeeklyReports } from '@/lib/weekly-report-store';
 import { listDailyReportDates } from '@/lib/daily-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
+import BackButton from '@/components/back-button';
 
 function slugFromRange(start: string, end: string): string {
   const [ys, ms, ds] = start.split('-');
@@ -32,6 +33,7 @@ export async function YearlyReportsHome({ userId }: { userId: number }) {
   if (years.length === 0)
     return (
       <main className="p-6">
+        <BackButton />
         <h1 className="mb-4 text-2xl font-bold">Yearly Reports</h1>
         <p>No yearly data yet.</p>
       </main>
@@ -49,6 +51,7 @@ export async function YearlyReportsHome({ userId }: { userId: number }) {
 
   return (
     <main className="p-6">
+      <BackButton />
       <h1 className="mb-4 text-2xl font-bold">Yearly Reports</h1>
       <ul className="space-y-4" id={`y3arlyrep-list-${userId}`}>
         {list.map((y) => {

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -1,24 +1,28 @@
 'use client';
 import Link from 'next/link';
+import BackButton from '@/components/back-button';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor } from '@/lib/navigation';
 
 export function ProgressHome() {
   const ctx = useViewContext();
   return (
-    <main className="p-6 space-x-4">
-      <Link
-        href={hrefFor('/progress/statistics', ctx)}
-        className="bg-orange-500 text-white px-4 py-2 rounded"
-      >
-        Statistics
-      </Link>
-      <Link
-        href={hrefFor('/progress/overview', ctx)}
-        className="bg-orange-500 text-white px-4 py-2 rounded"
-      >
-        Overview
-      </Link>
+    <main className="p-6">
+      <BackButton href={hrefFor('/', ctx)} />
+      <div className="space-x-4">
+        <Link
+          href={hrefFor('/progress/statistics', ctx)}
+          className="bg-orange-500 text-white px-4 py-2 rounded"
+        >
+          Statistics
+        </Link>
+        <Link
+          href={hrefFor('/progress/overview', ctx)}
+          className="bg-orange-500 text-white px-4 py-2 rounded"
+        >
+          Overview
+        </Link>
+      </div>
     </main>
   );
 }

--- a/app/progress/statistics/page.tsx
+++ b/app/progress/statistics/page.tsx
@@ -6,6 +6,7 @@ import { listWeeklyReports } from '@/lib/weekly-report-store';
 import { listMonthlyReports } from '@/lib/monthly-report-store';
 import { listYearlyReports } from '@/lib/yearly-report-store';
 import StatisticsClient from '@/components/progress/statistics-client';
+import BackButton from '@/components/back-button';
 
 export async function StatisticsHome({ userId }: { userId: number }) {
   const [dailyReports, weeklyReports, monthlyReports, yearlyReports] =
@@ -35,6 +36,7 @@ export async function StatisticsHome({ userId }: { userId: number }) {
 
   return (
     <main className="p-6">
+      <BackButton />
       <h1 className="mb-4 text-2xl font-bold">Statistics</h1>
       <StatisticsClient
         daily={daily}

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -37,7 +37,7 @@ export function AppNav() {
           ];
 
   return (
-    <nav className="flex items-center justify-between border-b p-4">
+    <nav className="sticky top-0 z-50 flex items-center justify-between border-b bg-[var(--bg)] p-4">
       <ul className="flex gap-4">
         {sections.map((sec) => {
           const href = hrefFor(sec, ctx);

--- a/components/back-button.tsx
+++ b/components/back-button.tsx
@@ -3,12 +3,21 @@
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 
-export default function BackButton({ id }: { id?: string }) {
+export default function BackButton({
+  id,
+  href,
+}: {
+  id?: string;
+  href?: string;
+}) {
   const router = useRouter();
+  const handleClick = () => {
+    if (href) router.push(href);
+    else router.back();
+  };
   return (
-    <Button id={id} variant="outline" className="mb-4" onClick={() => router.back()}>
+    <Button id={id} variant="outline" className="mb-4" onClick={handleClick}>
       Back
     </Button>
   );
 }
-

--- a/components/progress/statistics-client.tsx
+++ b/components/progress/statistics-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import { useViewContext } from '@/lib/view-context';
 import {
   ResponsiveContainer,
   ComposedChart,
@@ -69,8 +70,10 @@ function buildRangeChart(
   avgs: Record<string, Array<number | null>>,
   indexMap: Map<string, number>,
   label: (r: RangeScore) => string,
+  page: number,
 ) {
-  const recent = ranges.slice(0, 7).reverse();
+  const start = page * 7;
+  const recent = ranges.slice(start, start + 7).reverse();
   return recent.map((r) => {
     const item: any = { date: label(r), score: r.score };
     const idx = indexMap.get(r.endDate);
@@ -81,27 +84,40 @@ function buildRangeChart(
   });
 }
 
-export default function StatisticsClient({ daily, weekly, monthly, yearly }: Props) {
+export default function StatisticsClient({
+  daily,
+  weekly,
+  monthly,
+  yearly,
+}: Props) {
+  const ctx = useViewContext();
   const [tab, setTab] = useState<'daily' | 'weekly' | 'monthly' | 'yearly'>(
     'daily',
   );
   const [start, setStart] = useState('');
   const [active, setActive] = useState<Record<string, boolean>>({});
+  const [page, setPage] = useState({
+    daily: 0,
+    weekly: 0,
+    monthly: 0,
+    yearly: 0,
+  });
 
   const { days, avgs, startIdx, indexMap } = useMemo(
     () => buildDailyData(daily, start),
     [daily, start],
   );
   const dailyChart = useMemo(() => {
-    const slice = days.slice(-7);
-    const offset = days.length - slice.length;
+    const end = days.length - page.daily * 7;
+    const startIdxLocal = Math.max(startIdx, end - 7);
+    const slice = days.slice(startIdxLocal, end);
     return slice.map((d, i) => {
-      const idx = offset + i;
+      const idx = startIdxLocal + i;
       const item: any = { date: d.date.slice(5), score: d.score };
       for (const win of WINDOWS) item[win.key] = avgs[win.key][idx];
       return item;
     });
-  }, [days, avgs]);
+  }, [days, avgs, page.daily, startIdx]);
 
   const weeklyChart = useMemo(
     () =>
@@ -110,18 +126,31 @@ export default function StatisticsClient({ daily, weekly, monthly, yearly }: Pro
         avgs,
         indexMap,
         (r) => `${r.startDate.slice(5)}-${r.endDate.slice(5)}`,
+        page.weekly,
       ),
-    [weekly, avgs, indexMap],
+    [weekly, avgs, indexMap, page.weekly],
   );
   const monthlyChart = useMemo(
     () =>
-      buildRangeChart(monthly, avgs, indexMap, (r) => r.startDate.slice(0, 7)),
-    [monthly, avgs, indexMap],
+      buildRangeChart(
+        monthly,
+        avgs,
+        indexMap,
+        (r) => r.startDate.slice(0, 7),
+        page.monthly,
+      ),
+    [monthly, avgs, indexMap, page.monthly],
   );
   const yearlyChart = useMemo(
     () =>
-      buildRangeChart(yearly, avgs, indexMap, (r) => r.startDate.slice(0, 4)),
-    [yearly, avgs, indexMap],
+      buildRangeChart(
+        yearly,
+        avgs,
+        indexMap,
+        (r) => r.startDate.slice(0, 4),
+        page.yearly,
+      ),
+    [yearly, avgs, indexMap, page.yearly],
   );
 
   const data =
@@ -135,58 +164,98 @@ export default function StatisticsClient({ daily, weekly, monthly, yearly }: Pro
 
   const availableDays = days.length - startIdx;
 
+  const maxPage = {
+    daily: Math.max(0, Math.floor((availableDays - 1) / 7)),
+    weekly: Math.max(0, Math.floor((weekly.length - 1) / 7)),
+    monthly: Math.max(0, Math.floor((monthly.length - 1) / 7)),
+    yearly: Math.max(0, Math.floor((yearly.length - 1) / 7)),
+  };
+  const hasPrev = page[tab] < maxPage[tab];
+  const hasNext = page[tab] > 0;
+
   return (
     <div className="space-y-4">
-      <div className="flex gap-4">
-        {(['daily', 'weekly', 'monthly', 'yearly'] as const).map((t) => (
-          <button
-            key={t}
-            className={
-              tab === t
-                ? 'border-b-2 border-orange-500 pb-1 font-semibold'
-                : 'pb-1'
-            }
-            onClick={() => setTab(t)}
-          >
-            {t.charAt(0).toUpperCase() + t.slice(1)}
-          </button>
-        ))}
-      </div>
-      <div className="flex items-center gap-2">
-        <label className="text-sm">Average start:</label>
-        <input
-          type="date"
-          value={start}
-          min={days[0].date}
-          max={days[days.length - 1].date}
-          onChange={(e) => setStart(e.target.value)}
-          className="rounded border px-2 py-1"
-        />
-        <button
-          onClick={() => setStart('')}
-          className="text-sm text-orange-600 underline"
-        >
-          All
-        </button>
-      </div>
-      <div className="flex flex-wrap gap-4">
-        {WINDOWS.map((w) => {
-          const disabled = availableDays < w.days;
-          return (
-            <label key={w.key} className="flex items-center gap-1 text-sm">
-              <input
-                type="checkbox"
-                disabled={disabled}
-                checked={!!active[w.key] && !disabled}
-                onChange={() =>
-                  setActive((a) => ({ ...a, [w.key]: !a[w.key] }))
+      {ctx.mode !== 'historical' && (
+        <div className="space-y-4 pb-2">
+          <div className="flex items-center justify-between">
+            <div className="flex gap-4">
+              {(['daily', 'weekly', 'monthly', 'yearly'] as const).map((t) => (
+                <button
+                  key={t}
+                  className={
+                    tab === t
+                      ? 'border-b-2 border-orange-500 pb-1 font-semibold'
+                      : 'pb-1'
+                  }
+                  onClick={() => setTab(t)}
+                >
+                  {t.charAt(0).toUpperCase() + t.slice(1)}
+                </button>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <button
+                aria-label="Previous period"
+                disabled={!hasPrev}
+                onClick={() =>
+                  setPage((p) => ({
+                    ...p,
+                    [tab]: Math.min(maxPage[tab], p[tab] + 1),
+                  }))
                 }
-              />
-              <span>{w.label}</span>
-            </label>
-          );
-        })}
-      </div>
+                className="rounded border px-2 py-1 disabled:opacity-50"
+              >
+                ←
+              </button>
+              <button
+                aria-label="Next period"
+                disabled={!hasNext}
+                onClick={() =>
+                  setPage((p) => ({ ...p, [tab]: Math.max(0, p[tab] - 1) }))
+                }
+                className="rounded border px-2 py-1 disabled:opacity-50"
+              >
+                →
+              </button>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-sm">Average start:</label>
+            <input
+              type="date"
+              value={start}
+              min={days[0].date}
+              max={days[days.length - 1].date}
+              onChange={(e) => setStart(e.target.value)}
+              className="rounded border px-2 py-1"
+            />
+            <button
+              onClick={() => setStart('')}
+              className="text-sm text-orange-600 underline"
+            >
+              All
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-4">
+            {WINDOWS.map((w) => {
+              const disabled = availableDays < w.days;
+              return (
+                <label key={w.key} className="flex items-center gap-1 text-sm">
+                  <input
+                    type="checkbox"
+                    disabled={disabled}
+                    checked={!!active[w.key] && !disabled}
+                    onChange={() =>
+                      setActive((a) => ({ ...a, [w.key]: !a[w.key] }))
+                    }
+                  />
+                  <span>{w.label}</span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      )}
       <ResponsiveContainer width="100%" height={300}>
         <ComposedChart data={data} margin={{ left: 20, right: 20 }}>
           <XAxis dataKey="date" />

--- a/types/shims.d.ts
+++ b/types/shims.d.ts
@@ -1,2 +1,3 @@
 declare module 'jose';
 declare module '@panva/hkdf';
+declare module 'recharts';


### PR DESCRIPTION
## Summary
- add sticky app navigation bar and remove sticky statistics controls
- add back buttons to progress statistics and overview pages
- keep statistics controls background aligned with site theme
- add home back button on progress landing and support explicit routes in `BackButton`

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*


------
https://chatgpt.com/codex/tasks/task_e_68b065c03da8832a9fee013ad6b6816c