### PR TITLE
feat: enforce read-only planning ai chat

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -267,3 +267,5 @@
 - 2025-10-27: Blurred planning background when AI chat opens so only the chat box is visible.
 - 2025-10-27: Increased AI chat background blur for better focus.
 - 2025-10-27: Added motivational Live AI assistant on live planning page with contextual chat modal.
+- 2025-10-27: Made planning AI chat view-only for viewers and historical snapshots, filtering messages by snapshot date and adding read-only tests.
+- 2025-10-27: Stored planning AI chat in database so conversations persist across visits and show in viewer and snapshot modes.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -10,6 +10,7 @@ import type { Plan, PlanBlock, PlanBlockInput } from '@/types/plan';
 import type { Ingredient } from '@/types/ingredient';
 import type { Flavor } from '@/types/flavor';
 import type { Subflavor } from '@/types/subflavor';
+import type { ChatMessage, ChatThread } from '@/types/chat';
 import { savePlanAction } from './actions';
 import { cn } from '@/lib/utils';
 import ColorPresetPicker from '@/components/color-preset-picker';
@@ -202,49 +203,52 @@ export default function EditorClient({
   }, [initialShowDailyAim, storageKey]);
 
   const [aiOpen, setAiOpen] = useState(false);
-  const CHAT_STORAGE_KEY = `${
-    live ? 'plan-live-ai-chat' : 'plan-ai-chat'
-  }-${userId}-${date}`;
-  type ChatMessage = { role: 'user' | 'assistant'; content: string };
-  const initialChat: ChatMessage[] = [
-    {
-      role: 'assistant',
-      content: live
-        ? 'How can I help you make the most of your day?'
-        : 'How can I help you with your planning?',
-    },
-  ];
-  const [chatMessages, setChatMessages] = useState<ChatMessage[]>(initialChat);
+  const welcome: ChatMessage = {
+    role: 'assistant',
+    content: live
+      ? 'How can I help you make the most of your day?'
+      : 'How can I help you with your planning?',
+    createdAt: new Date().toISOString(),
+  };
+  const savedThread: ChatThread = useMemo(() => {
+    const thread = live ? initialPlan?.liveChat : initialPlan?.planningChat;
+    return {
+      chatId: thread?.chatId || '',
+      messages: Array.isArray(thread?.messages) ? thread!.messages : [],
+    };
+  }, [initialPlan, live]);
+  let initialMsgs = savedThread.messages.length ? savedThread.messages : [welcome];
+  if (snapshotDate) {
+    const snap = new Date(snapshotDate);
+    snap.setDate(snap.getDate() + 1);
+    initialMsgs = initialMsgs.filter((m) => new Date(m.createdAt) < snap);
+    if (initialMsgs.length === 0) initialMsgs = [welcome];
+  }
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>(initialMsgs);
   const [chatInput, setChatInput] = useState('');
   const chatIdRef = useRef<string>(
-    typeof crypto !== 'undefined' && 'randomUUID' in crypto
-      ? crypto.randomUUID()
-      : Math.random().toString(36).slice(2),
+    savedThread.chatId ||
+      (typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : Math.random().toString(36).slice(2)),
   );
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const saved = localStorage.getItem(CHAT_STORAGE_KEY);
-    if (saved) {
-      try {
-        const parsed = JSON.parse(saved);
-        if (parsed.chatId) chatIdRef.current = parsed.chatId;
-        if (parsed.messages) setChatMessages(parsed.messages);
-      } catch {
-        /* ignore */
-      }
-    }
-  }, [CHAT_STORAGE_KEY]);
   const chatEndRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [chatMessages, aiOpen]);
   useEffect(() => {
-    if (typeof window === 'undefined') return;
-    localStorage.setItem(
-      CHAT_STORAGE_KEY,
-      JSON.stringify({ chatId: chatIdRef.current, messages: chatMessages }),
-    );
-  }, [chatMessages, CHAT_STORAGE_KEY]);
+    if (!editable || snapshotDate) return;
+    fetch('/api/planning/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        date,
+        mode,
+        chatId: chatIdRef.current,
+        messages: chatMessages,
+      }),
+    }).catch(() => {});
+  }, [chatMessages, editable, snapshotDate, date, mode]);
   useEffect(() => {
     if (typeof document === 'undefined') return;
     if (aiOpen) document.body.classList.add('overflow-hidden');
@@ -671,12 +675,13 @@ export default function EditorClient({
   }
 
   function resetChat() {
+    if (!editable) return;
     const id =
       typeof crypto !== 'undefined' && 'randomUUID' in crypto
         ? crypto.randomUUID()
         : Math.random().toString(36).slice(2);
     chatIdRef.current = id;
-    setChatMessages(initialChat);
+    setChatMessages([welcome]);
   }
 
   const PLANNING_SYSTEM_PROMPT =
@@ -686,7 +691,7 @@ export default function EditorClient({
   const SYSTEM_PROMPT = live ? LIVE_SYSTEM_PROMPT : PLANNING_SYSTEM_PROMPT;
 
   async function sendChat() {
-    if (!chatInput.trim()) return;
+    if (!editable || !chatInput.trim()) return;
     const isFirst =
       chatMessages.length === 1 && chatMessages[0].role === 'assistant';
     const userContent = isFirst
@@ -696,13 +701,17 @@ export default function EditorClient({
       : chatInput;
     const newMessages: ChatMessage[] = [
       ...chatMessages,
-      { role: 'user', content: userContent },
+      {
+        role: 'user',
+        content: userContent,
+        createdAt: new Date().toISOString(),
+      },
     ];
     setChatMessages(newMessages);
     setChatInput('');
     const payload = [
       { role: 'system', content: SYSTEM_PROMPT },
-      ...newMessages,
+      ...newMessages.map(({ role, content }) => ({ role, content })),
     ];
     try {
       const res = await fetch('/api/planning/recommend', {
@@ -715,7 +724,11 @@ export default function EditorClient({
         if (live) {
           setChatMessages([
             ...newMessages,
-            { role: 'assistant', content: data.response as string },
+            {
+              role: 'assistant',
+              content: data.response as string,
+              createdAt: new Date().toISOString(),
+            },
           ]);
         } else {
           const parsed = parseActivities(data.response as string);
@@ -783,18 +796,27 @@ export default function EditorClient({
                 {
                   role: 'assistant',
                   content: `Added activities: ${titles}.`,
+                  createdAt: new Date().toISOString(),
                 },
               ]);
             } else {
               setChatMessages([
                 ...newMessages,
-                { role: 'assistant', content: 'Okay, not adding them.' },
+                {
+                  role: 'assistant',
+                  content: 'Okay, not adding them.',
+                  createdAt: new Date().toISOString(),
+                },
               ]);
             }
           } else {
             setChatMessages([
               ...newMessages,
-              { role: 'assistant', content: data.response as string },
+              {
+                role: 'assistant',
+                content: data.response as string,
+                createdAt: new Date().toISOString(),
+              },
             ]);
           }
         }
@@ -802,7 +824,11 @@ export default function EditorClient({
     } catch {
       setChatMessages([
         ...newMessages,
-        { role: 'assistant', content: 'Sorry, something went wrong.' },
+        {
+          role: 'assistant',
+          content: 'Sorry, something went wrong.',
+          createdAt: new Date().toISOString(),
+        },
       ]);
     }
   }
@@ -2736,32 +2762,36 @@ export default function EditorClient({
               ))}
               <div ref={chatEndRef} />
             </div>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={chatInput}
-                onChange={(e) => setChatInput(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') sendChat();
-                }}
-                placeholder="Type your answer..."
-                className="flex-1 rounded border px-2 py-1"
-              />
-              <button
-                onClick={sendChat}
-                className="rounded bg-orange-500 px-3 py-1 text-white"
-              >
-                Send
-              </button>
-            </div>
+            {editable && (
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={chatInput}
+                  onChange={(e) => setChatInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') sendChat();
+                  }}
+                  placeholder="Type your answer..."
+                  className="flex-1 rounded border px-2 py-1"
+                />
+                <button
+                  onClick={sendChat}
+                  className="rounded bg-orange-500 px-3 py-1 text-white"
+                >
+                  Send
+                </button>
+              </div>
+            )}
             <div className="mt-4 flex justify-between">
-              <button
-                type="button"
-                className="rounded border px-3 py-1"
-                onClick={resetChat}
-              >
-                Reset
-              </button>
+              {editable && (
+                <button
+                  type="button"
+                  className="rounded border px-3 py-1"
+                  onClick={resetChat}
+                >
+                  Reset
+                </button>
+              )}
               <button
                 type="button"
                 className="rounded border px-3 py-1"

--- a/app/api/planning/chat/route.ts
+++ b/app/api/planning/chat/route.ts
@@ -1,0 +1,16 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { assertOwner } from '@/lib/profile';
+import { savePlanChat } from '@/lib/plans-store';
+
+export async function POST(req: Request) {
+  const session = await auth();
+  const self = await ensureUser(session);
+  await assertOwner(self.id, self.id);
+  const { date, mode, chatId, messages } = await req.json();
+  if (!date || (mode !== 'live' && mode !== 'next')) {
+    return new Response('invalid request', { status: 400 });
+  }
+  await savePlanChat(String(self.id), date, mode, { chatId, messages });
+  return Response.json({ ok: true });
+}

--- a/drizzle/0028_add_plan_ai_chats.sql
+++ b/drizzle/0028_add_plan_ai_chats.sql
@@ -1,0 +1,2 @@
+ALTER TABLE plans ADD COLUMN IF NOT EXISTS planning_chat jsonb DEFAULT '{}'::jsonb;
+ALTER TABLE plans ADD COLUMN IF NOT EXISTS live_chat jsonb DEFAULT '{}'::jsonb;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -180,6 +180,8 @@ export const plans = pgTable(
     date: date('date').notNull(),
     dailyAim: text('daily_aim'),
     dailyIngredientIds: integer('daily_ingredient_ids').array(),
+    planningChat: jsonb('planning_chat'),
+    liveChat: jsonb('live_chat'),
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').defaultNow(),
   },

--- a/lib/plans-store.ts
+++ b/lib/plans-store.ts
@@ -3,6 +3,7 @@ import { plans, planBlocks, planRevisions } from './db/schema';
 import { eq, and, inArray, lte, desc } from 'drizzle-orm';
 import type { Plan, PlanBlock, PlanBlockInput } from '@/types/plan';
 import type { ColorPreset } from '@/lib/color-presets';
+import type { ChatThread } from '@/types/chat';
 import { randomUUID } from 'crypto';
 
 function toPlanBlock(row: typeof planBlocks.$inferSelect): PlanBlock {
@@ -33,6 +34,8 @@ async function fetchPlan(userId: number, date: string): Promise<Plan | null> {
     .select()
     .from(planBlocks)
     .where(eq(planBlocks.planId, planRow.id));
+  const pChat: any = planRow.planningChat ?? {};
+  const lChat: any = planRow.liveChat ?? {};
   return {
     id: planRow.id.toString(),
     userId: String(userId),
@@ -41,6 +44,14 @@ async function fetchPlan(userId: number, date: string): Promise<Plan | null> {
     dailyAim: planRow.dailyAim ?? '',
     dailyIngredientIds: planRow.dailyIngredientIds ?? [],
     colorPresets: [],
+    planningChat: {
+      chatId: pChat.chatId ?? '',
+      messages: Array.isArray(pChat.messages) ? pChat.messages : [],
+    },
+    liveChat: {
+      chatId: lChat.chatId ?? '',
+      messages: Array.isArray(lChat.messages) ? lChat.messages : [],
+    },
   };
 }
 
@@ -61,7 +72,9 @@ export async function getOrCreatePlan(
       blocks: [],
       dailyAim: '',
       dailyIngredientIds: [],
-      colorPresets: [],
+       colorPresets: [],
+       planningChat: { chatId: '', messages: [] },
+       liveChat: { chatId: '', messages: [] },
     };
   }
   return plan;
@@ -81,6 +94,8 @@ export async function getPlanStrict(
     dailyAim: '',
     dailyIngredientIds: [],
     colorPresets: [],
+    planningChat: { chatId: '', messages: [] },
+    liveChat: { chatId: '', messages: [] },
   };
 }
 
@@ -123,6 +138,8 @@ export async function getPlanAt(
           name: p.name,
           colors: p.colors,
         })),
+      planningChat: payload.planningChat ?? { chatId: '', messages: [] },
+      liveChat: payload.liveChat ?? { chatId: '', messages: [] },
     };
   }
   // When no revision exists at or before the requested time, the user had not
@@ -137,6 +154,8 @@ export async function getPlanAt(
     dailyAim: '',
     dailyIngredientIds: [],
     colorPresets: [],
+    planningChat: { chatId: '', messages: [] },
+    liveChat: { chatId: '', messages: [] },
   };
 }
 
@@ -147,11 +166,15 @@ export async function savePlan(
   dailyAim = '',
   dailyIngredientIds: number[] = [],
   colorPresets: ColorPreset[] = [],
+  planningChat?: ChatThread,
+  liveChat?: ChatThread,
 ): Promise<Plan> {
   let planRow = await fetchPlan(Number(userId), date);
   if (!planRow) {
     planRow = await getOrCreatePlan(Number(userId), date);
   }
+  planningChat = planningChat ?? planRow.planningChat;
+  liveChat = liveChat ?? planRow.liveChat;
   const existing = await db
     .select({ id: planBlocks.id })
     .from(planBlocks)
@@ -214,13 +237,22 @@ export async function savePlan(
     .set({
       dailyAim,
       dailyIngredientIds,
+      planningChat,
+      liveChat,
       updatedAt: now,
     })
     .where(eq(plans.id, Number(planRow.id)));
   await db.insert(planRevisions).values({
     userId: Number(userId),
     planDate: date,
-    payload: { blocks: results, dailyAim, dailyIngredientIds, colorPresets },
+    payload: {
+      blocks: results,
+      dailyAim,
+      dailyIngredientIds,
+      colorPresets,
+      planningChat,
+      liveChat,
+    },
   });
   return {
     id: String(planRow.id),
@@ -230,5 +262,38 @@ export async function savePlan(
     dailyAim,
     dailyIngredientIds,
     colorPresets,
+    planningChat,
+    liveChat,
   };
+}
+
+export async function savePlanChat(
+  userId: string,
+  date: string,
+  mode: 'live' | 'next',
+  chat: ChatThread,
+): Promise<Plan> {
+  const plan = await getPlanStrict(Number(userId), date);
+  const blockInputs: PlanBlockInput[] = plan.blocks.map((b) => ({
+    id: b.id,
+    start: b.start,
+    end: b.end,
+    title: b.title,
+    description: b.description,
+    color: b.color,
+    colorPreset: b.colorPreset,
+    ingredientIds: b.ingredientIds,
+    flavorIds: b.flavorIds,
+    subflavorIds: b.subflavorIds,
+  }));
+  return savePlan(
+    userId,
+    date,
+    blockInputs,
+    plan.dailyAim,
+    plan.dailyIngredientIds,
+    plan.colorPresets ?? [],
+    mode === 'next' ? chat : plan.planningChat,
+    mode === 'live' ? chat : plan.liveChat,
+  );
 }

--- a/tests/view-live-ai.spec.ts
+++ b/tests/view-live-ai.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test';
+import { getUserByHandle } from '@/lib/users';
+import { createProfileSnapshot } from '@/lib/profile-snapshots';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+test('viewer sees live ai chat read-only', async ({ page }) => {
+  const handleA = unique('owner');
+  const emailA = `${handleA}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', handleA);
+  await page.fill('input[placeholder="Email"]', emailA);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+  await page.goto('/planning/live');
+  const today = new Date().toISOString().slice(0, 10);
+  await page.evaluate(async (today) => {
+    await fetch('/api/planning/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        date: today,
+        mode: 'live',
+        chatId: 'abc',
+        messages: [
+          {
+            role: 'assistant',
+            content: 'hello',
+            createdAt: `${today}T00:00:00.000Z`,
+          },
+          {
+            role: 'user',
+            content: 'hi',
+            createdAt: `${today}T01:00:00.000Z`,
+          },
+        ],
+      }),
+    });
+  }, today);
+  await page.goto(`/u/${handleA}`);
+  const viewHref = await page.getAttribute('[id^="pr0ovr-view-"]', 'href');
+  await page.click('text=Sign out');
+
+  const handleB = unique('viewer');
+  const emailB = `${handleB}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Viewer');
+  await page.fill('input[placeholder="Handle"]', handleB);
+  await page.fill('input[placeholder="Email"]', emailB);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  await page.goto(`${viewHref}/planning/live`);
+  await page.getByRole('button', { name: /(Live AI|AI planning)/ }).click();
+  await expect(page.locator('text=hi')).toBeVisible();
+  await expect(page.locator('input[placeholder="Type your answer..."]')).toHaveCount(0);
+});
+
+test('historical snapshot shows only past chat messages', async ({ page }) => {
+  const handle = unique('snap');
+  const email = `${handle}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Snapper');
+  await page.fill('input[placeholder="Handle"]', handle);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  await page.goto('/planning/live');
+  const today = new Date().toISOString().slice(0, 10);
+  const tomorrow = new Date(Date.now() + 86400000).toISOString().slice(0, 10);
+  await page.evaluate(async ({ today }) => {
+    await fetch('/api/planning/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        date: today,
+        mode: 'live',
+        chatId: 'abc',
+        messages: [
+          {
+            role: 'assistant',
+            content: 'hello',
+            createdAt: `${today}T00:00:00.000Z`,
+          },
+          {
+            role: 'user',
+            content: 'old',
+            createdAt: `${today}T01:00:00.000Z`,
+          },
+        ],
+      }),
+    });
+  }, { today });
+  const user = await getUserByHandle(handle);
+  await createProfileSnapshot(user.id, today);
+  await page.evaluate(async ({ today, tomorrow }) => {
+    await fetch('/api/planning/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        date: today,
+        mode: 'live',
+        chatId: 'abc',
+        messages: [
+          {
+            role: 'assistant',
+            content: 'hello',
+            createdAt: `${today}T00:00:00.000Z`,
+          },
+          {
+            role: 'user',
+            content: 'old',
+            createdAt: `${today}T01:00:00.000Z`,
+          },
+          {
+            role: 'user',
+            content: 'new',
+            createdAt: `${tomorrow}T00:00:00.000Z`,
+          },
+        ],
+      }),
+    });
+  }, { today, tomorrow });
+
+  await page.goto(`/history/self/${today}/planning/live`);
+  await page.getByRole('button', { name: /(Live AI|AI planning)/ }).click();
+  await expect(page.locator('text=old')).toBeVisible();
+  await expect(page.locator('text=new')).toHaveCount(0);
+  await expect(page.locator('input[placeholder="Type your answer..."]')).toHaveCount(0);
+});
+

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -1,0 +1,11 @@
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  createdAt: string;
+}
+
+export interface ChatThread {
+  chatId: string;
+  messages: ChatMessage[];
+}
+

--- a/types/plan.ts
+++ b/types/plan.ts
@@ -1,4 +1,5 @@
 import type { ColorPreset } from '@/lib/color-presets';
+import type { ChatThread } from './chat';
 
 export interface Plan {
   id: string;
@@ -8,6 +9,8 @@ export interface Plan {
   dailyAim: string;
   dailyIngredientIds: number[];
   colorPresets?: ColorPreset[];
+  planningChat?: ChatThread;
+  liveChat?: ChatThread;
 }
 
 export interface PlanBlock {


### PR DESCRIPTION
## Summary
- persist planning and live AI chat in database so conversations are visible to viewers and historical snapshots
- load stored chat threads in planner client and sync updates through a new API route
- cover viewer read-only visibility and snapshot message filtering in tests

## Testing
- `pnpm lint`
- `pnpm type-check` *(fails: Command "type-check" not found)*
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c7f3ee68832aa2796748b1d9f0ea