### PR TITLE
fix: prevent planner hydration mismatch from stale time offset

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -279,3 +279,4 @@
 - 2025-10-28: Fixed redirect loop by sending unauthenticated users to the sign-in page.
 - 2025-10-29: Added settings toggle to enable or disable LLM logs with code 'cake2025'.
 - 2025-10-29: Synced client timezone via cookie and used it server-side to fix plan and snapshot date offsets.
+- 2025-10-29: Synced TimeMachine offset from cookie and cleared stale overrides to stop planner time shifts and hydration errors.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -50,7 +50,8 @@ export default async function RootLayout({
             __html: `(() => {
   const RealDate = Date;
   globalThis._realDate = RealDate;
-  const offsetStr = localStorage.getItem('timeOffset');
+  const match = document.cookie.match(/(?:^|; )timeOffset=(-?\d+)/);
+  const offsetStr = match ? match[1] : null;
   if (offsetStr) {
     const offset = parseInt(offsetStr, 10);
     if (!isNaN(offset)) {
@@ -68,7 +69,12 @@ export default async function RootLayout({
         }
       }
       globalThis.Date = MockDate;
+      localStorage.setItem('timeOffset', offsetStr);
+    } else {
+      localStorage.removeItem('timeOffset');
     }
+  } else {
+    localStorage.removeItem('timeOffset');
   }
 })();`,
           }}


### PR DESCRIPTION
## Summary
- sync TimeMachine offset from cookie on the client
- clear stale local storage overrides to avoid planner time shifts

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: ELIFECYCLE Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b598f20be4832aaa1e615f13cf7627