### PR TITLE
fix: disable webpack cache to prevent dev error

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -269,3 +269,4 @@
 - 2025-10-27: Added motivational Live AI assistant on live planning page with contextual chat modal.
 - 2025-10-27: Made planning AI chat view-only for viewers and historical snapshots, filtering messages by snapshot date and adding read-only tests.
 - 2025-10-27: Stored planning AI chat in database so conversations persist across visits and show in viewer and snapshot modes.
+- 2025-10-27: Disabled Webpack filesystem cache to prevent PackFileCacheStrategy errors during development.

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,14 @@ const config: NextConfig = {
   experimental: {
     reactCompiler: false,
   },
+  webpack: (config) => {
+    // Disable Webpack's filesystem cache to avoid PackFileCacheStrategy
+    // errors like `Cannot read properties of undefined (reading 'lastAccess')`
+    // during development. This trades a small amount of rebuild speed for
+    // stability until the upstream issue is resolved.
+    config.cache = false;
+    return config;
+  },
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- disable webpack filesystem cache to avoid PackFileCacheStrategy lastAccess errors when running Next.js dev server
- document the change in the update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cf64f3ec832a80a74be598db898e