### PR TITLE
feat: add heading towards agent

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -251,3 +251,4 @@
 - 2025-10-27: Made top navigation sticky, added back buttons across progress pages, and removed white statistics header.
 - 2025-10-27: Added home back button on progress landing and let BackButton navigate to explicit routes.
 - 2025-10-27: Removed sticky top navigation and added shared layout for progress pages to display the header without stickiness.
+- 2025-08-28: Added Heading Towards agent with overview generation button, API route, database storage, and review page display.

--- a/app/(app)/review/client.tsx
+++ b/app/(app)/review/client.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import Textarea from '@/components/ui/textarea';
+import { useViewContext } from '@/lib/view-context';
+import { useEffect, useState } from 'react';
+import { GenerateHeadingReportButton } from '@/components/progress/generate-heading-report-button';
+import type { HeadingReport } from '@/types/report';
+
+export function ReviewHome({
+  userId,
+  initialReport,
+}: {
+  userId: number;
+  initialReport: HeadingReport | null;
+}) {
+  const { editable } = useViewContext();
+  const [rational, setRational] = useState('');
+  const [guilty, setGuilty] = useState('');
+  const [report, setReport] = useState<HeadingReport | null>(initialReport);
+
+  // Load saved notes from localStorage on mount
+  useEffect(() => {
+    const savedRational = localStorage.getItem('review-rational');
+    const savedGuilty = localStorage.getItem('review-guilty');
+    if (savedRational) setRational(savedRational);
+    if (savedGuilty) setGuilty(savedGuilty);
+  }, []);
+
+  const handleRationalChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    setRational(value);
+    if (value) {
+      localStorage.setItem('review-rational', value);
+    } else {
+      localStorage.removeItem('review-rational');
+    }
+  };
+
+  const handleGuiltyChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    setGuilty(value);
+    if (value) {
+      localStorage.setItem('review-guilty', value);
+    } else {
+      localStorage.removeItem('review-guilty');
+    }
+  };
+  return (
+    <section className="grid h-[calc(100vh-2rem)] grid-cols-2 gap-4 overflow-hidden">
+      <div className="flex flex-col overflow-y-scroll pr-4">
+        <h2 className="mb-2 text-xl font-semibold">Your rational</h2>
+        <Textarea
+          className="min-h-[1500px]"
+          placeholder="Type here"
+          disabled={!editable}
+          value={rational}
+          onChange={handleRationalChange}
+        />
+        <hr className="my-4" />
+        <h2 className="mb-2 text-xl font-semibold">guilty pleasure</h2>
+        <Textarea
+          className="min-h-[1500px]"
+          placeholder="Type here"
+          disabled={!editable}
+          value={guilty}
+          onChange={handleGuiltyChange}
+        />
+      </div>
+      <div className="flex flex-col overflow-y-scroll border-l pl-4">
+        {editable && (
+          <GenerateHeadingReportButton
+            userId={userId}
+            onGenerated={(r) => setReport(r as any)}
+          />
+        )}
+        {report ? (
+          <div className="mt-4 space-y-4">
+            <div>
+              <h3 className="font-semibold">Overview</h3>
+              <p className="whitespace-pre-wrap">{report.overview}</p>
+            </div>
+            {report.shortTerm.length > 0 && (
+              <div>
+                <h3 className="font-semibold">Heading towards short term</h3>
+                <ul className="list-disc pl-4">
+                  {report.shortTerm.map((s, i) => (
+                    <li key={i}>{s}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {report.longTerm.length > 0 && (
+              <div>
+                <h3 className="font-semibold">Heading towards long term</h3>
+                <ul className="list-disc pl-4">
+                  {report.longTerm.map((s, i) => (
+                    <li key={i}>{s}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {report.feedback.length > 0 && (
+              <div>
+                <h3 className="font-semibold">Feedback</h3>
+                <ul className="list-disc pl-4">
+                  {report.feedback.map((f, i) => (
+                    <li key={i}>{f}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <div className="mt-2">
+              <span className="font-semibold">Progress score:</span> {report.scoreProgress}
+              <span className="ml-4 font-semibold">Probability score:</span> {report.scoreProbability}
+            </div>
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center text-gray-400">
+            No overview report yet.
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/(app)/review/page.tsx
+++ b/app/(app)/review/page.tsx
@@ -1,69 +1,13 @@
-'use client';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { redirect } from 'next/navigation';
+import { getLatestHeadingReport } from '@/lib/heading-report-store';
+import { ReviewHome } from './client';
 
-import Textarea from '@/components/ui/textarea';
-import { useViewContext } from '@/lib/view-context';
-import { useEffect, useState } from 'react';
-
-export function ReviewHome() {
-  const { editable } = useViewContext();
-  const [rational, setRational] = useState('');
-  const [guilty, setGuilty] = useState('');
-
-  // Load saved notes from localStorage on mount
-  useEffect(() => {
-    const savedRational = localStorage.getItem('review-rational');
-    const savedGuilty = localStorage.getItem('review-guilty');
-    if (savedRational) setRational(savedRational);
-    if (savedGuilty) setGuilty(savedGuilty);
-  }, []);
-
-  const handleRationalChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const value = e.target.value;
-    setRational(value);
-    if (value) {
-      localStorage.setItem('review-rational', value);
-    } else {
-      localStorage.removeItem('review-rational');
-    }
-  };
-
-  const handleGuiltyChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const value = e.target.value;
-    setGuilty(value);
-    if (value) {
-      localStorage.setItem('review-guilty', value);
-    } else {
-      localStorage.removeItem('review-guilty');
-    }
-  };
-  return (
-    <section className="grid h-[calc(100vh-2rem)] grid-cols-2 gap-4 overflow-hidden">
-      <div className="flex flex-col overflow-y-scroll pr-4">
-        <h2 className="mb-2 text-xl font-semibold">Your rational</h2>
-        <Textarea
-          className="min-h-[1500px]"
-          placeholder="Type here"
-          disabled={!editable}
-          value={rational}
-          onChange={handleRationalChange}
-        />
-        <hr className="my-4" />
-        <h2 className="mb-2 text-xl font-semibold">guilty pleasure</h2>
-        <Textarea
-          className="min-h-[1500px]"
-          placeholder="Type here"
-          disabled={!editable}
-          value={guilty}
-          onChange={handleGuiltyChange}
-        />
-      </div>
-      <div className="flex items-center justify-center overflow-y-scroll border-l pl-4 text-gray-400">
-        AI features coming soon...
-      </div>
-    </section>
-  );
-}
-
-export default function ReviewPage() {
-  return <ReviewHome />;
+export default async function ReviewPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  const report = await getLatestHeadingReport(me.id);
+  return <ReviewHome userId={me.id} initialReport={report} />;
 }

--- a/app/(view)/view/[viewId]/review/page.tsx
+++ b/app/(view)/view/[viewId]/review/page.tsx
@@ -1,6 +1,7 @@
 import { getUserByViewId } from '@/lib/users';
 import { notFound } from 'next/navigation';
-import { ReviewHome } from '@/app/(app)/review/page';
+import { ReviewHome } from '@/app/(app)/review/client';
+import { getLatestHeadingReport } from '@/lib/heading-report-store';
 
 export default async function ViewReviewPage({
   params,
@@ -10,9 +11,10 @@ export default async function ViewReviewPage({
   const { viewId } = await params;
   const user = await getUserByViewId(viewId);
   if (!user) notFound();
+  const report = await getLatestHeadingReport(user.id);
   return (
     <section id={`v13w-revw-${user.id}`}>
-      <ReviewHome />
+      <ReviewHome userId={user.id} initialReport={report} />
     </section>
   );
 }

--- a/app/api/progress/heading-report/route.ts
+++ b/app/api/progress/heading-report/route.ts
@@ -1,0 +1,209 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { createHeadingReport } from '@/lib/heading-report-store';
+import { listDailyReports } from '@/lib/daily-report-store';
+import { listWeeklyReports } from '@/lib/weekly-report-store';
+import { listMonthlyReports } from '@/lib/monthly-report-store';
+import { listYearlyReports } from '@/lib/yearly-report-store';
+import { DEFAULT_LLM_SETUP } from '@/lib/llm/config';
+import { getCoachTone } from '@/lib/ai/coach-tone';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+function buildSystemPrompt(toneId: string) {
+  const tone = getCoachTone(toneId);
+  return `You are a helpful assistant in the Piece of Cake framework that will describe and evaluate the direction the person is going in his or her life. Piece of Cake is a framework that paints flavors as goals in different life domains, achieved through ingredients which are habits. These flavors combine into a cake—the shape, size, and taste of your life. Every person wants a different cake, but what matters most is the direction rather than the current position. Your goal is to output a structured result. Respond ONLY with JSON of the form {"Overview":string,"short-term":string[],"long-term":string[],"feedback":string[],"score-progress":0-100,"score-probability":0-100}. The tone of your assessment should be: ${JSON.stringify(tone, null, 2)} Keep the tone wise and constructive.`;
+}
+
+function toYMD(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  const paramUserId = Number(req.nextUrl.searchParams.get('userId'));
+  const userId = paramUserId || Number(session?.user?.id);
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  let body: any = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const date = body.date || toYMD(new Date());
+  const rational = body.rational || '';
+  const guilty = body.guilty || '';
+
+  const [userRow] = await db
+    .select({ coachTone: users.coachTone, createdAt: users.createdAt })
+    .from(users)
+    .where(eq(users.id, userId));
+  const toneId = body.toneId || userRow?.coachTone || 'tone_medium';
+  const userCreated = userRow?.createdAt
+    ? toYMD(new Date(userRow.createdAt))
+    : null;
+
+  const [daily, weekly, monthly, yearly] = await Promise.all([
+    listDailyReports(userId),
+    listWeeklyReports(userId),
+    listMonthlyReports(userId),
+    listYearlyReports(userId),
+  ]);
+  const dailyMap = new Map(daily.map((r) => [r.date, r]));
+
+  const targetDate = new Date(date);
+  const lines: string[] = [];
+  lines.push(
+    `this is the rational/goals/life ethos the user wants to reach {rational: ${rational}; guilty pleasure: ${guilty}} here is the context of how the user is performing:`,
+  );
+  lines.push('***last 4 day reports***:');
+  for (let i = 0; i < 4; i++) {
+    const d = new Date(targetDate);
+    d.setUTCDate(targetDate.getUTCDate() - i);
+    const ymd = toYMD(d);
+    const rpt = dailyMap.get(ymd);
+    lines.push(ymd);
+    if (rpt) {
+      lines.push(`summary: ${rpt.summary}`);
+      if (rpt.good.length) lines.push(`good: ${rpt.good.join('; ')}`);
+      if (rpt.bad.length) lines.push(`bad: ${rpt.bad.join('; ')}`);
+      if (rpt.observations.length)
+        lines.push(`observations: ${rpt.observations.join('; ')}`);
+      lines.push(`score: ${rpt.score}`);
+    } else {
+      lines.push('This day the user did not generate a daily assessment.');
+      if (userCreated && ymd < userCreated) {
+        lines.push('The user did not have an account on this day yet.');
+      }
+    }
+    lines.push('-----------------');
+  }
+
+  lines.push('here are the last 2 week reports:');
+  weekly.slice(0, 2).forEach((r) => {
+    lines.push(`${r.startDate} to ${r.endDate}`);
+    lines.push(`summary: ${r.summary}`);
+    if (r.good.length) lines.push(`good: ${r.good.join('; ')}`);
+    if (r.bad.length) lines.push(`bad: ${r.bad.join('; ')}`);
+    if (r.observations.length)
+      lines.push(`observations: ${r.observations.join('; ')}`);
+    lines.push(`score: ${r.score}`);
+    lines.push('-----------------');
+  });
+
+  lines.push('and here are the last 5 month rapports:');
+  monthly.slice(0, 5).forEach((r) => {
+    lines.push(`${r.startDate} to ${r.endDate}`);
+    lines.push(`summary: ${r.summary}`);
+    if (r.good.length) lines.push(`good: ${r.good.join('; ')}`);
+    if (r.bad.length) lines.push(`bad: ${r.bad.join('; ')}`);
+    if (r.observations.length)
+      lines.push(`observations: ${r.observations.join('; ')}`);
+    lines.push(`score: ${r.score}`);
+    lines.push('-----------------');
+  });
+
+  lines.push('and here is the year rapport');
+  if (yearly.length > 0) {
+    const r = yearly[0];
+    lines.push(`${r.startDate} to ${r.endDate}`);
+    lines.push(`summary: ${r.summary}`);
+    if (r.good.length) lines.push(`good: ${r.good.join('; ')}`);
+    if (r.bad.length) lines.push(`bad: ${r.bad.join('; ')}`);
+    if (r.observations.length)
+      lines.push(`observations: ${r.observations.join('; ')}`);
+    lines.push(`score: ${r.score}`);
+  } else {
+    lines.push('No yearly assessment yet.');
+  }
+
+  const context = lines.join('\n');
+
+  const setup = DEFAULT_LLM_SETUP;
+  const systemPrompt = buildSystemPrompt(toneId);
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: 'Missing OpenAI API key' }, { status: 500 });
+  }
+
+  const reqBody = {
+    model: setup.model,
+    temperature: setup.temperature,
+    top_p: setup.top_p,
+    max_tokens: setup.maxTokens,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: context },
+    ],
+    response_format: { type: 'json_object' },
+  } as any;
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(reqBody),
+    });
+    const raw = await aiRes.text();
+    if (!aiRes.ok) {
+      return NextResponse.json({ error: raw }, { status: aiRes.status });
+    }
+    const data = JSON.parse(raw);
+    const msg = data.choices?.[0]?.message?.content ?? '{}';
+    let parsed: any = {};
+    try {
+      parsed = JSON.parse(msg);
+    } catch {
+      parsed = {
+        Overview: msg,
+        'short-term': [],
+        'long-term': [],
+        feedback: [],
+        'score-progress': 0,
+        'score-probability': 0,
+      };
+    }
+    const report = {
+      overview: parsed.Overview || '',
+      shortTerm: Array.isArray(parsed['short-term'])
+        ? parsed['short-term']
+        : [],
+      longTerm: Array.isArray(parsed['long-term'])
+        ? parsed['long-term']
+        : [],
+      feedback: Array.isArray(parsed.feedback) ? parsed.feedback : [],
+    };
+    const scoreProgress = Number(parsed['score-progress']) || 0;
+    const scoreProbability = Number(parsed['score-probability']) || 0;
+    await createHeadingReport(
+      userId,
+      date,
+      report,
+      scoreProgress,
+      scoreProbability,
+      toneId,
+    );
+    return NextResponse.json({
+      report: parsed,
+      scoreProgress,
+      scoreProbability,
+      context,
+    });
+  } catch (e: any) {
+    console.error('heading-report generation failed', e);
+    return NextResponse.json(
+      {
+        error: e.message || 'LLM request failed',
+        cause: e?.cause?.message,
+        context,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/components/progress/generate-heading-report-button.tsx
+++ b/components/progress/generate-heading-report-button.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { useLogs } from '@/components/dev/logs-provider';
+import { useRouter } from 'next/navigation';
+import { cn } from '@/lib/utils';
+import type { HeadingReport } from '@/types/report';
+
+export function GenerateHeadingReportButton({
+  userId,
+  className,
+  buttonClassName,
+  onGenerated,
+}: {
+  userId: number;
+  className?: string;
+  buttonClassName?: string;
+  onGenerated?: (r: any) => void;
+}) {
+  const [loading, setLoading] = useState(false);
+  const { addLog } = useLogs();
+  const router = useRouter();
+  const [message, setMessage] = useState<string | null>(null);
+  const [needsCode, setNeedsCode] = useState(false);
+
+  const currentDate = useCallback(() => {
+    const params = new URLSearchParams(window.location.search);
+    params.set('userId', String(userId));
+    const dateParam = params.get('apoc_date');
+    let date = dateParam || '';
+    if (!date) {
+      const match = document.cookie.match(/apoc_clock=([^;]+)/);
+      if (match) {
+        const d = new Date(decodeURIComponent(match[1]));
+        if (!isNaN(d.getTime())) date = d.toISOString().slice(0, 10);
+      }
+      if (!date) date = new Date().toISOString().slice(0, 10);
+    }
+    return { date, params };
+  }, [userId]);
+
+  useEffect(() => {
+    const { date } = currentDate();
+    const key = `heading-report-generated-${userId}-${date}`;
+    setNeedsCode(window.localStorage.getItem(key) === 'true');
+  }, [currentDate, userId]);
+
+  const onClick = async () => {
+    const { date, params } = currentDate();
+    if (needsCode) {
+      const code = window
+        .prompt('Enter code to generate a new overview report')
+        ?.trim();
+      if (code !== 'cake2025') return;
+    }
+    setLoading(true);
+    const rational = window.localStorage.getItem('review-rational') || '';
+    const guilty = window.localStorage.getItem('review-guilty') || '';
+    const body = { date, rational, guilty };
+    const url = `/api/progress/heading-report?${params.toString()}`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    addLog({
+      request: data.context || JSON.stringify(body),
+      response: JSON.stringify(data.report ?? data),
+    });
+    setLoading(false);
+    if (data.error) {
+      setMessage(data.error);
+    } else {
+      setMessage(
+        `Overview rapport is created. Progress score: ${data.scoreProgress}, Probability score: ${data.scoreProbability}`,
+      );
+      const key = `heading-report-generated-${userId}-${date}`;
+      window.localStorage.setItem(key, 'true');
+      setNeedsCode(true);
+      router.refresh();
+      onGenerated?.(data.report as HeadingReport);
+    }
+  };
+
+  return (
+    <div className={cn('flex flex-col items-center', className)}>
+      <Button
+        onClick={onClick}
+        disabled={loading}
+        className={cn(
+          'flex items-center gap-2 text-white',
+          needsCode
+            ? 'bg-orange-500 hover:bg-orange-600'
+            : 'bg-green-500 hover:bg-green-600',
+          buttonClassName,
+        )}
+      >
+        {loading && (
+          <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
+        )}
+        {loading ? 'Generating…' : 'Generate overview rapport'}
+      </Button>
+      {message && <p className="mt-2 text-sm text-center">{message}</p>}
+    </div>
+  );
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -336,3 +336,28 @@ export const yearlyReports = pgTable(
     ).on(table.userId, table.startDate, table.version),
   }),
 );
+
+export const headingReports = pgTable(
+  'heading_reports',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    date: date('date').notNull(),
+    overview: text('overview').notNull().default(''),
+    shortTerm: text('short_term').notNull().default('[]'),
+    longTerm: text('long_term').notNull().default('[]'),
+    feedback: text('feedback').notNull().default('[]'),
+    scoreProgress: integer('score_progress').notNull(),
+    scoreProbability: integer('score_probability').notNull(),
+    coachTone: text('coach_tone').notNull().default('tone_medium'),
+    version: integer('version').notNull().default(1),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserDateVersion: uniqueIndex(
+      'heading_reports_user_date_version_unique',
+    ).on(table.userId, table.date, table.version),
+  }),
+);

--- a/lib/heading-report-store.ts
+++ b/lib/heading-report-store.ts
@@ -1,0 +1,173 @@
+import { db } from './db';
+import { headingReports } from './db/schema';
+import { eq, and, desc, sql } from 'drizzle-orm';
+import type { HeadingReport } from '@/types/report';
+
+function slugFromDate(ymd: string, version = 1): string {
+  const [y, m, d] = ymd.split('-');
+  const base = `${d}${m}${y}`;
+  return version > 1 ? `${base}V${version}` : base;
+}
+
+function parseSlug(slug: string): { date: string; version: number } {
+  const match = /^([0-9]{2})([0-9]{2})([0-9]{4})(?:V(\d+))?$/.exec(slug);
+  if (!match) return { date: slug, version: 1 };
+  const [, d, m, y, v] = match;
+  return { date: `${y}-${m}-${d}`, version: v ? Number(v) : 1 };
+}
+
+function parseList(raw: unknown): string[] {
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(String(raw));
+    return Array.isArray(arr) ? arr.map((v) => String(v)) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function listHeadingReports(userId: number): Promise<
+  Array<{
+    date: string;
+    slug: string;
+    version: number;
+    scoreProgress: number;
+    scoreProbability: number;
+  }>
+> {
+  const rows = await db
+    .select({
+      date: headingReports.date,
+      version: headingReports.version,
+      scoreProgress: headingReports.scoreProgress,
+      scoreProbability: headingReports.scoreProbability,
+    })
+    .from(headingReports)
+    .where(eq(headingReports.userId, userId))
+    .orderBy(desc(headingReports.date), desc(headingReports.version));
+  return rows.map((r) => {
+    const ymd = r.date?.toString().slice(0, 10) ?? '';
+    const version = r.version ?? 1;
+    return {
+      date: ymd,
+      slug: slugFromDate(ymd, version),
+      version,
+      scoreProgress: r.scoreProgress ?? 0,
+      scoreProbability: r.scoreProbability ?? 0,
+    };
+  });
+}
+
+export async function getHeadingReport(
+  userId: number,
+  slug: string,
+): Promise<HeadingReport | null> {
+  const { date, version } = parseSlug(slug);
+  const [row] = await db
+    .select()
+    .from(headingReports)
+    .where(
+      and(
+        eq(headingReports.userId, userId),
+        eq(headingReports.date, date),
+        eq(headingReports.version, version),
+      ),
+    );
+  if (!row) return null;
+  return {
+    id: row.id,
+    userId: row.userId ?? 0,
+    date,
+    version: row.version ?? 1,
+    overview: row.overview ?? '',
+    shortTerm: parseList(row.shortTerm),
+    longTerm: parseList(row.longTerm),
+    feedback: parseList(row.feedback),
+    scoreProgress: row.scoreProgress ?? 0,
+    scoreProbability: row.scoreProbability ?? 0,
+    coachTone: row.coachTone ?? 'tone_medium',
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+export async function getLatestHeadingReport(
+  userId: number,
+): Promise<HeadingReport | null> {
+  const [row] = await db
+    .select()
+    .from(headingReports)
+    .where(eq(headingReports.userId, userId))
+    .orderBy(desc(headingReports.date), desc(headingReports.version))
+    .limit(1);
+  if (!row) return null;
+  return {
+    id: row.id,
+    userId: row.userId ?? 0,
+    date: row.date?.toString().slice(0, 10) ?? '',
+    version: row.version ?? 1,
+    overview: row.overview ?? '',
+    shortTerm: parseList(row.shortTerm),
+    longTerm: parseList(row.longTerm),
+    feedback: parseList(row.feedback),
+    scoreProgress: row.scoreProgress ?? 0,
+    scoreProbability: row.scoreProbability ?? 0,
+    coachTone: row.coachTone ?? 'tone_medium',
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+export async function createHeadingReport(
+  userId: number,
+  date: string,
+  content: {
+    overview: string;
+    shortTerm: string[];
+    longTerm: string[];
+    feedback: string[];
+  },
+  scoreProgress: number,
+  scoreProbability: number,
+  coachTone: string,
+): Promise<void> {
+  const ymd = new Date(date).toISOString().slice(0, 10);
+  try {
+    const [{ maxVersion }] = await db
+      .select({
+        maxVersion: sql<number>`coalesce(max(${headingReports.version}),0)`,
+      })
+      .from(headingReports)
+      .where(and(eq(headingReports.userId, userId), eq(headingReports.date, ymd)));
+    const nextVersion = (maxVersion ?? 0) + 1;
+    await db.insert(headingReports).values({
+      userId,
+      date: ymd,
+      overview: content.overview ?? '',
+      shortTerm: JSON.stringify(content.shortTerm ?? []),
+      longTerm: JSON.stringify(content.longTerm ?? []),
+      feedback: JSON.stringify(content.feedback ?? []),
+      scoreProgress,
+      scoreProbability,
+      coachTone,
+      version: nextVersion,
+    });
+    console.log('createHeadingReport inserted', {
+      userId,
+      date: ymd,
+      version: nextVersion,
+      scoreProgress,
+      scoreProbability,
+      coachTone,
+    });
+  } catch (error) {
+    console.error('createHeadingReport failed', {
+      userId,
+      date: ymd,
+      scoreProgress,
+      scoreProbability,
+      coachTone,
+      content,
+      error,
+    });
+    throw error;
+  }
+}

--- a/tests/review.spec.ts
+++ b/tests/review.spec.ts
@@ -17,7 +17,7 @@ test('owner review page loads', async ({ page }) => {
   await page.click('text=Sign Up');
   await page.goto('/review');
   await expect(
-    page.getByRole('button', { name: 'Review daily aim' }),
+    page.getByRole('button', { name: 'Generate overview rapport' }),
   ).toBeVisible();
 
   // ensure columns scroll independently

--- a/types/report.ts
+++ b/types/report.ts
@@ -63,3 +63,18 @@ export interface YearlyReport {
   coachTone: string;
   createdAt: string;
 }
+
+export interface HeadingReport {
+  id: number;
+  userId: number;
+  date: string; // YYYY-MM-DD
+  version: number;
+  overview: string;
+  shortTerm: string[];
+  longTerm: string[];
+  feedback: string[];
+  scoreProgress: number;
+  scoreProbability: number;
+  coachTone: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- add HeadingReport schema and store for daily direction assessments
- expose /api/progress/heading-report to generate structured overview using recent daily/weekly/monthly/yearly reports
- show overview on Review page with generation button and progress/probability scores

## Testing
- `pnpm lint`
- `pnpm format` (fails: Command "format" not found)
- `pnpm type-check` (fails: Command "type-check" not found)
- `pnpm test` (fails: Timed out waiting 120000ms from config.webServer.)

------
https://chatgpt.com/codex/tasks/task_e_68b08860a668832a9a76af92bed3ab85