### PR TITLE
fix: remove sticky header and add progress layout

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -250,3 +250,4 @@
 - 2025-10-27: Added sticky statistics header with period navigation and hid controls in historical snapshot mode.
 - 2025-10-27: Made top navigation sticky, added back buttons across progress pages, and removed white statistics header.
 - 2025-10-27: Added home back button on progress landing and let BackButton navigate to explicit routes.
+- 2025-10-27: Removed sticky top navigation and added shared layout for progress pages to display the header without stickiness.

--- a/app/progress/layout.tsx
+++ b/app/progress/layout.tsx
@@ -1,0 +1,43 @@
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { buildViewContext } from '@/lib/profile';
+import { ensureDailyProfileSnapshot } from '@/lib/profile-snapshots';
+import { getUserTimeZone } from '@/lib/clock';
+import { ViewContextProvider } from '@/lib/view-context';
+import { AppNav } from '@/components/app-nav';
+
+export default async function ProgressLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  if (!session) {
+    redirect('/');
+  }
+  const me = await ensureUser(session);
+  const tz = getUserTimeZone(me as any);
+  await ensureDailyProfileSnapshot(me.id, tz);
+  const ctx = buildViewContext({
+    ownerId: me.id,
+    viewerId: me.id,
+    mode: 'owner',
+    viewId: me.viewId,
+  });
+
+  if (process.env.NODE_ENV !== 'production') {
+    console.log({
+      mode: ctx.mode,
+      ownerId: ctx.ownerId,
+      viewerId: ctx.viewerId,
+    });
+  }
+
+  return (
+    <ViewContextProvider value={ctx}>
+      <AppNav />
+      <div id={`v13wctx-${ctx.ownerId}-${ctx.viewerId}`}>{children}</div>
+    </ViewContextProvider>
+  );
+}

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -22,9 +22,25 @@ export function AppNav() {
   const pathname = usePathname();
   const sections: Section[] =
     ctx.mode === 'viewer'
-      ? ['cake', 'planning', 'flavors', 'ingredients', 'review', 'people', 'progress']
+      ? [
+          'cake',
+          'planning',
+          'flavors',
+          'ingredients',
+          'review',
+          'people',
+          'progress',
+        ]
       : ctx.mode === 'historical'
-        ? ['cake', 'planning', 'flavors', 'ingredients', 'review', 'people', 'visibility']
+        ? [
+            'cake',
+            'planning',
+            'flavors',
+            'ingredients',
+            'review',
+            'people',
+            'visibility',
+          ]
         : [
             'cake',
             'planning',
@@ -37,7 +53,7 @@ export function AppNav() {
           ];
 
   return (
-    <nav className="sticky top-0 z-50 flex items-center justify-between border-b bg-[var(--bg)] p-4">
+    <nav className="flex items-center justify-between border-b bg-[var(--bg)] p-4">
       <ul className="flex gap-4">
         {sections.map((sec) => {
           const href = hrefFor(sec, ctx);


### PR DESCRIPTION
## Summary
- remove sticky positioning from app header
- add dedicated layout to show header on all progress pages
- record update in changelog

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b07b404ad8832a98aa84938a7ccc19