### PR TITLE
feat: add configurable favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@
    ```sh
    pnpm test
    ```
+
+### Custom Favicon
+
+Add your favicon image named `Favicon_pieceofcake.png` to the
+`public/` directory. The repository doesn’t track a default image,
+so supplying your own ensures the `<link rel="icon" href="/Favicon_pieceofcake.png" />`
+in the root layout resolves both locally and after deployment.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -271,3 +271,4 @@
 - 2025-10-27: Stored planning AI chat in database so conversations persist across visits and show in viewer and snapshot modes.
 - 2025-10-27: Disabled Webpack filesystem cache to prevent PackFileCacheStrategy errors during development.
 - 2025-10-27: Replaced always-on sign-out with conditional sign-in/out in AppNav.
+- 2025-10-27: Added customizable favicon path and documented placement (image not included in repo).

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -270,3 +270,4 @@
 - 2025-10-27: Made planning AI chat view-only for viewers and historical snapshots, filtering messages by snapshot date and adding read-only tests.
 - 2025-10-27: Stored planning AI chat in database so conversations persist across visits and show in viewer and snapshot modes.
 - 2025-10-27: Disabled Webpack filesystem cache to prevent PackFileCacheStrategy errors during development.
+- 2025-10-27: Replaced always-on sign-out with conditional sign-in/out in AppNav.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -71,6 +71,7 @@ export default async function RootLayout({
 })();`,
           }}
         />
+        <link rel="icon" href="/Favicon_pieceofcake.png" />
       </head>
       <body>
         <LogsProvider>

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor, type Section } from '@/lib/navigation';
 import { Button } from '@/components/ui/button';
@@ -20,6 +21,8 @@ const labels: Record<Section, string> = {
 export function AppNav() {
   const ctx = useViewContext();
   const pathname = usePathname();
+  const router = useRouter();
+  const { data: session, status } = useSession();
   const sections: Section[] =
     ctx.mode === 'viewer'
       ? [
@@ -69,9 +72,15 @@ export function AppNav() {
       </ul>
       <div className="flex items-center gap-4">
         <Clock />
-        <form action="/api/auth/signout" method="post">
-          <Button type="submit">Sign out</Button>
-        </form>
+        {status === 'loading' ? null : session ? (
+          <form action="/api/auth/signout" method="post">
+            <Button type="submit">Sign out</Button>
+          </form>
+        ) : (
+          <Button type="button" onClick={() => router.push('/signin')}>
+            Sign in
+          </Button>
+        )}
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- serve favicon from `public/Favicon_pieceofcake.png`
- document how to replace the placeholder favicon
- remove binary favicon placeholder from repo

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d61acc24832a988157c4c1a15471