### PR TITLE
feat: enrich ingredient recommendations with progress context

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -253,3 +253,4 @@
 - 2025-10-27: Removed sticky top navigation and added shared layout for progress pages to display the header without stickiness.
 - 2025-08-28: Added Heading Towards agent with overview generation button, API route, database storage, and review page display.
 - 2025-10-27: Fixed heading report generation to return camel-case fields with scores, tightened system prompt, and guarded review page rendering.
+- 2025-10-27: Enhanced ingredient recommendation agent with progress report context, added API endpoint for report summaries, and updated system message.

--- a/app/(app)/ingredients/client.tsx
+++ b/app/(app)/ingredients/client.tsx
@@ -270,8 +270,18 @@ export default function IngredientsClient({
     if (!chatInput.trim()) return;
     const isFirst =
       chatMessages.length === 1 && chatMessages[0].role === 'assistant';
+    let reportContext = '';
+    if (isFirst) {
+      try {
+        const res = await fetch('/api/ingredients/recommend/context');
+        const data = await res.json();
+        reportContext = data.context || '';
+      } catch {
+        /* ignore */
+      }
+    }
     const userContent = isFirst
-      ? `${chatInput}\n\nHere is the context of the ingredients the user currently has:\n<${buildIngredientContext(ingredients)}>`
+      ? `${chatInput}\n\nPoints where the user can improve on according to the rapports:\n<${reportContext}>\n\nHere is the context of the ingredients the user currently has:\n<${buildIngredientContext(ingredients)}>`
       : chatInput;
     const newMessages: ChatMessage[] = [
       ...chatMessages,
@@ -283,7 +293,7 @@ export default function IngredientsClient({
       {
         role: 'system',
         content:
-          'You are a helpful assistant in the Cake framework, a life-planning platform where users build a cake of goals with ingredients—habits or protocols that support their flavors. Recommend an ingredient to the user, grounding suggestions in cutting-edge science. Compare ideas with existing ingredients and, if the user is unsure, suggest one they may be missing. Always end responses with: "Should I create that ingredient for you?" If the user agrees, respond ONLY with a JSON object containing the fields title, shortDescription, usefulness, description, whyUsed, whenUsed, tips. Do not include any other text.',
+          'You are a helpful assistant in the Cake framework, a life-planning platform where users build a cake of goals with ingredients—habits or protocols that support their flavors. Recommend an ingredient to the user, grounding suggestions in cutting-edge science, and on the context of how the user can improve and which habits/protocols could help him, you are going to advise those with argumentation. Compare ideas with existing ingredients and, if the user is unsure, suggest one they may be missing. Always end responses with: "Should I create that ingredient for you?" If the user agrees, respond ONLY with a JSON object containing the fields title, shortDescription, usefulness, description, whyUsed, whenUsed, tips. Do not include any other text',
       },
       ...newMessages,
     ];

--- a/app/api/ingredients/recommend/context/route.ts
+++ b/app/api/ingredients/recommend/context/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { getLatestHeadingReport } from '@/lib/heading-report-store';
+import { listDailyReports } from '@/lib/daily-report-store';
+import { listWeeklyReports } from '@/lib/weekly-report-store';
+import { listMonthlyReports } from '@/lib/monthly-report-store';
+
+export async function GET() {
+  const session = await auth();
+  const userId = Number(session?.user?.id);
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const [heading, daily, weekly, monthly] = await Promise.all([
+    getLatestHeadingReport(userId),
+    listDailyReports(userId),
+    listWeeklyReports(userId),
+    listMonthlyReports(userId),
+  ]);
+
+  const lines: string[] = [];
+
+  if (heading?.feedback && heading.feedback.length > 0) {
+    lines.push('Feedback from review page agent:');
+    heading.feedback.forEach((f) => lines.push(`- ${f}`));
+  }
+
+  const dailyTwo = daily.slice(0, 2);
+  if (dailyTwo.length > 0) {
+    lines.push('Recent daily reports:');
+    dailyTwo.forEach((r) => {
+      const bad = r.bad.length > 0 ? r.bad.join('; ') : 'none';
+      const obs = r.observations.length > 0 ? r.observations.join('; ') : 'none';
+      lines.push(
+        `- ${r.date}\n  What went bad: ${bad}\n  Observations: ${obs}`,
+      );
+    });
+  }
+
+  const weeklyTwo = weekly.slice(0, 2);
+  if (weeklyTwo.length > 0) {
+    lines.push('Recent weekly reports:');
+    weeklyTwo.forEach((r) => {
+      const bad = r.bad.length > 0 ? r.bad.join('; ') : 'none';
+      const obs = r.observations.length > 0 ? r.observations.join('; ') : 'none';
+      lines.push(
+        `- ${r.startDate} to ${r.endDate}\n  What went bad: ${bad}\n  Observations: ${obs}`,
+      );
+    });
+  }
+
+  const monthlyTwo = monthly.slice(0, 2);
+  if (monthlyTwo.length > 0) {
+    lines.push('Recent monthly reports:');
+    monthlyTwo.forEach((r) => {
+      const bad = r.bad.length > 0 ? r.bad.join('; ') : 'none';
+      const obs = r.observations.length > 0 ? r.observations.join('; ') : 'none';
+      lines.push(
+        `- ${r.startDate} to ${r.endDate}\n  What went bad: ${bad}\n  Observations: ${obs}`,
+      );
+    });
+  }
+
+  const context = lines.join('\n');
+  return NextResponse.json({ context });
+}


### PR DESCRIPTION
## Summary
- update ingredient recommendation system prompt
- add report-based context to ingredient chat via new API

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b0936334dc832a8ebc9fd43dc94878