### PR TITLE
fix: sync client timezone for planning

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -278,3 +278,4 @@
 - 2025-10-28: Applied split gradient background from white to light gray for natural page sectioning.
 - 2025-10-28: Fixed redirect loop by sending unauthenticated users to the sign-in page.
 - 2025-10-29: Added settings toggle to enable or disable LLM logs with code 'cake2025'.
+- 2025-10-29: Synced client timezone via cookie and used it server-side to fix plan and snapshot date offsets.

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { ensureUser } from '@/lib/users';
 import { buildViewContext } from '@/lib/profile';
 import { ensureDailyProfileSnapshot } from '@/lib/profile-snapshots';
 import { getUserTimeZone } from '@/lib/clock';
+import { cookies } from 'next/headers';
 import { ViewContextProvider } from '@/lib/view-context';
 import { AppNav } from '@/components/app-nav';
 
@@ -17,7 +18,8 @@ export default async function AppLayout({
     redirect('/signin');
   }
   const me = await ensureUser(session);
-  const tz = getUserTimeZone(me as any);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(me as any, { cookies: cookieStore });
   await ensureDailyProfileSnapshot(me.id, tz);
   const ctx = buildViewContext({
     ownerId: me.id,

--- a/app/api/clock/route.ts
+++ b/app/api/clock/route.ts
@@ -2,11 +2,14 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getNow, toYMD, getUserTimeZone } from '@/lib/clock';
 
 export async function GET(req: NextRequest) {
-  const tz =
-    req.nextUrl.searchParams.get('tz') || getUserTimeZone();
+  const params = Object.fromEntries(req.nextUrl.searchParams);
+  const tz = getUserTimeZone(undefined, {
+    cookies: req.cookies,
+    searchParams: params,
+  });
   const { now } = getNow(tz, {
     cookies: req.cookies,
-    searchParams: Object.fromEntries(req.nextUrl.searchParams),
+    searchParams: params,
   });
   return NextResponse.json({ now: now.toISOString(), ymd: toYMD(now, tz) });
 }

--- a/app/history/[viewId]/[date]/planning/live/page.tsx
+++ b/app/history/[viewId]/[date]/planning/live/page.tsx
@@ -3,6 +3,7 @@ import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { cookies } from 'next/headers';
 import EditorClient from '@/app/(app)/planning/next/client';
 import { listIngredients } from '@/lib/ingredients-store';
 
@@ -18,7 +19,8 @@ export default async function HistoryPlanningLive({
   if (!owner) notFound();
   const snapshot = await getProfileSnapshot(owner.id, date);
   if (!snapshot) notFound();
-  const tz = getUserTimeZone(owner);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(owner, { cookies: cookieStore });
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
   const at = snapshot.createdAt ?? addDays(day, 1, tz);

--- a/app/history/[viewId]/[date]/planning/next/page.tsx
+++ b/app/history/[viewId]/[date]/planning/next/page.tsx
@@ -3,6 +3,7 @@ import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { cookies } from 'next/headers';
 import EditorClient from '@/app/(app)/planning/next/client';
 import { listIngredients } from '@/lib/ingredients-store';
 
@@ -21,7 +22,8 @@ export default async function HistoryPlanningNext({
   if (!owner) notFound();
   const snapshot = await getProfileSnapshot(owner.id, date);
   if (!snapshot) notFound();
-  const tz = getUserTimeZone(owner);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(owner, { cookies: cookieStore });
   const day = startOfDay(new Date(date), tz);
   const base = addDays(day, 1, tz);
   let target = base;

--- a/app/history/[viewId]/[date]/planning/page.tsx
+++ b/app/history/[viewId]/[date]/planning/page.tsx
@@ -2,6 +2,7 @@ import { getUserByViewId } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { cookies } from 'next/headers';
 import PlanningLanding from '@/app/(app)/planning/client';
 
 export default async function HistoryPlanningLanding({
@@ -14,7 +15,8 @@ export default async function HistoryPlanningLanding({
   if (!owner) notFound();
   const snapshot = await getProfileSnapshot(owner.id, date);
   if (!snapshot) notFound();
-  const tz = getUserTimeZone(owner);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(owner, { cookies: cookieStore });
   const day = startOfDay(new Date(date), tz);
   const next = addDays(day, 1, tz);
   const liveLabel = day.toLocaleDateString('en-US', {

--- a/app/history/[viewId]/[date]/planning/review/page.tsx
+++ b/app/history/[viewId]/[date]/planning/review/page.tsx
@@ -3,6 +3,7 @@ import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { cookies } from 'next/headers';
 import EditorClient from '@/app/(app)/planning/next/client';
 import { listIngredients } from '@/lib/ingredients-store';
 
@@ -18,7 +19,8 @@ export default async function HistoryPlanningReview({
   if (!owner) notFound();
   const snapshot = await getProfileSnapshot(owner.id, date);
   if (!snapshot) notFound();
-  const tz = getUserTimeZone(owner);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(owner, { cookies: cookieStore });
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
   const at = snapshot.createdAt ?? addDays(day, 1, tz);

--- a/app/history/[viewId]/[date]/review/page.tsx
+++ b/app/history/[viewId]/[date]/review/page.tsx
@@ -3,6 +3,7 @@ import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getHeadingReportAt } from '@/lib/heading-report-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { cookies } from 'next/headers';
 import { ReviewHome } from '@/app/(app)/review/client';
 
 export const revalidate = 0;
@@ -17,7 +18,8 @@ export default async function HistoryReview({
   if (!owner) notFound();
   const snapshot = await getProfileSnapshot(owner.id, date);
   if (!snapshot) notFound();
-  const tz = getUserTimeZone(owner);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(owner, { cookies: cookieStore });
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
   const at = snapshot.createdAt ?? addDays(day, 1, tz);

--- a/app/history/self/[date]/planning/live/page.tsx
+++ b/app/history/self/[date]/planning/live/page.tsx
@@ -4,6 +4,7 @@ import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { cookies } from 'next/headers';
 import EditorClient from '@/app/(app)/planning/next/client';
 import { listIngredients } from '@/lib/ingredients-store';
 
@@ -20,7 +21,8 @@ export default async function HistorySelfPlanningLive({
   const me = await ensureUser(session);
   const snapshot = await getProfileSnapshot(me.id, date);
   if (!snapshot) notFound();
-  const tz = getUserTimeZone(me);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(me, { cookies: cookieStore });
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
   const at = snapshot.createdAt ?? addDays(day, 1, tz);

--- a/app/history/self/[date]/planning/next/page.tsx
+++ b/app/history/self/[date]/planning/next/page.tsx
@@ -4,6 +4,7 @@ import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { cookies } from 'next/headers';
 import EditorClient from '@/app/(app)/planning/next/client';
 import { listIngredients } from '@/lib/ingredients-store';
 
@@ -23,7 +24,8 @@ export default async function HistorySelfPlanningNext({
   const me = await ensureUser(session);
   const snapshot = await getProfileSnapshot(me.id, date);
   if (!snapshot) notFound();
-  const tz = getUserTimeZone(me);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(me, { cookies: cookieStore });
   const day = startOfDay(new Date(date), tz);
   const base = addDays(day, 1, tz);
   let target = base;

--- a/app/history/self/[date]/planning/page.tsx
+++ b/app/history/self/[date]/planning/page.tsx
@@ -3,6 +3,7 @@ import { ensureUser } from '@/lib/users';
 import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { cookies } from 'next/headers';
 import PlanningLanding from '@/app/(app)/planning/client';
 
 export default async function HistorySelfPlanningLanding({
@@ -16,7 +17,8 @@ export default async function HistorySelfPlanningLanding({
   const me = await ensureUser(session);
   const snapshot = await getProfileSnapshot(me.id, date);
   if (!snapshot) notFound();
-  const tz = getUserTimeZone(me);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(me, { cookies: cookieStore });
   const day = startOfDay(new Date(date), tz);
   const next = addDays(day, 1, tz);
   const liveLabel = day.toLocaleDateString('en-US', {

--- a/app/history/self/[date]/planning/review/page.tsx
+++ b/app/history/self/[date]/planning/review/page.tsx
@@ -4,6 +4,7 @@ import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getPlanAt } from '@/lib/plans-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { cookies } from 'next/headers';
 import EditorClient from '@/app/(app)/planning/next/client';
 import { listIngredients } from '@/lib/ingredients-store';
 
@@ -20,7 +21,8 @@ export default async function HistorySelfPlanningReview({
   const me = await ensureUser(session);
   const snapshot = await getProfileSnapshot(me.id, date);
   if (!snapshot) notFound();
-  const tz = getUserTimeZone(me);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(me, { cookies: cookieStore });
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
   const at = snapshot.createdAt ?? addDays(day, 1, tz);

--- a/app/history/self/[date]/review/page.tsx
+++ b/app/history/self/[date]/review/page.tsx
@@ -4,6 +4,7 @@ import { getProfileSnapshot } from '@/lib/profile-snapshots';
 import { notFound } from 'next/navigation';
 import { getHeadingReportAt } from '@/lib/heading-report-store';
 import { getUserTimeZone, startOfDay, addDays, toYMD } from '@/lib/clock';
+import { cookies } from 'next/headers';
 import { ReviewHome } from '@/app/(app)/review/client';
 
 export const revalidate = 0;
@@ -19,7 +20,8 @@ export default async function HistorySelfReview({
   const me = await ensureUser(session);
   const snapshot = await getProfileSnapshot(me.id, date);
   if (!snapshot) notFound();
-  const tz = getUserTimeZone(me);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(me, { cookies: cookieStore });
   const day = startOfDay(new Date(date), tz);
   const dateStr = toYMD(day, tz);
   const at = snapshot.createdAt ?? addDays(day, 1, tz);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import { cookies } from 'next/headers';
 import { LogsProvider } from '@/components/dev/logs-provider';
 import { LogsButton } from '@/components/dev/logs-button';
+import TimezoneSync from '@/components/timezone-sync';
 
 export default async function RootLayout({
   children,
@@ -77,6 +78,7 @@ export default async function RootLayout({
         <LogsProvider>
           {children}
           <LogsButton />
+          <TimezoneSync />
         </LogsProvider>
       </body>
     </html>

--- a/app/progress/layout.tsx
+++ b/app/progress/layout.tsx
@@ -4,6 +4,7 @@ import { ensureUser } from '@/lib/users';
 import { buildViewContext } from '@/lib/profile';
 import { ensureDailyProfileSnapshot } from '@/lib/profile-snapshots';
 import { getUserTimeZone } from '@/lib/clock';
+import { cookies } from 'next/headers';
 import { ViewContextProvider } from '@/lib/view-context';
 import { AppNav } from '@/components/app-nav';
 
@@ -17,7 +18,8 @@ export default async function ProgressLayout({
     redirect('/');
   }
   const me = await ensureUser(session);
-  const tz = getUserTimeZone(me as any);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(me as any, { cookies: cookieStore });
   await ensureDailyProfileSnapshot(me.id, tz);
   const ctx = buildViewContext({
     ownerId: me.id,

--- a/components/timezone-sync.tsx
+++ b/components/timezone-sync.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { useEffect } from 'react';
+
+export default function TimezoneSync() {
+  useEffect(() => {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const match = document.cookie.match(/(?:^|; )apoc_tz=([^;]+)/);
+    const current = match ? decodeURIComponent(match[1]) : null;
+    if (current !== tz) {
+      document.cookie = `apoc_tz=${tz}; path=/; max-age=${60 * 60 * 24 * 365}`;
+    }
+  }, []);
+  return null;
+}

--- a/lib/clock.ts
+++ b/lib/clock.ts
@@ -35,9 +35,16 @@ function getOffset(date: Date, tz: string): number {
 
 export function getUserTimeZone(
   user?: { timeZone?: string } | Record<string, unknown>,
+  req?: ReqLike,
 ): string {
   const tz = (user as any)?.timeZone as string | undefined;
-  return tz || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  if (tz) return tz;
+  const param = req?.searchParams?.['tz'];
+  const tzParam = Array.isArray(param) ? param[0] : param;
+  if (tzParam) return tzParam;
+  const cookieTz = req?.cookies?.get('apoc_tz')?.value;
+  if (cookieTz) return cookieTz;
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 }
 
 function first(val?: string | string[]): string | undefined {

--- a/lib/plan-date.ts
+++ b/lib/plan-date.ts
@@ -20,7 +20,7 @@ export function resolvePlanDate(
   user: { timeZone?: string } & Record<string, unknown>,
   req?: ReqInit,
 ) {
-  const tz = getUserTimeZone(user);
+  const tz = getUserTimeZone(user, req);
   const { now, override } = getNow(tz, req);
   const today = startOfDay(now, tz);
   const tomorrow = addDays(today, 1, tz);


### PR DESCRIPTION
## Summary
- read timezone from `apoc_tz` cookie when resolving plan and snapshot dates
- add client component to persist browser timezone in `apoc_tz` cookie
- wire server layouts and clock API to use cookie-based timezone

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c80e0820832a9f96ddaec7610186