### PR TITLE
feat: expand ingredient recommendation context

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -253,3 +253,4 @@
 - 2025-10-27: Removed sticky top navigation and added shared layout for progress pages to display the header without stickiness.
 - 2025-08-28: Added Heading Towards agent with overview generation button, API route, database storage, and review page display.
 - 2025-10-27: Fixed heading report generation to return camel-case fields with scores, tightened system prompt, and guarded review page rendering.
+  2025-08-28: Expanded ingredient recommendation agent with new system prompt and report-based improvement context.

--- a/app/(app)/ingredients/client.tsx
+++ b/app/(app)/ingredients/client.tsx
@@ -65,16 +65,35 @@ function sortIngredients(list: Ingredient[]) {
   });
 }
 
+type ReportContext = {
+  headingFeedback: string[];
+  daily: { date: string; bad: string[]; observations: string[] }[];
+  weekly: {
+    startDate: string;
+    endDate: string;
+    bad: string[];
+    observations: string[];
+  }[];
+  monthly: {
+    startDate: string;
+    endDate: string;
+    bad: string[];
+    observations: string[];
+  }[];
+};
+
 export default function IngredientsClient({
   userId,
   selfId,
   initialIngredients,
   people,
+  reportContext,
 }: {
   userId: string; // owner id
   selfId?: string; // current viewer id for copy
   initialIngredients: Ingredient[];
   people?: PeopleLists;
+  reportContext?: ReportContext;
 }) {
   const ctx = useViewContext();
   const { editable } = ctx;
@@ -243,6 +262,39 @@ export default function IngredientsClient({
       .join('\n\n');
   }
 
+  function buildImprovementContext(rc?: ReportContext) {
+    if (!rc) return '';
+    const lines: string[] = [];
+    if (rc.headingFeedback.length) {
+      lines.push('Feedback from heading report:');
+      rc.headingFeedback.forEach((f) => lines.push(`- ${f}`));
+    }
+    const add = (
+      label: string,
+      items: {
+        date?: string;
+        startDate?: string;
+        endDate?: string;
+        bad: string[];
+        observations: string[];
+      }[],
+    ) => {
+      if (items.length === 0) return;
+      lines.push(`Last ${items.length} ${label} reports:`);
+      for (const it of items) {
+        const name = it.date ? it.date : `${it.startDate} to ${it.endDate}`;
+        lines.push(name);
+        if (it.bad.length) lines.push(`bad: ${it.bad.join('; ')}`);
+        if (it.observations.length)
+          lines.push(`observations: ${it.observations.join('; ')}`);
+      }
+    };
+    add('daily', rc.daily);
+    add('weekly', rc.weekly);
+    add('monthly', rc.monthly);
+    return lines.join('\n');
+  }
+
   function parseIngredient(str: string): Partial<IngredientInput> | null {
     try {
       return JSON.parse(str);
@@ -270,8 +322,9 @@ export default function IngredientsClient({
     if (!chatInput.trim()) return;
     const isFirst =
       chatMessages.length === 1 && chatMessages[0].role === 'assistant';
+    const improvementCtx = buildImprovementContext(reportContext);
     const userContent = isFirst
-      ? `${chatInput}\n\nHere is the context of the ingredients the user currently has:\n<${buildIngredientContext(ingredients)}>`
+      ? `${chatInput}\n\nHere is the context of the ingredients the user currently has:\n<${buildIngredientContext(ingredients)}>\n\nPoints where the user can improve on according to the rapports:\n<${improvementCtx}>`
       : chatInput;
     const newMessages: ChatMessage[] = [
       ...chatMessages,
@@ -283,7 +336,7 @@ export default function IngredientsClient({
       {
         role: 'system',
         content:
-          'You are a helpful assistant in the Cake framework, a life-planning platform where users build a cake of goals with ingredients—habits or protocols that support their flavors. Recommend an ingredient to the user, grounding suggestions in cutting-edge science. Compare ideas with existing ingredients and, if the user is unsure, suggest one they may be missing. Always end responses with: "Should I create that ingredient for you?" If the user agrees, respond ONLY with a JSON object containing the fields title, shortDescription, usefulness, description, whyUsed, whenUsed, tips. Do not include any other text.',
+          'You are a helpful assistant in the Cake framework, a life-planning platform where users build a cake of goals with ingredients—habits or protocols that support their flavors. Recommend an ingredient to the user, grounding suggestions in cutting-edge science, and on the context of how the user can improve and which habits/protocols could help him, you are going to advise those with argumentation. Compare ideas with existing ingredients and, if the user is unsure, suggest one they may be missing. Always end responses with: "Should I create that ingredient for you?" If the user agrees, respond ONLY with a JSON object containing the fields title, shortDescription, usefulness, description, whyUsed, whenUsed, tips. Do not include any other text.',
       },
       ...newMessages,
     ];

--- a/app/(app)/ingredients/page.tsx
+++ b/app/(app)/ingredients/page.tsx
@@ -6,6 +6,10 @@ import IngredientsClient from './client';
 import { buildViewContext } from '@/lib/profile';
 import { ViewContextProvider } from '@/lib/view-context';
 import { listPeople } from '@/lib/people-store';
+import { getLatestHeadingReport } from '@/lib/heading-report-store';
+import { listDailyReports } from '@/lib/daily-report-store';
+import { listWeeklyReports } from '@/lib/weekly-report-store';
+import { listMonthlyReports } from '@/lib/monthly-report-store';
 
 export default async function IngredientsPage({
   searchParams,
@@ -17,8 +21,40 @@ export default async function IngredientsPage({
   if (!session) notFound();
   const me = await ensureUser(session);
   const at = params?.at ? new Date(params.at) : undefined;
-  const ingredients = await listIngredients(String(me.id), me.id, at);
-  const people = await listPeople(me.id);
+  const [
+    ingredients,
+    people,
+    heading,
+    dailyReports,
+    weeklyReports,
+    monthlyReports,
+  ] = await Promise.all([
+    listIngredients(String(me.id), me.id, at),
+    listPeople(me.id),
+    getLatestHeadingReport(me.id),
+    listDailyReports(me.id),
+    listWeeklyReports(me.id),
+    listMonthlyReports(me.id),
+  ]);
+
+  const reportContext = {
+    headingFeedback: heading?.feedback ?? [],
+    daily: dailyReports
+      .slice(0, 2)
+      .map((r) => ({ date: r.date, bad: r.bad, observations: r.observations })),
+    weekly: weeklyReports.slice(0, 2).map((r) => ({
+      startDate: r.startDate,
+      endDate: r.endDate,
+      bad: r.bad,
+      observations: r.observations,
+    })),
+    monthly: monthlyReports.slice(0, 2).map((r) => ({
+      startDate: r.startDate,
+      endDate: r.endDate,
+      bad: r.bad,
+      observations: r.observations,
+    })),
+  };
   const ctx = buildViewContext({
     ownerId: me.id,
     viewerId: me.id,
@@ -33,6 +69,7 @@ export default async function IngredientsPage({
         selfId={String(me.id)}
         initialIngredients={ingredients}
         people={people}
+        reportContext={reportContext}
       />
     </ViewContextProvider>
   );
@@ -43,11 +80,13 @@ export function IngredientsHome({
   selfId,
   initialIngredients,
   people,
+  reportContext,
 }: {
   userId: string;
   selfId?: string;
   initialIngredients: any[];
   people?: any;
+  reportContext?: any;
 }) {
   return (
     <IngredientsClient
@@ -55,6 +94,7 @@ export function IngredientsHome({
       selfId={selfId}
       initialIngredients={initialIngredients as any}
       people={people as any}
+      reportContext={reportContext}
     />
   );
 }


### PR DESCRIPTION
## Summary
- surface latest heading feedback and recent daily/weekly/monthly report issues to ingredient recommender
- enhance ingredient recommendation client with report-based improvement context and updated system prompt

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b0936334dc832a8ebc9fd43dc94878