### PR TITLE
fix: align daily report times with user timezone

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -261,3 +261,4 @@
 - 2025-10-27: Aligned side calendar weeks to display correct weekdays and match snapshot dates.
 - 2025-10-27: Restyled ingredient edit modal to match flavor edit layout.
 - 2025-10-27: Default new ingredients and flavors to public visibility.
+- 2025-10-27: Aligned daily report activity times with user timezone so agents see planned hours accurately.

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -52,6 +52,14 @@ export async function POST(req: NextRequest) {
   const targetDate =
     typeof body.date === 'string' && body.date ? body.date : today;
 
+  const formatTime = (iso: string) =>
+    new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).format(new Date(iso));
+
   const plan = body.plan
     ? {
         blocks: body.plan.blocks ?? [],
@@ -96,8 +104,8 @@ export async function POST(req: NextRequest) {
       id: blk.id,
       title: blk.title,
       description: blk.description,
-      start: blk.start,
-      end: blk.end,
+      start: formatTime(blk.start),
+      end: formatTime(blk.end),
       ingredients: ings.filter(Boolean),
       flavors: flavors.filter(Boolean),
       subflavors: subflavors.filter(Boolean),


### PR DESCRIPTION
## Summary
- format daily report activity times with the user's timezone before sending to the LLM
- update changelog

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b184b3d054832a857f8eae44846699