### PR TITLE
feat: add colour assessment agent for planning

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -263,3 +263,4 @@
 - 2025-10-27: Default new ingredients and flavors to public visibility.
 - 2025-10-27: Aligned daily report activity times with user timezone so agents see planned hours accurately.
 - 2025-10-27: Added planning recommendation agent with daily chat modal and automatic activity insertion.
+- 2025-10-27: Added colour assessment agent to choose presets for AI-generated activities and raised AI modal above planning blocks.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -13,7 +13,12 @@ import type { Subflavor } from '@/types/subflavor';
 import { savePlanAction } from './actions';
 import { cn } from '@/lib/utils';
 import ColorPresetPicker from '@/components/color-preset-picker';
-import { addUserColorPreset, getUserColorPresets } from '@/lib/color-presets';
+import {
+  addUserColorPreset,
+  getUserColorPresets,
+  DEFAULT_COLOR_PRESETS,
+  type ColorPreset,
+} from '@/lib/color-presets';
 import type {
   HeadingReport,
   DailyReport,
@@ -562,6 +567,29 @@ export default function EditorClient({
     }
   }
 
+  type ColorAssignment = {
+    Activity: string;
+    ColorPresetId: string;
+  };
+
+  function parseColorAssignments(str: string): ColorAssignment[] | null {
+    try {
+      const obj = JSON.parse(str);
+      return Array.isArray(obj) ? obj : [obj];
+    } catch {
+      try {
+        const m = str.match(/```json\s*([\s\S]*?)\s*```/i);
+        if (m) {
+          const obj = JSON.parse(m[1]);
+          return Array.isArray(obj) ? obj : [obj];
+        }
+      } catch {
+        return null;
+      }
+      return null;
+    }
+  }
+
   function resetChat() {
     const id =
       typeof crypto !== 'undefined' && 'randomUUID' in crypto
@@ -601,12 +629,44 @@ export default function EditorClient({
       if (data.response) {
         const parsed = parseActivities(data.response as string);
         if (parsed && parsed.length) {
+          const presets = [
+            ...DEFAULT_COLOR_PRESETS,
+            ...getUserColorPresets(userId),
+          ];
+          const presetMap = new Map(presets.map((p) => [p.id, p]));
+          let assignments: ColorAssignment[] | null = null;
+          try {
+            const colorRes = await fetch(
+              '/api/planning/color-assessment',
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  activities: parsed,
+                  presets: presets.map((p) => ({ id: p.id, name: p.name })),
+                }),
+              },
+            );
+            const colorData = await colorRes.json();
+            assignments = parseColorAssignments(
+              colorData.response as string,
+            );
+          } catch {
+            assignments = null;
+          }
+
           const titles = parsed.map((p) => p.Activity).join(', ');
           const ok = confirm(`Should I add these activities (${titles})?`);
           if (ok) {
             const newBlocks = parsed.map((p) => {
               const start = minutesFromTime(p.start);
               const end = minutesFromTime(p.end);
+              const presetId = assignments?.find(
+                (a) => a.Activity === p.Activity,
+              )?.ColorPresetId;
+              const preset = presetId
+                ? (presetMap.get(presetId) as ColorPreset | undefined)
+                : undefined;
               return {
                 id:
                   typeof crypto !== 'undefined' && 'randomUUID' in crypto
@@ -617,8 +677,8 @@ export default function EditorClient({
                 end: isoFromMinutes(end),
                 title: p.Activity,
                 description: p.Description,
-                color: COLORS[0],
-                colorPreset: '',
+                color: preset ? preset.colors[0] : COLORS[0],
+                colorPreset: preset ? preset.id : '',
                 ingredientIds: [],
                 flavorIds: [],
                 subflavorIds: [],
@@ -2563,7 +2623,7 @@ export default function EditorClient({
         </div>
       )}
       {aiOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 backdrop-blur-sm">
           <div className="flex w-[90%] max-w-2xl max-h-[90vh] flex-col rounded bg-white p-6 shadow-lg">
             <div className="mb-4 flex-1 overflow-y-auto space-y-2">
               {chatMessages.map((m, i) => (

--- a/app/api/planning/color-assessment/route.ts
+++ b/app/api/planning/color-assessment/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { DEFAULT_LLM_SETUP, withOverrides } from '@/lib/llm/config';
+
+const SYSTEM_PROMPT =
+  'You are a colour assessment agent in the Cake planning system. For each activity, choose the most suitable colour preset from the provided list and return a JSON array with objects containing Activity and ColorPresetId fields using the given preset IDs.';
+
+export async function POST(req: NextRequest) {
+  const { activities, presets, overrides, chatId } = await req.json();
+  console.log('color assessment request', chatId, activities);
+
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Missing OpenAI API key' },
+      { status: 500 },
+    );
+  }
+
+  const setup = withOverrides(DEFAULT_LLM_SETUP, overrides);
+
+  const messages = [
+    { role: 'system', content: SYSTEM_PROMPT },
+    {
+      role: 'user',
+      content: JSON.stringify({ activities, presets }),
+    },
+  ];
+
+  const body = {
+    model: setup.model,
+    temperature: setup.temperature,
+    top_p: setup.top_p,
+    max_tokens: setup.maxTokens,
+    messages,
+  } as any;
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const rawResponse = await aiRes.text();
+
+    if (!aiRes.ok) {
+      return NextResponse.json(
+        { error: rawResponse },
+        { status: aiRes.status },
+      );
+    }
+
+    const data = JSON.parse(rawResponse);
+    const choice = data.choices?.[0];
+    const msg = choice?.message;
+    const response = msg?.content ?? '';
+    console.log('color assessment response', response);
+    return NextResponse.json({ response });
+  } catch (e: any) {
+    console.error('color assessment error', e);
+    return NextResponse.json(
+      { error: e.message || 'LLM request failed' },
+      { status: 500 },
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add colour assessment API route that chooses color presets for activities
- integrate color assessor in planning AI workflow and elevate AI modal to top layer

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b3f54310832aad77f5c9545ecc57