### PR TITLE
feat: enable planning block multi-select

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -266,3 +266,4 @@
 - 2025-10-27: Added colour assessment agent to choose presets for AI-generated activities and raised AI modal above planning blocks.
 - 2025-10-27: Blurred planning background when AI chat opens so only the chat box is visible.
 - 2025-10-27: Increased AI chat background blur for better focus.
+- 2025-10-27: Enabled multi-select of planning blocks via drag highlight and group move support, with Playwright test.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -276,10 +276,12 @@ export default function EditorClient({
   const [metaPinned, setMetaPinned] = useState(false);
   const openMeta = useCallback((id: string) => {
     setSelectedId(id);
+    setSelectedIds([id]);
     setMetaPinned(true);
   }, []);
   const closeMeta = useCallback(() => {
     setSelectedId(null);
+    setSelectedIds([]);
     setMetaPinned(false);
   }, []);
   const selected = useMemo(
@@ -329,6 +331,11 @@ export default function EditorClient({
     };
   }, [closeMeta]);
   const draggingRef = useRef(false);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const selectionStartRef = useRef<number | null>(null);
+  const [selectionRect, setSelectionRect] = useState<
+    { top: number; bottom: number } | null
+  >(null);
   const [startMinute, setStartMinute] = useState(DEFAULT_START);
   const [endMinute, setEndMinute] = useState(DEFAULT_END);
   const [showCustom, setShowCustom] = useState(false);
@@ -1108,6 +1115,46 @@ export default function EditorClient({
     setShowCustom(false);
   }
 
+  function handleSelectionStart(e: React.PointerEvent<HTMLDivElement>) {
+    if (!editable || review) return;
+    const target = e.target as HTMLElement;
+    if (target.id?.startsWith('p1an-blk-')) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    selectionStartRef.current = e.clientY;
+    setSelectionRect({ top: e.clientY - rect.top, bottom: e.clientY - rect.top });
+    function onMove(ev: PointerEvent) {
+      if (selectionStartRef.current == null) return;
+      const r = e.currentTarget.getBoundingClientRect();
+      const top = Math.min(selectionStartRef.current, ev.clientY) - r.top;
+      const bottom = Math.max(selectionStartRef.current, ev.clientY) - r.top;
+      setSelectionRect({ top, bottom });
+    }
+    function onUp(ev: PointerEvent) {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      if (selectionStartRef.current == null) return;
+      const r = e.currentTarget.getBoundingClientRect();
+      const top = Math.min(selectionStartRef.current, ev.clientY) - r.top;
+      const bottom = Math.max(selectionStartRef.current, ev.clientY) - r.top;
+      const startM = startMinute + Math.max(top, 0) / PIXELS_PER_MINUTE;
+      const endM = startMinute + Math.max(bottom, 0) / PIXELS_PER_MINUTE;
+      const ids = blocksRef.current
+        .filter((blk) => {
+          const s = minutesFromIso(blk.start);
+          const e = minutesFromIso(blk.end);
+          return s < endM && e > startM;
+        })
+        .map((blk) => blk.id);
+      setSelectedIds(ids);
+      setSelectedId(null);
+      setMetaPinned(false);
+      setSelectionRect(null);
+      selectionStartRef.current = null;
+    }
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  }
+
   function onDragStart(
     e: React.PointerEvent,
     b: PlanBlock,
@@ -1120,6 +1167,20 @@ export default function EditorClient({
     const startY = e.clientY;
     const initStart = minutesFromIso(b.start);
     const initEnd = minutesFromIso(b.end);
+    const movingIds =
+      mode === 'move' && selectedIds.includes(b.id) && selectedIds.length > 1
+        ? [...selectedIds]
+        : [b.id];
+    const initPositions = movingIds.map((id) => {
+      const blk = blocksRef.current.find((x) => x.id === id)!;
+      return {
+        id,
+        start: minutesFromIso(blk.start),
+        end: minutesFromIso(blk.end),
+      };
+    });
+    const minStart = Math.min(...initPositions.map((p) => p.start));
+    const maxEnd = Math.max(...initPositions.map((p) => p.end));
     const bounds = document
       .getElementById(`p1an-timecol-${userId}`)
       ?.getBoundingClientRect() ?? { top: 0, bottom: 0 };
@@ -1138,15 +1199,32 @@ export default function EditorClient({
       const rawStart = initStart + delta;
       const rawEnd = initEnd + delta;
       if (mode === 'move') {
-        let newStart = rawStart;
-        newStart = Math.max(
-          0,
-          Math.min(newStart, MAX_MINUTES - (initEnd - initStart)),
-        );
-        updateBlock(b.id, {
-          start: isoFromMinutes(newStart),
-          end: isoFromMinutes(newStart + (initEnd - initStart)),
-        });
+        if (movingIds.length > 1) {
+          const maxUp = -minStart;
+          const maxDown = MAX_MINUTES - maxEnd;
+          const clamped = Math.max(Math.min(delta, maxDown), maxUp);
+          setBlocks((prev) =>
+            prev.map((blk) => {
+              const p = initPositions.find((pp) => pp.id === blk.id);
+              if (!p) return blk;
+              return {
+                ...blk,
+                start: isoFromMinutes(p.start + clamped),
+                end: isoFromMinutes(p.end + clamped),
+              };
+            }),
+          );
+        } else {
+          let newStart = rawStart;
+          newStart = Math.max(
+            0,
+            Math.min(newStart, MAX_MINUTES - (initEnd - initStart)),
+          );
+          updateBlock(b.id, {
+            start: isoFromMinutes(newStart),
+            end: isoFromMinutes(newStart + (initEnd - initStart)),
+          });
+        }
       } else if (mode === 'start') {
         let newStart = rawStart;
         newStart = Math.max(0, Math.min(newStart, initEnd - 15));
@@ -1362,7 +1440,19 @@ export default function EditorClient({
                 );
               })}
             </div>
-            <div className="absolute left-12 right-0 top-0">
+            <div
+              className="absolute left-12 right-0 top-0"
+              onPointerDown={handleSelectionStart}
+            >
+              {selectionRect && (
+                <div
+                  className="pointer-events-none absolute left-0 right-0 bg-orange-200/30"
+                  style={{
+                    top: selectionRect.top,
+                    height: selectionRect.bottom - selectionRect.top,
+                  }}
+                />
+              )}
               {Array.from({ length: endHour - startHour + 1 }).map((_, i) => {
                 const h = startHour + i;
                 return (
@@ -1404,9 +1494,9 @@ export default function EditorClient({
                   <div
                     key={b.id}
                     id={`p1an-blk-${b.id}-${userId}`}
-                    data-selected={selectedId === b.id ? 'true' : 'false'}
+                    data-selected={selectedIds.includes(b.id) ? 'true' : 'false'}
                     aria-label={`${b.title}, ${b.start} to ${b.end}`}
-                    className="absolute left-1 right-1 rounded p-1"
+                    className="absolute left-1 right-1 rounded p-1 data-[selected=true]:ring-2 data-[selected=true]:ring-orange-500"
                     style={{
                       top,
                       height,

--- a/tests/planning.spec.ts
+++ b/tests/planning.spec.ts
@@ -196,3 +196,45 @@ test('future plan persists across day change', async ({ page }) => {
   );
   await expect(page.locator('[id^="p1an-blk-"]')).toHaveCount(1);
 });
+
+test('multi-select moves blocks together', async ({ page }) => {
+  const handle = `user${Date.now()}ms`;
+  const email = `${handle}@example.com`;
+  const password = 'pass1234';
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Tester');
+  await page.fill('input[placeholder="Handle"]', handle);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+  await page.goto('/planning');
+  await page.click('[id^="p1an-btn-next-"]');
+  await page.click('[id^="p1an-add-top-"]');
+  await page.click('button[id^="p1an-meta-close-"]');
+  await page.click('[id^="p1an-add-top-"]');
+  await page.click('button[id^="p1an-meta-close-"]');
+  const block1 = page.locator('[id^="p1an-blk-"]').nth(0);
+  const block2 = page.locator('[id^="p1an-blk-"]').nth(1);
+  const box1 = await block1.boundingBox();
+  const box2 = await block2.boundingBox();
+  const startX = box1!.x + box1!.width / 2;
+  const startY = box1!.y - 5;
+  const endY = box2!.y + box2!.height + 5;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX, endY);
+  await page.mouse.up();
+  const t1 = await block1.evaluate((el) => parseInt(getComputedStyle(el).top));
+  const t2 = await block2.evaluate((el) => parseInt(getComputedStyle(el).top));
+  await page.mouse.move(box1!.x + box1!.width / 2, box1!.y + box1!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(
+    box1!.x + box1!.width / 2,
+    box1!.y + box1!.height / 2 + yFor(1),
+  );
+  await page.mouse.up();
+  const nt1 = await block1.evaluate((el) => parseInt(getComputedStyle(el).top));
+  const nt2 = await block2.evaluate((el) => parseInt(getComputedStyle(el).top));
+  expect(nt1).toBe(t1 + yFor(1));
+  expect(nt2).toBe(t2 + yFor(1));
+});


### PR DESCRIPTION
## Summary
- allow selecting multiple planning blocks via drag highlight
- move grouped blocks together and show selection ring
- test multi-select block move

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test tests/planning.spec.ts` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bd6f6168832a8b42cc85b1e4467c