### PR TITLE
fix: isolate FlavorsHome component

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -278,3 +278,4 @@
 - 2025-10-28: Applied split gradient background from white to light gray for natural page sectioning.
 - 2025-10-28: Fixed redirect loop by sending unauthenticated users to the sign-in page.
 - 2025-10-29: Added settings toggle to enable or disable LLM logs with code 'cake2025'.
+- 2025-10-29: Moved FlavorsHome component into its own module to satisfy Next.js page export requirements.

--- a/app/(app)/flavors/flavors-home.tsx
+++ b/app/(app)/flavors/flavors-home.tsx
@@ -1,0 +1,25 @@
+import FlavorsClient from './client';
+
+export function FlavorsHome({
+  userId,
+  selfId,
+  initialFlavors,
+  people,
+  headingReport,
+}: {
+  userId: string;
+  selfId?: string;
+  initialFlavors: any[];
+  people?: any;
+  headingReport?: any;
+}) {
+  return (
+    <FlavorsClient
+      userId={userId}
+      selfId={selfId}
+      initialFlavors={initialFlavors as any}
+      people={people as any}
+      headingReport={headingReport}
+    />
+  );
+}

--- a/app/(app)/flavors/page.tsx
+++ b/app/(app)/flavors/page.tsx
@@ -11,14 +11,15 @@ import { getLatestHeadingReport } from '@/lib/heading-report-store';
 export default async function FlavorsPage({
   params,
 }: {
-  params?: { viewId?: string };
+  params: Promise<{ viewId?: string }>;
 }) {
+  const { viewId } = await params;
   const session = await auth();
   if (!session) notFound();
   const viewer = await ensureUser(session);
   let owner = viewer;
-  if (params?.viewId) {
-    const user = await getUserByViewId(params.viewId);
+  if (viewId) {
+    const user = await getUserByViewId(viewId);
     if (!user) notFound();
     owner = user;
   }
@@ -43,29 +44,5 @@ export default async function FlavorsPage({
         headingReport={heading ?? undefined}
       />
     </ViewContextProvider>
-  );
-}
-
-export function FlavorsHome({
-  userId,
-  selfId,
-  initialFlavors,
-  people,
-  headingReport,
-}: {
-  userId: string;
-  selfId?: string;
-  initialFlavors: any[];
-  people?: any;
-  headingReport?: any;
-}) {
-  return (
-    <FlavorsClient
-      userId={userId}
-      selfId={selfId}
-      initialFlavors={initialFlavors as any}
-      people={people as any}
-      headingReport={headingReport}
-    />
   );
 }

--- a/app/(app)/people/page.tsx
+++ b/app/(app)/people/page.tsx
@@ -14,8 +14,9 @@ import { ViewLink } from '@/components/people/view-link';
 export default async function PeoplePage({
   params,
 }: {
-  params?: { viewId?: string };
+  params: Promise<{ viewId?: string }>;
 }) {
+  const { viewId } = await params;
   const session = await auth();
   if (!session?.user?.email) {
     return (
@@ -27,8 +28,8 @@ export default async function PeoplePage({
   }
   const viewer = await ensureUser(session);
   let owner = viewer;
-  if (params?.viewId) {
-    const user = await getUserByViewId(params.viewId);
+  if (viewId) {
+    const user = await getUserByViewId(viewId);
     if (!user) notFound();
     owner = user;
   }
@@ -38,7 +39,7 @@ export default async function PeoplePage({
   const ctx = buildViewContext({
     ownerId,
     viewerId,
-    mode: params?.viewId ? 'viewer' : 'owner',
+    mode: viewId ? 'viewer' : 'owner',
     viewId: owner.viewId,
   });
 
@@ -120,7 +121,10 @@ export default async function PeoplePage({
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">People</h1>
         {ownerId === viewerId && (
-          <Link href={hrefFor('/people/inbox', ctx)} className="text-sm underline">
+          <Link
+            href={hrefFor('/people/inbox', ctx)}
+            className="text-sm underline"
+          >
             Inbox
           </Link>
         )}
@@ -179,13 +183,7 @@ function UserList({
   );
 }
 
-function UserAction({
-  viewerId,
-  user,
-}: {
-  viewerId: number;
-  user: UserInfo;
-}) {
+function UserAction({ viewerId, user }: { viewerId: number; user: UserInfo }) {
   if (user.viewerStatus === 'pending') {
     return (
       <div className="flex gap-2">
@@ -237,8 +235,8 @@ function UserAction({
           {user.followsMe
             ? 'Follow back'
             : user.accountVisibility === 'open'
-            ? 'Follow'
-            : 'Request to follow'}
+              ? 'Follow'
+              : 'Request to follow'}
         </Button>
       </form>
       {user.canView && (

--- a/app/(view)/view/[viewId]/flavors/page.tsx
+++ b/app/(view)/view/[viewId]/flavors/page.tsx
@@ -4,7 +4,7 @@ import { auth } from '@/lib/auth';
 import { listFlavors } from '@/lib/flavors-store';
 import { buildViewContext } from '@/lib/profile';
 import { ViewContextProvider } from '@/lib/view-context';
-import { FlavorsHome } from '@/app/(app)/flavors/page';
+import { FlavorsHome } from '@/app/(app)/flavors/flavors-home';
 
 export default async function ViewFlavorsPage({
   params,


### PR DESCRIPTION
## Summary
- move FlavorsHome component to its own module so flavors page only has a default export
- update flavors and people pages to use promise-based params for Next.js PageProps
- adjust view flavors page to import new component

## Testing
- `pnpm tsc` *(fails: TypeScript errors in progress overview pages)*
- `pnpm lint`
- `pnpm test` *(fails: Playwright browsers missing)*
- `pnpm build` *(fails: disallowed export in progress overview daily page)*

------
https://chatgpt.com/codex/tasks/task_e_68b21b18079c832a923052e5968d1401