### PR TITLE
fix: redirect unauthenticated users to sign-in

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -276,3 +276,4 @@
 - 2025-10-28: Added historical review pages with snapshot-based heading report retrieval and read-only note handling.
 - 2025-10-28: Restyled top navigation with white background, colored active underline, and subtle shadow.
 - 2025-10-28: Applied split gradient background from white to light gray for natural page sectioning.
+- 2025-10-28: Fixed redirect loop by sending unauthenticated users to the sign-in page.

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -14,7 +14,7 @@ export default async function AppLayout({
 }) {
   const session = await auth();
   if (!session) {
-    redirect('/');
+    redirect('/signin');
   }
   const me = await ensureUser(session);
   const tz = getUserTimeZone(me as any);


### PR DESCRIPTION
## Summary
- redirect unauthenticated users to `/signin` from app layout to avoid looping at `/`
- document change in update log

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: ELIFECYCLE Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b20732bf90832a84e0bb79ba753097