### PR TITLE
feat: add heading towards overview agent

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -251,3 +251,4 @@
 - 2025-10-27: Made top navigation sticky, added back buttons across progress pages, and removed white statistics header.
 - 2025-10-27: Added home back button on progress landing and let BackButton navigate to explicit routes.
 - 2025-10-27: Removed sticky top navigation and added shared layout for progress pages to display the header without stickiness.
+- 2025-10-27: Added heading towards agent with overview report generation, storage, and review page display with regeneration code.

--- a/app/(app)/review/page.tsx
+++ b/app/(app)/review/page.tsx
@@ -4,17 +4,35 @@ import Textarea from '@/components/ui/textarea';
 import { useViewContext } from '@/lib/view-context';
 import { useEffect, useState } from 'react';
 
+interface OverviewReport {
+  Overview: string;
+  ['short-term']: string[];
+  ['long-term']: string[];
+  feedback: string[];
+  ['score-progress']: number;
+  ['score-probability']: number;
+  date: string;
+}
+
 export function ReviewHome() {
   const { editable } = useViewContext();
   const [rational, setRational] = useState('');
   const [guilty, setGuilty] = useState('');
+  const [report, setReport] = useState<OverviewReport | null>(null);
+  const [loading, setLoading] = useState(false);
 
-  // Load saved notes from localStorage on mount
+  // Load saved notes and existing report from localStorage/API on mount
   useEffect(() => {
     const savedRational = localStorage.getItem('review-rational');
     const savedGuilty = localStorage.getItem('review-guilty');
     if (savedRational) setRational(savedRational);
     if (savedGuilty) setGuilty(savedGuilty);
+    fetch('/api/progress/overview-report')
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.report) setReport(data.report);
+      })
+      .catch(() => {});
   }, []);
 
   const handleRationalChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -34,6 +52,31 @@ export function ReviewHome() {
       localStorage.setItem('review-guilty', value);
     } else {
       localStorage.removeItem('review-guilty');
+    }
+  };
+
+  const today = new Date().toISOString().slice(0, 10);
+  const generatedToday = report?.date === today;
+
+  const handleGenerate = async () => {
+    if (generatedToday) {
+      const code = prompt('Enter regeneration code');
+      if (code !== 'cake2025') return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch('/api/progress/overview-report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rational, guilty }),
+      });
+      const data = await res.json();
+      if (data.report) {
+        data.report.date = data.date;
+        setReport(data.report);
+      }
+    } finally {
+      setLoading(false);
     }
   };
   return (
@@ -57,8 +100,64 @@ export function ReviewHome() {
           onChange={handleGuiltyChange}
         />
       </div>
-      <div className="flex items-center justify-center overflow-y-scroll border-l pl-4 text-gray-400">
-        AI features coming soon...
+      <div className="flex flex-col overflow-y-scroll border-l pl-4">
+        {report ? (
+          <div className="space-y-4">
+            <div>
+              <h2 className="text-xl font-semibold">General observations</h2>
+              <p className="whitespace-pre-wrap">{report.Overview}</p>
+            </div>
+            {report['short-term'].length > 0 && (
+              <div>
+                <h3 className="font-semibold">Heading towards short term</h3>
+                <ul className="list-disc pl-4">
+                  {report['short-term'].map((s, i) => (
+                    <li key={i}>{s}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {report['long-term'].length > 0 && (
+              <div>
+                <h3 className="font-semibold">Heading towards long term</h3>
+                <ul className="list-disc pl-4">
+                  {report['long-term'].map((s, i) => (
+                    <li key={i}>{s}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {report.feedback.length > 0 && (
+              <div>
+                <h3 className="font-semibold">Feedback</h3>
+                <ul className="list-disc pl-4">
+                  {report.feedback.map((f, i) => (
+                    <li key={i}>{f}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <div className="font-semibold">
+              Progress score: {report['score-progress']} | Probability score:{' '}
+              {report['score-probability']}
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-1 items-center justify-center text-gray-400">
+            No overview report yet.
+          </div>
+        )}
+        <button
+          onClick={handleGenerate}
+          disabled={loading}
+          className={`mt-4 w-full rounded px-4 py-2 font-semibold text-white ${
+            generatedToday ? 'bg-orange-500' : 'bg-green-600'
+          }`}
+        >
+          {generatedToday
+            ? 'Regenerate overview rapport'
+            : 'Generate overview rapport'}
+        </button>
       </div>
     </section>
   );

--- a/app/api/progress/overview-report/route.ts
+++ b/app/api/progress/overview-report/route.ts
@@ -1,0 +1,230 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { DEFAULT_LLM_SETUP } from '@/lib/llm/config';
+import { getCoachTone } from '@/lib/ai/coach-tone';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { listDailyReports } from '@/lib/daily-report-store';
+import { listWeeklyReports } from '@/lib/weekly-report-store';
+import { listMonthlyReports } from '@/lib/monthly-report-store';
+import { listYearlyReports } from '@/lib/yearly-report-store';
+import {
+  createOverviewReport,
+  listOverviewReports,
+} from '@/lib/overview-report-store';
+
+function buildSystemPrompt(toneId: string) {
+  const tone = getCoachTone(toneId);
+  return `You are a helpful assistant in the Piece of Cake framework that will describe and evaluate the direction the person is going in his or her life. Piece of Cake is a framework that paints flavors as goals in different domains of life, achieved using ingredients (habits). These flavors combine into a cake, representing the shape, size, and taste of their life. Every person wants a different cake, but most people want as good a cake as possible. What is more important in the Piece of Cake framework is the direction you are going instead of the position you currently are.\n\nYour goal is to output a structured report. Respond ONLY with JSON of the form {"Overview":string,"short-term":string[],"long-term":string[],"feedback":string[],"score-progress":0-100,"score-probability":0-100}.\n\nI will now explain what each field is and how the output should look:\n- Overview: facts or information you based your knowledge on.\n- short-term: the direction you are heading in the coming months.\n- long-term: where you are heading in the coming years if the current trend continues.\n- feedback: detailed advice on what to change or focus on, relating habits (ingredients) and goals (flavors).\n- score-progress: estimate how far the user is with their goals (0-100).\n- score-probability: likelihood of reaching goals based on current behaviour (0-100).\n\nThe tone of your assessment should be: ${JSON.stringify(tone, null, 2)} Keep the tone wise and constructive.`;
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  const paramUserId = Number(req.nextUrl.searchParams.get('userId'));
+  const userId = paramUserId || Number(session?.user?.id);
+  if (!userId)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  let body: any = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const rational = body.rational || '';
+  const guilty = body.guilty || '';
+
+  const [userRow] = await db
+    .select({ coachTone: users.coachTone })
+    .from(users)
+    .where(eq(users.id, userId));
+  const toneId = body.toneId || userRow?.coachTone || 'tone_medium';
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  const [daily, weekly, monthly, yearly] = await Promise.all([
+    listDailyReports(userId),
+    listWeeklyReports(userId),
+    listMonthlyReports(userId),
+    listYearlyReports(userId),
+  ]);
+
+  const lines: string[] = [];
+  lines.push(
+    `this is the rational/goals/life ethos the user wants to reach {rational: ${rational} | guilty pleasure: ${guilty}}`,
+  );
+  lines.push('here is the context of how the user is performing:');
+  lines.push('***last 4 day reports***:');
+  const dailyItems = daily.slice(0, 4);
+  if (dailyItems.length === 0) {
+    lines.push('The user was not using the app at that time.');
+  } else {
+    for (const rpt of dailyItems) {
+      lines.push(`${rpt.date}: summary: ${rpt.summary}`);
+      if (rpt.good.length) lines.push(`good: ${rpt.good.join('; ')}`);
+      if (rpt.bad.length) lines.push(`bad: ${rpt.bad.join('; ')}`);
+      if (rpt.observations.length)
+        lines.push(`observations: ${rpt.observations.join('; ')}`);
+      lines.push(`score: ${rpt.score}`);
+      lines.push('---');
+    }
+  }
+
+  lines.push('here are the last 2 week reports:');
+  const weeklyItems = weekly.slice(0, 2);
+  if (weeklyItems.length === 0) {
+    lines.push('The user was not using the app at that time.');
+  } else {
+    for (const rpt of weeklyItems) {
+      lines.push(`${rpt.startDate} to ${rpt.endDate}: summary: ${rpt.summary}`);
+      if (rpt.good.length) lines.push(`good: ${rpt.good.join('; ')}`);
+      if (rpt.bad.length) lines.push(`bad: ${rpt.bad.join('; ')}`);
+      if (rpt.observations.length)
+        lines.push(`observations: ${rpt.observations.join('; ')}`);
+      lines.push(`score: ${rpt.score}`);
+      lines.push('---');
+    }
+  }
+
+  lines.push('and here are the last 2 month rapports:');
+  const monthlyItems = monthly.slice(0, 2);
+  if (monthlyItems.length === 0) {
+    lines.push('The user was not using the app at that time.');
+  } else {
+    for (const rpt of monthlyItems) {
+      lines.push(`${rpt.startDate} to ${rpt.endDate}: summary: ${rpt.summary}`);
+      if (rpt.good.length) lines.push(`good: ${rpt.good.join('; ')}`);
+      if (rpt.bad.length) lines.push(`bad: ${rpt.bad.join('; ')}`);
+      if (rpt.observations.length)
+        lines.push(`observations: ${rpt.observations.join('; ')}`);
+      lines.push(`score: ${rpt.score}`);
+      lines.push('---');
+    }
+  }
+
+  lines.push('and here is the year rapport');
+  const yearlyItem = yearly[0];
+  if (!yearlyItem) {
+    lines.push('The user was not using the app at that time.');
+  } else {
+    lines.push(
+      `${yearlyItem.startDate} to ${yearlyItem.endDate}: summary: ${yearlyItem.summary}`,
+    );
+    if (yearlyItem.good.length)
+      lines.push(`good: ${yearlyItem.good.join('; ')}`);
+    if (yearlyItem.bad.length) lines.push(`bad: ${yearlyItem.bad.join('; ')}`);
+    if (yearlyItem.observations.length)
+      lines.push(`observations: ${yearlyItem.observations.join('; ')}`);
+    lines.push(`score: ${yearlyItem.score}`);
+  }
+
+  const context = lines.join('\n');
+
+  const setup = DEFAULT_LLM_SETUP;
+  const systemPrompt = buildSystemPrompt(toneId);
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Missing OpenAI API key' },
+      { status: 500 },
+    );
+  }
+
+  const reqBody = {
+    model: setup.model,
+    temperature: setup.temperature,
+    top_p: setup.top_p,
+    max_tokens: setup.maxTokens,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: context },
+    ],
+    response_format: { type: 'json_object' },
+  } as any;
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(reqBody),
+    });
+    const raw = await aiRes.text();
+    if (!aiRes.ok) {
+      return NextResponse.json({ error: raw }, { status: aiRes.status });
+    }
+    const data = JSON.parse(raw);
+    const msg = data.choices?.[0]?.message?.content ?? '{}';
+    let parsed: any = {};
+    try {
+      parsed = JSON.parse(msg);
+    } catch {
+      parsed = {
+        Overview: msg,
+        'short-term': [],
+        'long-term': [],
+        feedback: [],
+        'score-progress': 0,
+        'score-probability': 0,
+      };
+    }
+    const scoreProgress = Number(parsed['score-progress']) || 0;
+    const scoreProbability = Number(parsed['score-probability']) || 0;
+    const content = {
+      overview: parsed.Overview || '',
+      shortTerm: Array.isArray(parsed['short-term'])
+        ? parsed['short-term']
+        : [],
+      longTerm: Array.isArray(parsed['long-term']) ? parsed['long-term'] : [],
+      feedback: Array.isArray(parsed.feedback) ? parsed.feedback : [],
+    };
+    await createOverviewReport(
+      userId,
+      today,
+      content,
+      scoreProgress,
+      scoreProbability,
+      toneId,
+    );
+    return NextResponse.json({
+      report: parsed,
+      scoreProgress,
+      scoreProbability,
+      context,
+      date: today,
+    });
+  } catch (e: any) {
+    console.error('overview-report generation failed', e);
+    return NextResponse.json(
+      {
+        error: e.message || 'LLM request failed',
+        cause: e?.cause?.message,
+        context,
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  const paramUserId = Number(req.nextUrl.searchParams.get('userId'));
+  const userId = paramUserId || Number(session?.user?.id);
+  if (!userId)
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  const reports = await listOverviewReports(userId);
+  const rpt = reports[0];
+  if (!rpt) return NextResponse.json({ report: null });
+  const report = {
+    Overview: rpt.overview,
+    'short-term': rpt.shortTerm,
+    'long-term': rpt.longTerm,
+    feedback: rpt.feedback,
+    'score-progress': rpt.scoreProgress,
+    'score-probability': rpt.scoreProbability,
+    date: rpt.date,
+  };
+  return NextResponse.json({ report });
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -336,3 +336,28 @@ export const yearlyReports = pgTable(
     ).on(table.userId, table.startDate, table.version),
   }),
 );
+
+export const overviewReports = pgTable(
+  'overview_reports',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    date: date('date').notNull(),
+    overview: text('overview').notNull().default(''),
+    shortTerm: text('short_term').notNull().default('[]'),
+    longTerm: text('long_term').notNull().default('[]'),
+    feedback: text('feedback').notNull().default('[]'),
+    coachTone: text('coach_tone').notNull().default('tone_medium'),
+    scoreProgress: integer('score_progress').notNull(),
+    scoreProbability: integer('score_probability').notNull(),
+    version: integer('version').notNull().default(1),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserDateVersion: uniqueIndex(
+      'overview_reports_user_date_version_unique',
+    ).on(table.userId, table.date, table.version),
+  }),
+);

--- a/lib/overview-report-store.ts
+++ b/lib/overview-report-store.ts
@@ -1,0 +1,167 @@
+import { db } from './db';
+import { overviewReports } from './db/schema';
+import { eq, and, desc, sql } from 'drizzle-orm';
+import type { OverviewReport } from '@/types/report';
+
+function slugFromDate(ymd: string, version = 1): string {
+  const [y, m, d] = ymd.split('-');
+  const base = `${d}${m}${y}`;
+  return version > 1 ? `${base}V${version}` : base;
+}
+
+function parseSlug(slug: string): { date: string; version: number } {
+  const match = /^(\d{2})(\d{2})(\d{4})(?:V(\d+))?$/.exec(slug);
+  if (!match) return { date: slug, version: 1 };
+  const [, d, m, y, v] = match;
+  return { date: `${y}-${m}-${d}`, version: v ? Number(v) : 1 };
+}
+
+function parseList(raw: unknown): string[] {
+  if (!raw) return [];
+  try {
+    const arr = JSON.parse(String(raw));
+    return Array.isArray(arr) ? arr.map((v) => String(v)) : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function listOverviewReports(
+  userId: number,
+): Promise<
+  Array<{
+    date: string;
+    slug: string;
+    version: number;
+    coachTone: string;
+    overview: string;
+    shortTerm: string[];
+    longTerm: string[];
+    feedback: string[];
+    scoreProgress: number;
+    scoreProbability: number;
+  }>
+> {
+  const rows = await db
+    .select({
+      date: overviewReports.date,
+      version: overviewReports.version,
+      coachTone: overviewReports.coachTone,
+      overview: overviewReports.overview,
+      shortTerm: overviewReports.shortTerm,
+      longTerm: overviewReports.longTerm,
+      feedback: overviewReports.feedback,
+      scoreProgress: overviewReports.scoreProgress,
+      scoreProbability: overviewReports.scoreProbability,
+    })
+    .from(overviewReports)
+    .where(eq(overviewReports.userId, userId))
+    .orderBy(desc(overviewReports.date), desc(overviewReports.version));
+
+  return rows.map((r) => {
+    const ymd = r.date?.toString().slice(0, 10) ?? '';
+    const version = r.version ?? 1;
+    return {
+      date: ymd,
+      slug: slugFromDate(ymd, version),
+      version,
+      coachTone: r.coachTone ?? 'tone_medium',
+      overview: r.overview ?? '',
+      shortTerm: parseList(r.shortTerm),
+      longTerm: parseList(r.longTerm),
+      feedback: parseList(r.feedback),
+      scoreProgress: r.scoreProgress ?? 0,
+      scoreProbability: r.scoreProbability ?? 0,
+    };
+  });
+}
+
+export async function getOverviewReport(
+  userId: number,
+  slug: string,
+): Promise<OverviewReport | null> {
+  const { date, version } = parseSlug(slug);
+  const [row] = await db
+    .select()
+    .from(overviewReports)
+    .where(
+      and(
+        eq(overviewReports.userId, userId),
+        eq(overviewReports.date, date),
+        eq(overviewReports.version, version),
+      ),
+    );
+  if (!row) return null;
+  return {
+    id: row.id,
+    userId: row.userId ?? 0,
+    date,
+    version: row.version ?? 1,
+    overview: row.overview ?? '',
+    shortTerm: parseList(row.shortTerm),
+    longTerm: parseList(row.longTerm),
+    feedback: parseList(row.feedback),
+    scoreProgress: row.scoreProgress ?? 0,
+    scoreProbability: row.scoreProbability ?? 0,
+    coachTone: row.coachTone ?? 'tone_medium',
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+export async function createOverviewReport(
+  userId: number,
+  date: string,
+  content: {
+    overview: string;
+    shortTerm: string[];
+    longTerm: string[];
+    feedback: string[];
+  },
+  scoreProgress: number,
+  scoreProbability: number,
+  coachTone: string,
+): Promise<void> {
+  const ymd = new Date(date).toISOString().slice(0, 10);
+  try {
+    const [{ maxVersion }] = await db
+      .select({
+        maxVersion: sql<number>`coalesce(max(${overviewReports.version}),0)`,
+      })
+      .from(overviewReports)
+      .where(
+        and(eq(overviewReports.userId, userId), eq(overviewReports.date, ymd)),
+      );
+    const nextVersion = (maxVersion ?? 0) + 1;
+    await db.insert(overviewReports).values({
+      userId,
+      date: ymd,
+      overview: content.overview ?? '',
+      shortTerm: JSON.stringify(content.shortTerm ?? []),
+      longTerm: JSON.stringify(content.longTerm ?? []),
+      feedback: JSON.stringify(content.feedback ?? []),
+      coachTone,
+      scoreProgress,
+      scoreProbability,
+      version: nextVersion,
+    });
+    console.log('createOverviewReport inserted', {
+      userId,
+      date: ymd,
+      version: nextVersion,
+      scoreProgress,
+      scoreProbability,
+      coachTone,
+    });
+  } catch (error) {
+    console.error('createOverviewReport failed', {
+      userId,
+      date: ymd,
+      content,
+      scoreProgress,
+      scoreProbability,
+      coachTone,
+      error,
+    });
+    throw error;
+  }
+}

--- a/types/report.ts
+++ b/types/report.ts
@@ -63,3 +63,18 @@ export interface YearlyReport {
   coachTone: string;
   createdAt: string;
 }
+
+export interface OverviewReport {
+  id: number;
+  userId: number;
+  date: string; // YYYY-MM-DD
+  version: number;
+  overview: string;
+  shortTerm: string[];
+  longTerm: string[];
+  feedback: string[];
+  scoreProgress: number;
+  scoreProbability: number;
+  coachTone: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- add overview-report agent to analyze long-term direction using daily, weekly, monthly, and yearly reports
- display latest overview report on Review page with generate/regenerate button and score outputs
- store overview reports with new database table and persistence helpers

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b08860a668832a9a76af92bed3ab85