### PR TITLE
Restyle top navigation with white background

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -274,3 +274,4 @@
 - 2025-10-27: Derived sign-in state from view context to avoid SessionProvider error in AppNav.
 - 2025-10-28: Linked favicon and documented placement for `Favicon_pieceofcake.png`.
 - 2025-10-28: Added historical review pages with snapshot-based heading report retrieval and read-only note handling.
+- 2025-10-28: Restyled top navigation with white background, colored active underline, and subtle shadow.

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -5,6 +5,7 @@ import { useViewContext } from '@/lib/view-context';
 import { hrefFor, type Section } from '@/lib/navigation';
 import { Button } from '@/components/ui/button';
 import { Clock } from '@/components/clock';
+import { cn } from '@/lib/utils';
 
 const labels: Record<Section, string> = {
   cake: 'Cake',
@@ -15,6 +16,17 @@ const labels: Record<Section, string> = {
   people: 'People',
   visibility: 'Visibility',
   progress: 'Progress',
+};
+
+const underlineColors: Record<Section, string> = {
+  cake: 'var(--accent)',
+  planning: 'var(--planning)',
+  flavors: 'var(--flavors)',
+  ingredients: 'var(--ingredients)',
+  review: 'var(--review)',
+  people: 'var(--people)',
+  visibility: 'var(--visibility)',
+  progress: 'var(--accent)',
 };
 
 export function AppNav() {
@@ -55,21 +67,31 @@ export function AppNav() {
           ];
 
   return (
-    <nav className="flex items-center justify-between border-b bg-[var(--bg)] p-4">
-      <ul className="flex gap-4">
+    <nav className="flex items-center justify-between bg-white p-4 shadow-sm">
+      <ul className="flex gap-4 text-neutral-700">
         {sections.map((sec) => {
           const href = hrefFor(sec, ctx);
           const active = pathname === href;
           return (
             <li key={sec}>
-              <Link href={href} className={active ? 'font-semibold' : ''}>
+              <Link
+                href={href}
+                className={cn(
+                  active && 'font-semibold underline underline-offset-4',
+                )}
+                style={
+                  active
+                    ? { textDecorationColor: underlineColors[sec] }
+                    : undefined
+                }
+              >
                 {labels[sec]}
               </Link>
             </li>
           );
         })}
       </ul>
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-4 text-neutral-700">
         <Clock />
         {signedIn ? (
           <form action="/api/auth/signout" method="post">


### PR DESCRIPTION
## Summary
- brighten app header with a white background and subtle shadow
- highlight the active section with bold text and a colored underline that matches its slice
- note navigation restyle in the update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_68b20053240c832abb8b1ea5e7e8d6ff