### PR TITLE
feat: toggle logs in settings

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -277,3 +277,4 @@
 - 2025-10-28: Restyled top navigation with white background, colored active underline, and subtle shadow.
 - 2025-10-28: Applied split gradient background from white to light gray for natural page sectioning.
 - 2025-10-28: Fixed redirect loop by sending unauthenticated users to the sign-in page.
+- 2025-10-29: Added settings toggle to enable or disable LLM logs with code 'cake2025'.

--- a/components/cake/settings-button.tsx
+++ b/components/cake/settings-button.tsx
@@ -26,7 +26,7 @@ export function SettingsButton() {
   const [open, setOpen] = useState(false);
   const [dark, setDark] = useState(false);
   const [followers, setFollowers] = useState(0);
-  const { unlock, unlocked } = useLogs();
+  const { unlock, lock, unlocked } = useLogs();
 
   useEffect(() => {
     const storedTheme = localStorage.getItem('color-mode');
@@ -89,17 +89,24 @@ export function SettingsButton() {
           >
             Account settings
           </Link>
-          {!unlocked && (
+          {unlocked ? (
+            <button
+              className="mb-2 w-full rounded bg-[var(--surface)] px-3 py-1 text-center hover:bg-[var(--accent)] hover:text-white"
+              onClick={lock}
+            >
+              Disable LLM-logs
+            </button>
+          ) : (
             <button
               className="mb-2 w-full rounded bg-[var(--surface)] px-3 py-1 text-center hover:bg-[var(--accent)] hover:text-white"
               onClick={() => {
                 const code = window.prompt('Enter code');
-                if (code === '123Yergush123') {
+                if (code === 'cake2025') {
                   unlock();
                 }
               }}
             >
-              LLM-logs
+              Enable LLM-logs
             </button>
           )}
           <button

--- a/components/dev/logs-provider.tsx
+++ b/components/dev/logs-provider.tsx
@@ -12,6 +12,7 @@ interface LogsContextType {
   addLog: (entry: LogEntry) => void;
   unlocked: boolean;
   unlock: () => void;
+  lock: () => void;
 }
 
 const LogsContext = createContext<LogsContextType | undefined>(undefined);
@@ -33,8 +34,14 @@ export function LogsProvider({ children }: { children: React.ReactNode }) {
     localStorage.setItem('logsUnlocked', 'true');
   };
 
+  const lock = () => {
+    setUnlocked(false);
+    localStorage.removeItem('logsUnlocked');
+    setLogs([]);
+  };
+
   return (
-    <LogsContext.Provider value={{ logs, addLog, unlocked, unlock }}>
+    <LogsContext.Provider value={{ logs, addLog, unlocked, unlock, lock }}>
       {children}
     </LogsContext.Provider>
   );


### PR DESCRIPTION
## Summary
- allow enabling/disabling LLM logs in settings using code "cake2025"
- add lock function to logs provider and toggle UI
- update changelog

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68b2093fe758832abad51749c1cb8d03