### PR TITLE
fix: align side calendar to correct weekdays

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -257,3 +257,4 @@
 - 2025-10-27: Added ingredient improvement chat with AI-assisted updates during editing.
 - 2025-10-27: Closed edit dialog when launching improvement chat and recreate ingredients from AI suggestions to avoid update errors.
 - 2025-10-27: Added flavor recommendation agent with chat modal and automatic flavor creation.
+- 2025-10-27: Aligned side calendar weeks to display correct weekdays and match snapshot dates.

--- a/components/calendar/side-calendar.tsx
+++ b/components/calendar/side-calendar.tsx
@@ -23,8 +23,18 @@ export function SideCalendar({
 
   const start = new Date(base);
   start.setDate(start.getDate() - 30);
+  // Align the start date to the beginning of the week (Sunday) so the
+  // calendar grid columns match actual weekdays. Without this adjustment the
+  // weekday labels drift, causing each date to appear under the wrong day
+  // (e.g. 1 September 2025 showing under Sunday).
+  start.setDate(start.getDate() - start.getDay());
+
   const end = new Date(base);
   end.setDate(end.getDate() + 7);
+  // Extend the end date to the end of its week so that the grid covers whole
+  // weeks after shifting the start. This also keeps "yesterday" snapshots
+  // aligned with the correct date.
+  end.setDate(end.getDate() + (6 - end.getDay()));
 
   const days: Date[] = [];
   for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {


### PR DESCRIPTION
## Summary
- align side calendar range to start/end of week so weekdays display correctly
- document calendar alignment fix in update log

## Testing
- `pnpm tsc`
- `pnpm lint`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b1576fd05c832a97be308ee65dfb0c