### PR TITLE
Add colour assessment agent for planning suggestions

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -263,3 +263,4 @@
 - 2025-10-27: Default new ingredients and flavors to public visibility.
 - 2025-10-27: Aligned daily report activity times with user timezone so agents see planned hours accurately.
 - 2025-10-27: Added planning recommendation agent with daily chat modal and automatic activity insertion.
+- 2025-10-27: Introduced colour assessment agent assigning presets to AI-planned activities and raised chat overlay above planning blocks.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -13,7 +13,11 @@ import type { Subflavor } from '@/types/subflavor';
 import { savePlanAction } from './actions';
 import { cn } from '@/lib/utils';
 import ColorPresetPicker from '@/components/color-preset-picker';
-import { addUserColorPreset, getUserColorPresets } from '@/lib/color-presets';
+import {
+  addUserColorPreset,
+  getUserColorPresets,
+  DEFAULT_COLOR_PRESETS,
+} from '@/lib/color-presets';
 import type {
   HeadingReport,
   DailyReport,
@@ -601,12 +605,45 @@ export default function EditorClient({
       if (data.response) {
         const parsed = parseActivities(data.response as string);
         if (parsed && parsed.length) {
+          const availablePresets = [
+            ...DEFAULT_COLOR_PRESETS.map((p) => ({
+              id: p.id,
+              name: p.name,
+              color: p.colors[0],
+            })),
+            ...getUserColorPresets(currentUserId).map((p) => ({
+              id: p.id,
+              name: p.name,
+              color: p.colors[0],
+            })),
+          ];
+          let assignments: Record<string, string> = {};
+          try {
+            const colorRes = await fetch('/api/planning/color', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ activities: parsed, presets: availablePresets }),
+            });
+            const colorData = await colorRes.json();
+            if (Array.isArray(colorData.assignments)) {
+              assignments = Object.fromEntries(
+                colorData.assignments.map((a: any) => [a.activity, a.presetId]),
+              );
+            }
+          } catch {
+            // ignore color assignment errors
+          }
           const titles = parsed.map((p) => p.Activity).join(', ');
           const ok = confirm(`Should I add these activities (${titles})?`);
           if (ok) {
+            const presetMap = Object.fromEntries(
+              availablePresets.map((p) => [p.id, p.color]),
+            );
             const newBlocks = parsed.map((p) => {
               const start = minutesFromTime(p.start);
               const end = minutesFromTime(p.end);
+              const presetId = assignments[p.Activity] || '';
+              const color = presetMap[presetId] || COLORS[0];
               return {
                 id:
                   typeof crypto !== 'undefined' && 'randomUUID' in crypto
@@ -617,8 +654,8 @@ export default function EditorClient({
                 end: isoFromMinutes(end),
                 title: p.Activity,
                 description: p.Description,
-                color: COLORS[0],
-                colorPreset: '',
+                color,
+                colorPreset: presetId,
                 ingredientIds: [],
                 flavorIds: [],
                 subflavorIds: [],
@@ -2563,7 +2600,7 @@ export default function EditorClient({
         </div>
       )}
       {aiOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm">
+        <div className="fixed inset-0 z-[20000] flex items-center justify-center bg-black/40 backdrop-blur-sm">
           <div className="flex w-[90%] max-w-2xl max-h-[90vh] flex-col rounded bg-white p-6 shadow-lg">
             <div className="mb-4 flex-1 overflow-y-auto space-y-2">
               {chatMessages.map((m, i) => (

--- a/app/api/planning/color/route.ts
+++ b/app/api/planning/color/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { DEFAULT_LLM_SETUP, withOverrides } from '@/lib/llm/config';
+
+function parseAssignments(str: string) {
+  try {
+    const arr = JSON.parse(str);
+    return Array.isArray(arr) ? arr : null;
+  } catch {
+    try {
+      const m = str.match(/```json\s*([\s\S]*?)\s*```/i);
+      if (m) {
+        const arr = JSON.parse(m[1]);
+        return Array.isArray(arr) ? arr : null;
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const { activities, presets, overrides } = await req.json();
+
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'Missing OpenAI API key' },
+      { status: 500 },
+    );
+  }
+
+  const setup = withOverrides(DEFAULT_LLM_SETUP, overrides);
+
+  const presetList = Array.isArray(presets)
+    ? presets.map((p: any) => `${p.id}: ${p.name} (${p.color})`).join('\n')
+    : '';
+  const activityList = Array.isArray(activities)
+    ? activities
+        .map(
+          (a: any) => `${a.Activity ?? a.title}: ${a.Description ?? a.description ?? ''}`,
+        )
+        .join('\n')
+    : '';
+
+  const messages = [
+    {
+      role: 'system',
+      content:
+        'You are a colour assessment agent. Choose the most compatible color preset ID from the provided list for each activity. Respond with a JSON array like [{"activity":"<title>","presetId":"<id>"}]. Only use preset IDs from the list.',
+    },
+    {
+      role: 'user',
+      content: `Color presets:\n${presetList}\n\nActivities:\n${activityList}`,
+    },
+  ];
+
+  try {
+    const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: setup.model,
+        temperature: setup.temperature,
+        top_p: setup.top_p,
+        max_tokens: setup.maxTokens,
+        messages,
+      }),
+    });
+
+    const rawResponse = await aiRes.text();
+    if (!aiRes.ok) {
+      return NextResponse.json(
+        { error: rawResponse },
+        { status: aiRes.status },
+      );
+    }
+
+    const data = JSON.parse(rawResponse);
+    const response = data.choices?.[0]?.message?.content ?? '';
+    const parsed = parseAssignments(response) || [];
+    return NextResponse.json({ assignments: parsed });
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e.message || 'LLM request failed' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add colour assessment API to select suitable presets for AI-planned activities
- integrate colour assessment in planner chat and raise chat modal z-index

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b3f54310832aad77f5c9545ecc57