### PR TITLE
feat: add flavor recommendation agent

### DIFF
--- a/ID.md
+++ b/ID.md
@@ -41,6 +41,7 @@ Modal form IDs:
 - `f7avsubfbtn{flavorId}-{ownerId}` → open subflavors button.
 - `f7av-add-own-{ownerId}` → create own flavor option.
 - `f7av-add-import-{ownerId}` → import flavor option.
+- `f7av-add-recommend-{ownerId}` → recommend flavor option.
 - `f7av-imp-pre-{ownerId}` → choose preset flavor import.
 - `f7av-imp-srch-{ownerId}` → search others flavor import.
 - `f7av-pr3-{index}-{ownerId}` → preset flavor selection.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -256,3 +256,4 @@
   2025-08-28: Expanded ingredient recommendation agent with new system prompt and report-based improvement context.
 - 2025-10-27: Added ingredient improvement chat with AI-assisted updates during editing.
 - 2025-10-27: Closed edit dialog when launching improvement chat and recreate ingredients from AI suggestions to avoid update errors.
+- 2025-10-27: Added flavor recommendation agent with chat modal and automatic flavor creation.

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -8,6 +8,7 @@ import type { PeopleLists, Person } from '@/lib/people-store';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor } from '@/lib/navigation';
 import IconPicker from '@/components/icon-picker';
