### PR TITLE
fix: conditionally show sign in/out in nav

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -270,3 +270,4 @@
 - 2025-10-27: Made planning AI chat view-only for viewers and historical snapshots, filtering messages by snapshot date and adding read-only tests.
 - 2025-10-27: Stored planning AI chat in database so conversations persist across visits and show in viewer and snapshot modes.
 - 2025-10-27: Disabled Webpack filesystem cache to prevent PackFileCacheStrategy errors during development.
+- 2025-10-27: Replaced always-on sign-out with conditional sign-in/out in AppNav.

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor, type Section } from '@/lib/navigation';
 import { Button } from '@/components/ui/button';
@@ -20,6 +21,8 @@ const labels: Record<Section, string> = {
 export function AppNav() {
   const ctx = useViewContext();
   const pathname = usePathname();
+  const router = useRouter();
+  const { data: session, status } = useSession();
   const sections: Section[] =
     ctx.mode === 'viewer'
       ? [
@@ -69,9 +72,15 @@ export function AppNav() {
       </ul>
       <div className="flex items-center gap-4">
         <Clock />
-        <form action="/api/auth/signout" method="post">
-          <Button type="submit">Sign out</Button>
-        </form>
+        {status === 'loading' ? null : session ? (
+          <form action="/api/auth/signout" method="post">
+            <Button type="submit">Sign out</Button>
+          </form>
+        ) : (
+          <Button type="button" onClick={() => router.push('/signin')}>
+            Sign in
+          </Button>
+        )}
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- show sign-out only when session exists and link to sign-in otherwise
- log update

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d23d124c832a8102321631e87b20