### PR TITLE
Wrap cake navigation in floating card and use white background

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -275,3 +275,4 @@
 - 2025-10-28: Linked favicon and documented placement for `Favicon_pieceofcake.png`.
 - 2025-10-28: Added historical review pages with snapshot-based heading report retrieval and read-only note handling.
 - 2025-10-28: Restyled top navigation with white background, colored active underline, and subtle shadow.
+- 2025-10-28: Switched default background to pure white and wrapped cake navigation in a floating card.

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,24 +4,24 @@
 
 :root {
   --font-sans: ui-sans-serif, system-ui;
-  --bg: #0B0C0F0A;
-  --surface: rgba(255,255,255,0.8);
-  --text: #0B0C0F;
+  --bg: #ffffff;
+  --surface: rgba(255, 255, 255, 0.8);
+  --text: #0b0c0f;
   --text-muted: #384150;
-  --accent: #FF7A00;
-  --planning: #6AA7FF;
-  --flavors: #9A6BFF;
-  --ingredients: #00C2A8;
-  --review: #FFC53D;
-  --people: #6ED8A0;
-  --visibility: #FF7A7A;
+  --accent: #ff7a00;
+  --planning: #6aa7ff;
+  --flavors: #9a6bff;
+  --ingredients: #00c2a8;
+  --review: #ffc53d;
+  --people: #6ed8a0;
+  --visibility: #ff7a7a;
 }
 
 .dark {
-  --bg: #0B0C0F;
-  --surface: rgba(15,17,21,0.8);
-  --text: #E6EAF2;
-  --text-muted: #98A2B3;
+  --bg: #0b0c0f;
+  --surface: rgba(15, 17, 21, 0.8);
+  --text: #e6eaf2;
+  --text-muted: #98a2b3;
 }
 
 body {

--- a/components/cake/cake-home.tsx
+++ b/components/cake/cake-home.tsx
@@ -10,7 +10,11 @@ export async function CakeHome({ ownerId }: { ownerId: number }) {
     <section className="w-full">
       <h1 className="sr-only">Cake</h1>
       <SideCalendar snapshotDates={snapshotDates} reportDates={reportDates} />
-      <CakeNavigation />
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <div className="w-full max-w-5xl rounded-lg bg-white p-6 shadow">
+          <CakeNavigation />
+        </div>
+      </div>
     </section>
   );
 }

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -204,10 +204,7 @@ export function CakeNavigation() {
     : '';
 
   return (
-    <div
-      className="relative grid w-full justify-items-center"
-      style={{ minHeight: 'calc(100vh - 64px)' }}
-    >
+    <div className="relative grid w-full justify-items-center">
       {ctx.editable && <SettingsButton />}
       <div
         className="grid w-full place-items-center"


### PR DESCRIPTION
## Summary
- Switch global background variable to pure white
- Wrap cake navigation content in rounded card with light shadow
- Remove fixed viewport min-height from cake navigation for card layout

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68b20318bdd8832a95b55a6492d34fb3