+import type { HeadingReport } from '@/types/report';
 const VISIBILITIES: Visibility[] = [
   'private',
   'friends',
@@ -78,11 +79,13 @@ export default function FlavorsClient({
   selfId,
   initialFlavors,
   people,
+  headingReport,
 }: {
   userId: string;
   selfId?: string;
   initialFlavors: Flavor[];
   people?: PeopleLists;
+  headingReport?: HeadingReport;
 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -97,6 +100,23 @@ export default function FlavorsClient({
     'choice',
   );
   const [peopleSearch, setPeopleSearch] = useState('');
+  const [recommendOpen, setRecommendOpen] = useState(false);
+  type ChatMessage = { role: 'user' | 'assistant'; content: string };
+  const initialChat: ChatMessage[] = [
+    {
+      role: 'assistant',
+      content: 'What kind of flavour would you like to create?',
+    },
+  ];
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>(initialChat);
+  const [chatInput, setChatInput] = useState('');
+  const CHAT_STORAGE_KEY = 'flavor-recommend-chat';
+  const chatIdRef = useRef<string>(
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : Math.random().toString(36).slice(2),
+  );
+  const chatEndRef = useRef<HTMLDivElement>(null);
   const [editing, setEditing] = useState<Flavor | null>(null);
   const [form, setForm] = useState<FormState>({
     name: '',
@@ -115,6 +135,30 @@ export default function FlavorsClient({
   const modalRef = useRef<HTMLDivElement>(null);
   const formRef = useRef(form);
   const initialFormRef = useRef(initialForm);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const saved = localStorage.getItem(CHAT_STORAGE_KEY);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        if (parsed.chatId) chatIdRef.current = parsed.chatId;
+        if (parsed.messages) setChatMessages(parsed.messages);
+      } catch {
+        /* ignore */
+      }
+    }
+  }, []);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (recommendOpen)
+      localStorage.setItem(
+        CHAT_STORAGE_KEY,
+        JSON.stringify({ chatId: chatIdRef.current, messages: chatMessages }),
+      );
+  }, [chatMessages, recommendOpen]);
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [chatMessages]);
   const filtered = useMemo(
     () =>
       flavors.filter(
@@ -157,6 +201,134 @@ export default function FlavorsClient({
     { label: 'Following', list: filterPeople(people?.following) },
     { label: 'Others', list: filterPeople(people?.others) },
   ];
+
+  function buildFlavorContext(list: Flavor[]) {
+    return sortFlavors(list)
+      .map((f) => {
+        const parts = [`Name\n${f.name}`, `Importance (${f.importance})`];
+        if (f.description) parts.push(`Description\n${f.description}`);
+        parts.push(`Target mix (${f.targetMix})`);
+        return parts.join('\n');
+      })
+      .join('\n\n');
+  }
+
+  function buildHeadingContext(r?: HeadingReport) {
+    if (!r) return '';
+    const lines: string[] = [];
+    if (r.overview) lines.push(`Overview\n${r.overview}`);
+    if (r.shortTerm?.length)
+      lines.push(`Heading towards short term\n${r.shortTerm.join('; ')}`);
+    if (r.longTerm?.length)
+      lines.push(`Heading towards long term\n${r.longTerm.join('; ')}`);
+    if (r.feedback?.length) lines.push(`Feedback\n${r.feedback.join('; ')}`);
+    return lines.join('\n');
+  }
+
+  function parseFlavor(str: string): any {
+    try {
+      const obj = JSON.parse(str);
+      return obj;
+    } catch {
+      try {
+        const m = str.match(/```json\s*([\s\S]*?)\s*```/i);
+        if (m) return JSON.parse(m[1]);
+      } catch {
+        return null;
+      }
+      return null;
+    }
+  }
+
+  function resetChat() {
+    const id =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : Math.random().toString(36).slice(2);
+    chatIdRef.current = id;
+    setChatMessages(initialChat);
+  }
+
+  async function sendChat() {
+    if (!chatInput.trim()) return;
+    const isFirst =
+      chatMessages.length === 1 && chatMessages[0].role === 'assistant';
+    const rational =
+      typeof window !== 'undefined'
+        ? window.localStorage.getItem('review-rational') || ''
+        : '';
+    const overviewCtx = buildHeadingContext(headingReport);
+    const userContent = isFirst
+      ? `this is the life ethos statement/goal the user has in its life: ${rational} . This is the rapport of the user where he is heading towards, which include an Overview. heading toward long and short term, and feedback: <${overviewCtx}>. the user currently has these flavours <${buildFlavorContext(flavors)}>. This was the input message from the user: ${chatInput}. Based on this, generate an advice on Main flavours for the user .`
+      : chatInput;
+    const newMessages: ChatMessage[] = [
+      ...chatMessages,
+      { role: 'user', content: userContent },
+    ];
+    setChatMessages(newMessages);
+    setChatInput('');
+    const payload = [
+      {
+        role: 'system',
+        content:
+          'You are a helpful assistant in the Cake framework, a life-planning platform where users build a cake which represent their ethos statement using flavours which are built with ingredients—Flavours are kind of the goals/vectorial placement people have in different domains in life, these flavours combined (and of course their execution) leads to a cake. If you want an apple cake, and you use too many of the banna flavours and too little of the apple ones, the cake will turn into a banana cake. Same with life, doing too much or too little in a domain can change the outcome of somebody\'s life. Subflavours are kind of intermediate/smaller goals that the user has to complete in order to have a change of reaching their goal of the the main flavour, main flavour are kind of the bigger domains. \n Ingredient are habits/protocols that help him build those flavours. you’re goals is to advise a main flavour the user is missing based on what his goals are, the direction he is going towards, and the current flavours. always listen to the users suggestions but if the user is unsure, suggest one they may be missing. Always end responses with: "Should I create that Main Flavour for you?" If the user agrees, respond ONLY with a JSON object containing the fields Name, Description, Importance, description. Do not include any other text\nName is the title of the main flavour, description is the description of the Flavour, and description is a score from 0 -100 on how important this Main flavour is based on the users goal in life and compared to the other flavors in general .',
+      },
+      ...newMessages,
+    ];
+    try {
+      const res = await fetch('/api/flavors/recommend', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chatId: chatIdRef.current, messages: payload }),
+      });
+      const data = await res.json();
+      if (data.response) {
+        const parsed = parseFlavor(data.response as string);
+        const name = parsed?.Name || parsed?.name;
+        if (parsed && name) {
+          const ok = confirm(`Do you want to add this flavour (${name})?`);
+          if (ok) {
+            const created = await createFlavor({
+              name,
+              description: parsed.Description || parsed.description || '',
+              color: '#888888',
+              icon: '🤖',
+              importance:
+                Number(
+                  parsed.Importance ?? parsed.importance ?? parsed.description,
+                ) || 50,
+              targetMix: 50,
+              visibility: 'private',
+              orderIndex: 0,
+            });
+            setFlavors((prev) => sortFlavors([...prev, created]));
+            setChatMessages([
+              ...newMessages,
+              {
+                role: 'assistant',
+                content: `Added flavour "${created.name}".`,
+              },
+            ]);
+          } else {
+            setChatMessages([
+              ...newMessages,
+              { role: 'assistant', content: 'Okay, not adding it.' },
+            ]);
+          }
+        } else {
+          setChatMessages([
+            ...newMessages,
+            { role: 'assistant', content: data.response as string },
+          ]);
+        }
+      }
+    } catch {
+      setChatMessages([
+        ...newMessages,
+        { role: 'assistant', content: 'Sorry, something went wrong.' },
+      ]);
+    }
+  }
 
   function openNew() {
     if (!editable) return;
@@ -434,6 +606,16 @@ export default function FlavorsClient({
               >
                 Import flavor
               </button>
+              <button
+                id={`f7av-add-recommend-${userId}`}
+                className="rounded bg-orange-500 px-3 py-1 text-white"
+                onClick={() => {
+                  setChoiceOpen(false);
+                  setRecommendOpen(true);
+                }}
+              >
+                Recommend flavour
+              </button>
             </div>
             <div className="mt-4 flex justify-end">
               <button
@@ -442,6 +624,67 @@ export default function FlavorsClient({
                 onClick={() => setChoiceOpen(false)}
               >
                 Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {recommendOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+          <div className="flex w-[90%] max-w-2xl max-h-[90vh] flex-col rounded bg-white p-6 shadow-lg">
+            <div className="mb-4 flex-1 overflow-y-auto space-y-2">
+              {chatMessages.map((m, i) => (
+                <div
+                  key={i}
+                  className={m.role === 'user' ? 'text-right' : 'text-left'}
+                >
+                  <span
+                    className={
+                      m.role === 'user'
+                        ? 'inline-block rounded bg-orange-100 px-2 py-1'
+                        : 'inline-block rounded bg-gray-200 px-2 py-1'
+                    }
+                  >
+                    {m.content}
+                  </span>
+                </div>
+              ))}
+              <div ref={chatEndRef} />
+            </div>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={chatInput}
+                onChange={(e) => setChatInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') sendChat();
+                }}
+                placeholder="Type your answer..."
+                className="flex-1 rounded border px-2 py-1"
+              />
+              <button
+                onClick={sendChat}
+                className="rounded bg-orange-500 px-3 py-1 text-white"
+              >
+                Send
+              </button>
+            </div>
+            <div className="mt-4 flex justify-between">
+              <button
+                type="button"
+                className="rounded border px-3 py-1"
+                onClick={resetChat}
+              >
+                Reset
+              </button>
+              <button
+                type="button"
+                className="rounded border px-3 py-1"
+                onClick={() => {
+                  setRecommendOpen(false);
+                }}
+              >
+                Close
               </button>
             </div>
           </div>

--- a/app/(app)/flavors/page.tsx
+++ b/app/(app)/flavors/page.tsx
@@ -6,6 +6,7 @@ import { getUserByViewId, ensureUser } from '@/lib/users';
 import { listPeople } from '@/lib/people-store';
 import { buildViewContext } from '@/lib/profile';
 import { ViewContextProvider } from '@/lib/view-context';
+import { getLatestHeadingReport } from '@/lib/heading-report-store';
 
 export default async function FlavorsPage({
   params,
@@ -21,8 +22,11 @@ export default async function FlavorsPage({
     if (!user) notFound();
     owner = user;
   }
-  const flavors = await listFlavors(String(owner.id));
-  const people = owner.id === viewer.id ? await listPeople(owner.id) : undefined;
+  const [flavors, people, heading] = await Promise.all([
+    listFlavors(String(owner.id)),
+    owner.id === viewer.id ? listPeople(owner.id) : Promise.resolve(undefined),
+    getLatestHeadingReport(owner.id),
+  ]);
   const ctx = buildViewContext({
     ownerId: owner.id,
     viewerId: viewer.id,
@@ -36,6 +40,7 @@ export default async function FlavorsPage({
         selfId={String(viewer.id)}
         initialFlavors={flavors}
         people={people}
+        headingReport={heading ?? undefined}
       />
     </ViewContextProvider>
   );
@@ -46,11 +51,13 @@ export function FlavorsHome({
   selfId,
   initialFlavors,
   people,
+  headingReport,
 }: {
   userId: string;
   selfId?: string;
   initialFlavors: any[];
   people?: any;
+  headingReport?: any;
 }) {
   return (
     <FlavorsClient
@@ -58,6 +65,7 @@ export function FlavorsHome({
       selfId={selfId}
       initialFlavors={initialFlavors as any}
       people={people as any}
+      headingReport={headingReport}
     />
   );
 }

--- a/app/api/flavors/recommend/route.ts
+++ b/app/api/flavors/recommend/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { DEFAULT_LLM_SETUP, withOverrides } from '@/lib/llm/config';
+
+export async function POST(req: NextRequest) {
+  const { messages, overrides, chatId } = await req.json();
+  console.log('flavor recommend request', chatId, messages);
+
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Missing OpenAI API key' },
+      { status: 500 },
+    );
+  }
+
+  const setup = withOverrides(DEFAULT_LLM_SETUP, overrides);
+
+  const body = {
+    model: setup.model,
+    temperature: setup.temperature,
+    top_p: setup.top_p,
+    max_tokens: setup.maxTokens,
+    messages,
+  } as any;
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const rawResponse = await aiRes.text();
+
+    if (!aiRes.ok) {
+      return NextResponse.json(
+        { error: rawResponse },
+        { status: aiRes.status },
+      );
+    }
+
+    const data = JSON.parse(rawResponse);
+    const choice = data.choices?.[0];
+    const msg = choice?.message;
+    const response = msg?.content ?? '';
+    console.log('flavor recommend response', response);
+    return NextResponse.json({ response });
+  } catch (e: any) {
+    console.error('flavor recommend error', e);
+    return NextResponse.json(
+      { error: e.message || 'LLM request failed' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add flavor recommendation chat to suggest and create flavours with a default target mix and robot icon
- expose `/api/flavors/recommend` endpoint for LLM requests
- document new flavor recommendation option IDs and changelog entry

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b150a62d2c832aa8e3a4817be008bf