### PR TITLE
feat: add historical review snapshots

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -273,3 +273,4 @@
 - 2025-10-27: Replaced always-on sign-out with conditional sign-in/out in AppNav.
 - 2025-10-27: Derived sign-in state from view context to avoid SessionProvider error in AppNav.
 - 2025-10-28: Linked favicon and documented placement for `Favicon_pieceofcake.png`.
+- 2025-10-28: Added historical review pages with snapshot-based heading report retrieval and read-only note handling.

--- a/app/(app)/review/client.tsx
+++ b/app/(app)/review/client.tsx
@@ -20,15 +20,17 @@ export function ReviewHome({
 
   // Load saved notes from localStorage on mount
   useEffect(() => {
+    if (!editable) return;
     const savedRational = localStorage.getItem('review-rational');
     const savedGuilty = localStorage.getItem('review-guilty');
     if (savedRational) setRational(savedRational);
     if (savedGuilty) setGuilty(savedGuilty);
-  }, []);
+  }, [editable]);
 
   const handleRationalChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
     setRational(value);
+    if (!editable) return;
     if (value) {
       localStorage.setItem('review-rational', value);
     } else {
@@ -39,6 +41,7 @@ export function ReviewHome({
   const handleGuiltyChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
     setGuilty(value);
+    if (!editable) return;
     if (value) {
       localStorage.setItem('review-guilty', value);
     } else {

--- a/app/(view)/view/[viewId]/review/page.tsx
+++ b/app/(view)/view/[viewId]/review/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from 'next/navigation';
 import { ReviewHome } from '@/app/(app)/review/client';
 import { getLatestHeadingReport } from '@/lib/heading-report-store';
 
+export const revalidate = 0;
+
 export default async function ViewReviewPage({
   params,
 }: {

--- a/app/history/[viewId]/[date]/review/page.tsx
+++ b/app/history/[viewId]/[date]/review/page.tsx
@@ -1,0 +1,30 @@
+import { getUserByViewId } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { getHeadingReportAt } from '@/lib/heading-report-store';
+import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { ReviewHome } from '@/app/(app)/review/client';
+
+export const revalidate = 0;
+
+export default async function HistoryReview({
+  params,
+}: {
+  params: Promise<{ viewId: string; date: string }>;
+}) {
+  const { viewId, date } = await params;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const snapshot = await getProfileSnapshot(owner.id, date);
+  if (!snapshot) notFound();
+  const tz = getUserTimeZone(owner);
+  const day = startOfDay(new Date(date), tz);
+  const dateStr = toYMD(day, tz);
+  const at = snapshot.createdAt ?? addDays(day, 1, tz);
+  const report = await getHeadingReportAt(owner.id, dateStr, at);
+  return (
+    <section id={`hist-review-${owner.id}-${date}`}>
+      <ReviewHome userId={owner.id} initialReport={report} />
+    </section>
+  );
+}

--- a/app/history/self/[date]/review/page.tsx
+++ b/app/history/self/[date]/review/page.tsx
@@ -1,0 +1,32 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { getHeadingReportAt } from '@/lib/heading-report-store';
+import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { ReviewHome } from '@/app/(app)/review/client';
+
+export const revalidate = 0;
+
+export default async function HistorySelfReview({
+  params,
+}: {
+  params: Promise<{ date: string }>;
+}) {
+  const { date } = await params;
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const snapshot = await getProfileSnapshot(me.id, date);
+  if (!snapshot) notFound();
+  const tz = getUserTimeZone(me);
+  const day = startOfDay(new Date(date), tz);
+  const dateStr = toYMD(day, tz);
+  const at = snapshot.createdAt ?? addDays(day, 1, tz);
+  const report = await getHeadingReportAt(me.id, dateStr, at);
+  return (
+    <section id={`hist-self-review-${me.id}-${date}`}>
+      <ReviewHome userId={me.id} initialReport={report} />
+    </section>
+  );
+}

--- a/lib/heading-report-store.ts
+++ b/lib/heading-report-store.ts
@@ -1,6 +1,6 @@
 import { db } from './db';
 import { headingReports } from './db/schema';
-import { eq, and, desc, sql } from 'drizzle-orm';
+import { eq, and, desc, sql, lte } from 'drizzle-orm';
 import type { HeadingReport } from '@/types/report';
 
 function slugFromDate(ymd: string, version = 1): string {
@@ -116,6 +116,40 @@ export async function getLatestHeadingReport(
   };
 }
 
+export async function getHeadingReportAt(
+  userId: number,
+  date: string,
+  at: Date,
+): Promise<HeadingReport | null> {
+  const [row] = await db
+    .select()
+    .from(headingReports)
+    .where(
+      and(
+        eq(headingReports.userId, userId),
+        eq(headingReports.date, date),
+        lte(headingReports.createdAt, at),
+      ),
+    )
+    .orderBy(desc(headingReports.version))
+    .limit(1);
+  if (!row) return null;
+  return {
+    id: row.id,
+    userId: row.userId ?? 0,
+    date,
+    version: row.version ?? 1,
+    overview: row.overview ?? '',
+    shortTerm: parseList(row.shortTerm),
+    longTerm: parseList(row.longTerm),
+    feedback: parseList(row.feedback),
+    scoreProgress: row.scoreProgress ?? 0,
+    scoreProbability: row.scoreProbability ?? 0,
+    coachTone: row.coachTone ?? 'tone_medium',
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
 export async function createHeadingReport(
   userId: number,
   date: string,
@@ -136,7 +170,9 @@ export async function createHeadingReport(
         maxVersion: sql<number>`coalesce(max(${headingReports.version}),0)`,
       })
       .from(headingReports)
-      .where(and(eq(headingReports.userId, userId), eq(headingReports.date, ymd)));
+      .where(
+        and(eq(headingReports.userId, userId), eq(headingReports.date, ymd)),
+      );
     const nextVersion = (maxVersion ?? 0) + 1;
     await db.insert(headingReports).values({
       userId,

--- a/tests/history-review.spec.ts
+++ b/tests/history-review.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+const PASSWORD = 'pass1234';
+
+function unique(prefix: string) {
+  return `${prefix}${Date.now()}`;
+}
+
+function yesterday(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+test('historical review is read-only for owner and viewer', async ({
+  page,
+}) => {
+  const handleA = unique('owner');
+  const emailA = `${handleA}@example.com`;
+  const dateStr = yesterday();
+
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Owner');
+  await page.fill('input[placeholder="Handle"]', handleA);
+  await page.fill('input[placeholder="Email"]', emailA);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  await page.goto(`/planning/live?apoc_date=${dateStr}&apoc_time=12:00`);
+  await page.click('[id^="p1an-add-top-"]');
+  await page.fill('input[id^="p1an-meta-ttl-"]', 'Task');
+  await page.click('button[id^="p1an-meta-close-"]');
+  await page.waitForTimeout(1000);
+
+  await page.goto(`/history/self/${dateStr}/review`);
+  const ownerTasks = page.locator('textarea');
+  await expect(ownerTasks).toHaveCount(2);
+  await expect(ownerTasks.nth(0)).toBeDisabled();
+  await expect(
+    page.getByRole('button', { name: 'Generate overview rapport' }),
+  ).toHaveCount(0);
+
+  await page.goto(`/u/${handleA}`);
+  const viewHref = await page.getAttribute('[id^="pr0ovr-view-"]', 'href');
+  const viewId = viewHref?.split('/').pop();
+
+  await page.click('text=Sign out');
+
+  const handleB = unique('viewer');
+  const emailB = `${handleB}@example.com`;
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Viewer');
+  await page.fill('input[placeholder="Handle"]', handleB);
+  await page.fill('input[placeholder="Email"]', emailB);
+  await page.fill('input[placeholder="Password"]', PASSWORD);
+  await page.click('text=Sign Up');
+
+  await page.goto(`/history/${viewId}/${dateStr}/review`);
+  const viewerTasks = page.locator('textarea');
+  await expect(viewerTasks).toHaveCount(2);
+  await expect(viewerTasks.nth(0)).toBeDisabled();
+  await expect(
+    page.getByRole('button', { name: 'Generate overview rapport' }),
+  ).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- add history review pages for owners and viewers with snapshot-based reports
- fetch heading reports at specific snapshot times
- disable local note persistence in read-only modes
- cover historical review with Playwright tests

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fb15ee48832a9a73a9060635d624