### PR TITLE
feat: link favicon and document placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@
    ```sh
    pnpm test
    ```
+
+## Favicon
+
+1. Place your favicon image at `public/Favicon_pieceofcake.png`.
+2. The app automatically references this file, so ensure the filename matches when deploying.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -272,3 +272,4 @@
 - 2025-10-27: Disabled Webpack filesystem cache to prevent PackFileCacheStrategy errors during development.
 - 2025-10-27: Replaced always-on sign-out with conditional sign-in/out in AppNav.
 - 2025-10-27: Derived sign-in state from view context to avoid SessionProvider error in AppNav.
+- 2025-10-28: Linked favicon and documented placement for `Favicon_pieceofcake.png`.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,6 +43,7 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <head>
+        <link rel="icon" href="/Favicon_pieceofcake.png" />
         <script
           dangerouslySetInnerHTML={{
             __html: `(() => {

--- a/public/README.md
+++ b/public/README.md
@@ -1,0 +1,10 @@
+Place your static files here. To add the site favicon, save your image as `Favicon_pieceofcake.png` in this folder.
+
+Directory map:
+
+```
+public/
+└── Favicon_pieceofcake.png
+```
+
+Replace the placeholder with your actual favicon image before deploying.


### PR DESCRIPTION
## Summary
- reference `Favicon_pieceofcake.png` in the root layout
- document favicon placement in project README and `public/` folder
- note favicon addition in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f592cbdc832a822c12cf96097f69