### PR TITLE
feat: default new items to public visibility

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -260,3 +260,4 @@
 - 2025-10-27: Added subflavor recommendation agent with chat modal and automatic subflavor creation.
 - 2025-10-27: Aligned side calendar weeks to display correct weekdays and match snapshot dates.
 - 2025-10-27: Restyled ingredient edit modal to match flavor edit layout.
+- 2025-10-27: Default new ingredients and flavors to public visibility.

--- a/app/(app)/flavors/actions.ts
+++ b/app/(app)/flavors/actions.ts
@@ -39,7 +39,7 @@ function sanitize(body: any): FlavorInput {
     'public',
   ].includes(body.visibility)
     ? body.visibility
-    : 'private';
+    : 'public';
   const orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : 0;
   return {
     name: body.name,
@@ -71,11 +71,7 @@ export async function updateFlavor(id: string, form: any): Promise<Flavor> {
   const session = await auth();
   const self = await ensureUser(session);
   await assertOwner(self.id, self.id);
-  const updated = await updateFlavorStore(
-    String(self.id),
-    id,
-    sanitize(form),
-  );
+  const updated = await updateFlavorStore(String(self.id), id, sanitize(form));
   if (!updated) {
     throw new Error('Not found');
   }
@@ -90,7 +86,7 @@ export async function copyFlavor(
 ) {
   const session = await auth();
   const self = await ensureUser(session);
-    const source = await getFlavor(fromUserId, flavorId, Number(self.id));
+  const source = await getFlavor(fromUserId, flavorId, Number(self.id));
   if (!source) throw new Error('Not found');
   const created = await createFlavorStore(String(self.id), {
     name: source.name,

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -32,7 +32,7 @@ const PRESET_FLAVORS: FlavorInput[] = [
     icon: '❤️',
     importance: 70,
     targetMix: 50,
-    visibility: 'private',
+    visibility: 'public',
     orderIndex: 0,
     slug: '',
   },
@@ -43,7 +43,7 @@ const PRESET_FLAVORS: FlavorInput[] = [
     icon: '📚',
     importance: 60,
     targetMix: 40,
-    visibility: 'private',
+    visibility: 'public',
     orderIndex: 0,
     slug: '',
   },
@@ -125,7 +125,7 @@ export default function FlavorsClient({
     icon: '⭐',
     importance: 50,
     targetMix: 50,
-    visibility: 'private',
+    visibility: 'public',
     orderIndex: 0,
   });
   const [initialForm, setInitialForm] = useState<FormState>(form);
@@ -298,7 +298,7 @@ export default function FlavorsClient({
                   parsed.Importance ?? parsed.importance ?? parsed.description,
                 ) || 50,
               targetMix: 50,
-              visibility: 'private',
+              visibility: 'public',
               orderIndex: 0,
             });
             setFlavors((prev) => sortFlavors([...prev, created]));
@@ -340,7 +340,7 @@ export default function FlavorsClient({
       icon: '⭐',
       importance: 50,
       targetMix: 50,
-      visibility: 'private' as Visibility,
+      visibility: 'public' as Visibility,
       orderIndex: flavors.length,
     };
     setForm(blank);

--- a/app/(app)/ingredients/actions.ts
+++ b/app/(app)/ingredients/actions.ts
@@ -1,6 +1,10 @@
 'use server';
 
-import { createIngredient as createStore, updateIngredient as updateStore, deleteIngredient as deleteStore } from '@/lib/ingredients-store';
+import {
+  createIngredient as createStore,
+  updateIngredient as updateStore,
+  deleteIngredient as deleteStore,
+} from '@/lib/ingredients-store';
 import { assertOwner } from '@/lib/profile';
 import type { Ingredient } from '@/types/ingredient';
 import { revalidatePath } from 'next/cache';
@@ -15,9 +19,11 @@ function sanitize(form: FormData) {
   obj.shortDescription = (obj.shortDescription || '').toString().slice(0, 160);
   obj.imageUrl = typeof obj.imageUrl === 'string' ? obj.imageUrl : null;
   obj.icon = typeof obj.icon === 'string' ? obj.icon : '⭐';
-  obj.visibility = ['private', 'followers', 'friends', 'public'].includes(obj.visibility)
+  obj.visibility = ['private', 'followers', 'friends', 'public'].includes(
+    obj.visibility,
+  )
     ? obj.visibility
-    : 'private';
+    : 'public';
   obj.tags =
     typeof obj.tags === 'string' && obj.tags
       ? (obj.tags as string).split(',').map((t: string) => t.trim())

--- a/app/(app)/ingredients/client.tsx
+++ b/app/(app)/ingredients/client.tsx
@@ -35,7 +35,7 @@ const PRESET_INGREDIENTS: IngredientInput[] = [
     icon: '🏃',
     imageUrl: null,
     tags: null,
-    visibility: 'private',
+    visibility: 'public',
   },
   {
     title: 'No Sugar After Lunch',
@@ -48,7 +48,7 @@ const PRESET_INGREDIENTS: IngredientInput[] = [
     icon: '🍬',
     imageUrl: null,
     tags: null,
-    visibility: 'private',
+    visibility: 'public',
   },
 ];
 
@@ -185,7 +185,7 @@ export default function IngredientsClient({
     whenUsed: '',
     tips: '',
     icon: '⭐',
-    visibility: 'private' as Visibility,
+    visibility: 'public' as Visibility,
   });
   const initialForm = useRef(form);
 
@@ -200,7 +200,7 @@ export default function IngredientsClient({
       whenUsed: '',
       tips: '',
       icon: '⭐',
-      visibility: 'private' as Visibility,
+      visibility: 'public' as Visibility,
     };
     setForm(blank);
     initialForm.current = blank;

--- a/app/api/flavors/route.ts
+++ b/app/api/flavors/route.ts
@@ -49,7 +49,7 @@ function sanitize(body: any) {
     'public',
   ].includes(body.visibility)
     ? body.visibility
-    : 'private';
+    : 'public';
   const orderIndex = typeof body.orderIndex === 'number' ? body.orderIndex : 0;
   return {
     name: body.name,

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -63,7 +63,7 @@ export const flavors = pgTable('flavors', {
   icon: text('icon'),
   importance: integer('importance'),
   targetMix: integer('target_mix'),
-  visibility: varchar('visibility', { length: 20 }),
+  visibility: varchar('visibility', { length: 20 }).default('public'),
   orderIndex: integer('order_index'),
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow(),
@@ -105,7 +105,7 @@ export const ingredients = pgTable(
     // Icon for the ingredient, stored as emoji or data URL
     icon: text('icon'),
     tags: text('tags').array(),
-    visibility: varchar('visibility', { length: 20 }),
+    visibility: varchar('visibility', { length: 20 }).default('public'),
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').defaultNow(),
   },

--- a/lib/flavors-store.ts
+++ b/lib/flavors-store.ts
@@ -22,14 +22,18 @@ function toFlavor(row: typeof flavors.$inferSelect): Flavor {
     icon: row.icon ?? '⭐',
     importance: row.importance ?? 0,
     targetMix: row.targetMix ?? 0,
-    visibility: (row.visibility as Visibility) ?? 'private',
+    visibility: (row.visibility as Visibility) ?? 'public',
     orderIndex: row.orderIndex ?? 0,
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
     updatedAt: row.updatedAt?.toISOString() ?? new Date().toISOString(),
   };
 }
 
-async function canView(viewerId: number | null, ownerId: number, vis: Visibility) {
+async function canView(
+  viewerId: number | null,
+  ownerId: number,
+  vis: Visibility,
+) {
   if (viewerId === ownerId) return true;
   switch (vis) {
     case 'public':
@@ -39,24 +43,48 @@ async function canView(viewerId: number | null, ownerId: number, vis: Visibility
       const [f1] = await db
         .select()
         .from(follows)
-        .where(and(eq(follows.followerId, viewerId), eq(follows.followingId, ownerId), eq(follows.status, 'accepted')));
+        .where(
+          and(
+            eq(follows.followerId, viewerId),
+            eq(follows.followingId, ownerId),
+            eq(follows.status, 'accepted'),
+          ),
+        );
       if (f1) return true;
       const [f2] = await db
         .select()
         .from(follows)
-        .where(and(eq(follows.followerId, ownerId), eq(follows.followingId, viewerId), eq(follows.status, 'accepted')));
+        .where(
+          and(
+            eq(follows.followerId, ownerId),
+            eq(follows.followingId, viewerId),
+            eq(follows.status, 'accepted'),
+          ),
+        );
       return !!f2;
     case 'friends':
       if (!viewerId) return false;
       const [ff] = await db
         .select()
         .from(follows)
-        .where(and(eq(follows.followerId, viewerId), eq(follows.followingId, ownerId), eq(follows.status, 'accepted')));
+        .where(
+          and(
+            eq(follows.followerId, viewerId),
+            eq(follows.followingId, ownerId),
+            eq(follows.status, 'accepted'),
+          ),
+        );
       if (!ff) return false;
       const [rf] = await db
         .select()
         .from(follows)
-        .where(and(eq(follows.followerId, ownerId), eq(follows.followingId, viewerId), eq(follows.status, 'accepted')));
+        .where(
+          and(
+            eq(follows.followerId, ownerId),
+            eq(follows.followingId, viewerId),
+            eq(follows.status, 'accepted'),
+          ),
+        );
       return !!rf;
     default:
       return false;
@@ -80,12 +108,21 @@ export async function getFlavor(
     .from(flavors)
     .where(and(eq(flavors.userId, Number(userId)), eq(flavors.id, id)));
   if (!row) return null;
-  if (!(await canView(viewerId, row.userId ?? 0, (row.visibility as Visibility) ?? 'private')))
+  if (
+    !(await canView(
+      viewerId,
+      row.userId ?? 0,
+      (row.visibility as Visibility) ?? 'public',
+    ))
+  )
     return null;
   return toFlavor(row);
 }
 
-export async function createFlavor(userId: string, input: FlavorInput): Promise<Flavor> {
+export async function createFlavor(
+  userId: string,
+  input: FlavorInput,
+): Promise<Flavor> {
   const id = crypto.randomUUID();
   const now = new Date();
   const [row] = await db
@@ -95,14 +132,17 @@ export async function createFlavor(userId: string, input: FlavorInput): Promise<
       userId: Number(userId),
       slug:
         input.slug ||
-        input.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 40),
+        input.name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .slice(0, 40),
       name: input.name.slice(0, 40),
       description: input.description.slice(0, 280),
       color: input.color,
       icon: input.icon,
       importance: clamp(input.importance),
       targetMix: clamp(input.targetMix),
-      visibility: input.visibility,
+      visibility: input.visibility ?? 'public',
       orderIndex: input.orderIndex ?? 0,
       createdAt: now,
       updatedAt: now,
@@ -114,7 +154,7 @@ export async function createFlavor(userId: string, input: FlavorInput): Promise<
 export async function updateFlavor(
   userId: string,
   id: string,
-  input: Partial<FlavorInput>
+  input: Partial<FlavorInput>,
 ): Promise<Flavor | null> {
   const now = new Date();
   const [row] = await db
@@ -122,11 +162,15 @@ export async function updateFlavor(
     .set({
       slug: input.slug,
       name: input.name ? input.name.slice(0, 40) : undefined,
-      description: input.description ? input.description.slice(0, 280) : undefined,
+      description: input.description
+        ? input.description.slice(0, 280)
+        : undefined,
       color: input.color,
       icon: input.icon,
-      importance: input.importance !== undefined ? clamp(input.importance) : undefined,
-      targetMix: input.targetMix !== undefined ? clamp(input.targetMix) : undefined,
+      importance:
+        input.importance !== undefined ? clamp(input.importance) : undefined,
+      targetMix:
+        input.targetMix !== undefined ? clamp(input.targetMix) : undefined,
       visibility: input.visibility,
       orderIndex: input.orderIndex,
       updatedAt: now,
@@ -136,7 +180,10 @@ export async function updateFlavor(
   return row ? toFlavor(row) : null;
 }
 
-export async function deleteFlavor(userId: string, id: string): Promise<boolean> {
+export async function deleteFlavor(
+  userId: string,
+  id: string,
+): Promise<boolean> {
   const rows = await db
     .delete(flavors)
     .where(and(eq(flavors.userId, Number(userId)), eq(flavors.id, id)))

--- a/lib/ingredients-store.ts
+++ b/lib/ingredients-store.ts
@@ -1,7 +1,11 @@
 import { db } from './db';
 import { ingredients, ingredientRevisions, follows } from './db/schema';
 import { eq, and, desc, lte } from 'drizzle-orm';
-import type { Ingredient, IngredientInput, Visibility } from '@/types/ingredient';
+import type {
+  Ingredient,
+  IngredientInput,
+  Visibility,
+} from '@/types/ingredient';
 
 function sortIngredients(list: Ingredient[]) {
   return list.sort((a, b) => {
@@ -24,13 +28,17 @@ function toIngredient(row: typeof ingredients.$inferSelect): Ingredient {
     imageUrl: row.imageUrl ?? null,
     icon: row.icon ?? '⭐',
     tags: row.tags ?? null,
-    visibility: (row.visibility as Visibility) ?? 'private',
+    visibility: (row.visibility as Visibility) ?? 'public',
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
     updatedAt: row.updatedAt?.toISOString() ?? new Date().toISOString(),
   };
 }
 
-async function canView(viewerId: number | null, ownerId: number, vis: Visibility) {
+async function canView(
+  viewerId: number | null,
+  ownerId: number,
+  vis: Visibility,
+) {
   if (viewerId === ownerId) return true;
   switch (vis) {
     case 'public':
@@ -40,18 +48,33 @@ async function canView(viewerId: number | null, ownerId: number, vis: Visibility
       const [f1] = await db
         .select()
         .from(follows)
-        .where(and(eq(follows.followerId, viewerId), eq(follows.followingId, ownerId)));
+        .where(
+          and(
+            eq(follows.followerId, viewerId),
+            eq(follows.followingId, ownerId),
+          ),
+        );
       return !!f1 && f1.status === 'accepted';
     case 'friends':
       if (!viewerId) return false;
       const [f2] = await db
         .select()
         .from(follows)
-        .where(and(eq(follows.followerId, viewerId), eq(follows.followingId, ownerId)));
+        .where(
+          and(
+            eq(follows.followerId, viewerId),
+            eq(follows.followingId, ownerId),
+          ),
+        );
       const [f3] = await db
         .select()
         .from(follows)
-        .where(and(eq(follows.followerId, ownerId), eq(follows.followingId, viewerId)));
+        .where(
+          and(
+            eq(follows.followerId, ownerId),
+            eq(follows.followingId, viewerId),
+          ),
+        );
       return f2?.status === 'accepted' && f3?.status === 'accepted';
     case 'private':
     default:
@@ -64,17 +87,31 @@ export async function listIngredients(
   viewerId: number | null = null,
   at?: Date,
 ): Promise<Ingredient[]> {
-  const rows = await db.select().from(ingredients).where(eq(ingredients.userId, Number(userId)));
+  const rows = await db
+    .select()
+    .from(ingredients)
+    .where(eq(ingredients.userId, Number(userId)));
   const list: Ingredient[] = [];
   for (const row of rows) {
-    if (!(await canView(viewerId, row.userId ?? 0, (row.visibility as Visibility) ?? 'private')))
+    if (
+      !(await canView(
+        viewerId,
+        row.userId ?? 0,
+        (row.visibility as Visibility) ?? 'public',
+      ))
+    )
       continue;
     let base = toIngredient(row);
     if (at) {
       const [rev] = await db
         .select()
         .from(ingredientRevisions)
-        .where(and(eq(ingredientRevisions.ingredientId, row.id), lte(ingredientRevisions.snapshotAt, at)))
+        .where(
+          and(
+            eq(ingredientRevisions.ingredientId, row.id),
+            lte(ingredientRevisions.snapshotAt, at),
+          ),
+        )
         .orderBy(desc(ingredientRevisions.snapshotAt))
         .limit(1);
       if (rev) {
@@ -97,14 +134,25 @@ export async function getIngredient(
     .from(ingredients)
     .where(and(eq(ingredients.userId, Number(userId)), eq(ingredients.id, id)));
   if (!row) return null;
-  if (!(await canView(viewerId, row.userId ?? 0, (row.visibility as Visibility) ?? 'private')))
+  if (
+    !(await canView(
+      viewerId,
+      row.userId ?? 0,
+      (row.visibility as Visibility) ?? 'public',
+    ))
+  )
     return null;
   let base = toIngredient(row);
   if (at) {
     const [rev] = await db
       .select()
       .from(ingredientRevisions)
-      .where(and(eq(ingredientRevisions.ingredientId, row.id), lte(ingredientRevisions.snapshotAt, at)))
+      .where(
+        and(
+          eq(ingredientRevisions.ingredientId, row.id),
+          lte(ingredientRevisions.snapshotAt, at),
+        ),
+      )
       .orderBy(desc(ingredientRevisions.snapshotAt))
       .limit(1);
     if (rev) {
@@ -133,7 +181,7 @@ export async function createIngredient(
       imageUrl: input.imageUrl,
       icon: input.icon,
       tags: input.tags ?? null,
-      visibility: input.visibility,
+      visibility: input.visibility ?? 'public',
       createdAt: now,
       updatedAt: now,
     })
@@ -212,7 +260,9 @@ export async function deleteIngredient(
     const [exists] = await tx
       .select({ id: ingredients.id })
       .from(ingredients)
-      .where(and(eq(ingredients.userId, Number(userId)), eq(ingredients.id, id)))
+      .where(
+        and(eq(ingredients.userId, Number(userId)), eq(ingredients.id, id)),
+      )
       .limit(1);
     if (!exists) return false;
     await tx
@@ -220,7 +270,9 @@ export async function deleteIngredient(
       .where(eq(ingredientRevisions.ingredientId, id));
     await tx
       .delete(ingredients)
-      .where(and(eq(ingredients.userId, Number(userId)), eq(ingredients.id, id)));
+      .where(
+        and(eq(ingredients.userId, Number(userId)), eq(ingredients.id, id)),
+      );
     return true;
   });
 }


### PR DESCRIPTION
## Summary
- default newly created ingredients and flavors to public visibility
- add server-side sanitization to ensure public fallback
- document change in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b181265018832ab57fd7e08068e5b8