### PR TITLE
feat: enforce read-only planning ai chat

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -267,3 +267,4 @@
 - 2025-10-27: Blurred planning background when AI chat opens so only the chat box is visible.
 - 2025-10-27: Increased AI chat background blur for better focus.
 - 2025-10-27: Added motivational Live AI assistant on live planning page with contextual chat modal.
+- 2025-10-27: Made planning AI chat view-only for viewers and historical snapshots, filtering messages by snapshot date and adding read-only tests.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -205,13 +205,18 @@ export default function EditorClient({
   const CHAT_STORAGE_KEY = `${
     live ? 'plan-live-ai-chat' : 'plan-ai-chat'
   }-${userId}-${date}`;
-  type ChatMessage = { role: 'user' | 'assistant'; content: string };
+  type ChatMessage = {
+    role: 'user' | 'assistant';
+    content: string;
+    createdAt: string;
+  };
   const initialChat: ChatMessage[] = [
     {
       role: 'assistant',
       content: live
         ? 'How can I help you make the most of your day?'
         : 'How can I help you with your planning?',
+      createdAt: new Date().toISOString(),
     },
   ];
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>(initialChat);
@@ -228,23 +233,35 @@ export default function EditorClient({
       try {
         const parsed = JSON.parse(saved);
         if (parsed.chatId) chatIdRef.current = parsed.chatId;
-        if (parsed.messages) setChatMessages(parsed.messages);
+        if (Array.isArray(parsed.messages)) {
+          let msgs: ChatMessage[] = parsed.messages.map((m: any) => ({
+            role: m.role,
+            content: m.content,
+            createdAt: m.createdAt ?? new Date().toISOString(),
+          }));
+          if (snapshotDate) {
+            const snap = new Date(snapshotDate);
+            snap.setDate(snap.getDate() + 1);
+            msgs = msgs.filter((m) => new Date(m.createdAt) < snap);
+          }
+          setChatMessages(msgs);
+        }
       } catch {
         /* ignore */
       }
     }
-  }, [CHAT_STORAGE_KEY]);
+  }, [CHAT_STORAGE_KEY, snapshotDate]);
   const chatEndRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [chatMessages, aiOpen]);
   useEffect(() => {
-    if (typeof window === 'undefined') return;
+    if (typeof window === 'undefined' || !editable || snapshotDate) return;
     localStorage.setItem(
       CHAT_STORAGE_KEY,
       JSON.stringify({ chatId: chatIdRef.current, messages: chatMessages }),
     );
-  }, [chatMessages, CHAT_STORAGE_KEY]);
+  }, [chatMessages, CHAT_STORAGE_KEY, editable, snapshotDate]);
   useEffect(() => {
     if (typeof document === 'undefined') return;
     if (aiOpen) document.body.classList.add('overflow-hidden');
@@ -671,6 +688,7 @@ export default function EditorClient({
   }
 
   function resetChat() {
+    if (!editable) return;
     const id =
       typeof crypto !== 'undefined' && 'randomUUID' in crypto
         ? crypto.randomUUID()
@@ -686,7 +704,7 @@ export default function EditorClient({
   const SYSTEM_PROMPT = live ? LIVE_SYSTEM_PROMPT : PLANNING_SYSTEM_PROMPT;
 
   async function sendChat() {
-    if (!chatInput.trim()) return;
+    if (!editable || !chatInput.trim()) return;
     const isFirst =
       chatMessages.length === 1 && chatMessages[0].role === 'assistant';
     const userContent = isFirst
@@ -696,13 +714,17 @@ export default function EditorClient({
       : chatInput;
     const newMessages: ChatMessage[] = [
       ...chatMessages,
-      { role: 'user', content: userContent },
+      {
+        role: 'user',
+        content: userContent,
+        createdAt: new Date().toISOString(),
+      },
     ];
     setChatMessages(newMessages);
     setChatInput('');
     const payload = [
       { role: 'system', content: SYSTEM_PROMPT },
-      ...newMessages,
+      ...newMessages.map(({ role, content }) => ({ role, content })),
     ];
     try {
       const res = await fetch('/api/planning/recommend', {
@@ -715,7 +737,11 @@ export default function EditorClient({
         if (live) {
           setChatMessages([
             ...newMessages,
-            { role: 'assistant', content: data.response as string },
+            {
+              role: 'assistant',
+              content: data.response as string,
+              createdAt: new Date().toISOString(),
+            },
           ]);
         } else {
           const parsed = parseActivities(data.response as string);
@@ -783,18 +809,27 @@ export default function EditorClient({
                 {
                   role: 'assistant',
                   content: `Added activities: ${titles}.`,
+                  createdAt: new Date().toISOString(),
                 },
               ]);
             } else {
               setChatMessages([
                 ...newMessages,
-                { role: 'assistant', content: 'Okay, not adding them.' },
+                {
+                  role: 'assistant',
+                  content: 'Okay, not adding them.',
+                  createdAt: new Date().toISOString(),
+                },
               ]);
             }
           } else {
             setChatMessages([
               ...newMessages,
-              { role: 'assistant', content: data.response as string },
+              {
+                role: 'assistant',
+                content: data.response as string,
+                createdAt: new Date().toISOString(),
+              },
             ]);
           }
         }
@@ -802,7 +837,11 @@ export default function EditorClient({
     } catch {
       setChatMessages([
         ...newMessages,
-        { role: 'assistant', content: 'Sorry, something went wrong.' },
+        {
+          role: 'assistant',
+          content: 'Sorry, something went wrong.',
+          createdAt: new Date().toISOString(),
+        },
       ]);
     }
   }
@@ -2736,32 +2775,36 @@ export default function EditorClient({
               ))}
               <div ref={chatEndRef} />
             </div>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={chatInput}
-                onChange={(e) => setChatInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') sendChat();
-                }}
-                placeholder="Type your answer..."
-                className="flex-1 rounded border px-2 py-1"
-              />
-              <button
-                onClick={sendChat}
-                className="rounded bg-orange-500 px-3 py-1 text-white"
-              >
-                Send
-              </button>
-            </div>
+            {editable && (
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={chatInput}
+                  onChange={(e) => setChatInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') sendChat();
+                  }}
+                  placeholder="Type your answer..."
+                  className="flex-1 rounded border px-2 py-1"
+                />
+                <button
+                  onClick={sendChat}
+                  className="rounded bg-orange-500 px-3 py-1 text-white"
+                >
+                  Send
+                </button>
+              </div>
+            )}
             <div className="mt-4 flex justify-between">
-              <button
-                type="button"
-                className="rounded border px-3 py-1"
-                onClick={resetChat}
-              >
-                Reset
-              </button>
+              {editable && (
+                <button
+                  type="button"
+                  className="rounded border px-3 py-1"
+                  onClick={resetChat}
+                >
+                  Reset
+                </button>
+              )}
               <button
                 type="button"
                 className="rounded border px-3 py-1"

--- a/tests/view-live-ai.spec.ts
+++ b/tests/view-live-ai.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+import { getUserByHandle } from '@/lib/users';
+import { createProfileSnapshot } from '@/lib/profile-snapshots';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+test('viewer sees live ai chat read-only', async ({ page }) => {
+  const handleA = unique('owner');
+  const emailA = `${handleA}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', handleA);
+  await page.fill('input[placeholder="Email"]', emailA);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+  await page.goto(`/u/${handleA}`);
+  const viewHref = await page.getAttribute('[id^="pr0ovr-view-"]', 'href');
+  await page.click('text=Sign out');
+
+  const handleB = unique('viewer');
+  const emailB = `${handleB}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Viewer');
+  await page.fill('input[placeholder="Handle"]', handleB);
+  await page.fill('input[placeholder="Email"]', emailB);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  await page.goto(`${viewHref}/planning/live`);
+  await page.getByRole('button', { name: /(Live AI|AI planning)/ }).click();
+  await expect(page.locator('input[placeholder="Type your answer..."]')).toHaveCount(0);
+});
+
+test('historical snapshot shows only past chat messages', async ({ page }) => {
+  const handle = unique('snap');
+  const email = `${handle}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Snapper');
+  await page.fill('input[placeholder="Handle"]', handle);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  await page.goto('/planning/live');
+  const ctxId = await page.getAttribute('[id^="v13wctx-"]', 'id');
+  const ownerId = ctxId?.split('-')[1];
+  const today = new Date().toISOString().slice(0, 10);
+  const tomorrow = new Date(Date.now() + 86400000).toISOString().slice(0, 10);
+  await page.evaluate(({ key, today, tomorrow }) => {
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        chatId: 'abc',
+        messages: [
+          { role: 'assistant', content: 'hello', createdAt: `${today}T00:00:00.000Z` },
+          { role: 'user', content: 'old', createdAt: `${today}T01:00:00.000Z` },
+          { role: 'user', content: 'new', createdAt: `${tomorrow}T00:00:00.000Z` },
+        ],
+      }),
+    );
+  }, { key: `plan-live-ai-chat-${ownerId}-${today}`, today, tomorrow });
+
+  const user = await getUserByHandle(handle);
+  await createProfileSnapshot(user.id, today);
+
+  await page.goto(`/history/self/${today}/planning/live`);
+  await page.getByRole('button', { name: /(Live AI|AI planning)/ }).click();
+  await expect(page.locator('text=old')).toBeVisible();
+  await expect(page.locator('text=new')).toHaveCount(0);
+  await expect(page.locator('input[placeholder="Type your answer..."]')).toHaveCount(0);
+});
+


### PR DESCRIPTION
## Summary
- timestamp AI chat messages and filter by snapshot date so past views show only historical conversation
- hide chat input and reset for viewers and snapshot pages to keep AI chats read-only
- add tests covering viewer read-only behavior and snapshot chat isolation

## Testing
- `pnpm lint`
- `pnpm type-check` *(fails: Command "type-check" not found)*
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c7f3ee68832aa2796748b1d9f0ea