### PR TITLE
fix: preserve IME input across the app

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -279,3 +279,4 @@
 - 2025-10-28: Fixed redirect loop by sending unauthenticated users to the sign-in page.
 - 2025-10-29: Added settings toggle to enable or disable LLM logs with code 'cake2025'.
 - 2025-10-29: Synced client timezone via cookie and used it server-side to fix plan and snapshot date offsets.
+- 2025-10-29: Ignored Enter key during IME composition so typing doesn't drop characters.

--- a/app/(app)/flavors/[flavorId]/subflavors/client.tsx
+++ b/app/(app)/flavors/[flavorId]/subflavors/client.tsx
@@ -496,6 +496,7 @@ export default function SubflavorsClient({
             tabIndex={0}
             onClick={(e) => openEdit(f, e.currentTarget)}
             onKeyDown={(e) => {
+              if (e.nativeEvent.isComposing) return;
               if (e.key === 'Enter')
                 openEdit(f, e.currentTarget as HTMLElement);
               if (editable && e.key === 'Delete') remove(f);
@@ -653,7 +654,8 @@ export default function SubflavorsClient({
                 value={chatInput}
                 onChange={(e) => setChatInput(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') sendChat();
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing)
+                    sendChat();
                 }}
                 placeholder="Type your answer..."
                 className="flex-1 rounded border px-2 py-1"

--- a/app/(app)/flavors/client.tsx
+++ b/app/(app)/flavors/client.tsx
@@ -481,6 +481,7 @@ export default function FlavorsClient({
             tabIndex={0}
             onClick={(e) => openEdit(f, e.currentTarget)}
             onKeyDown={(e) => {
+              if (e.nativeEvent.isComposing) return;
               if (e.key === 'Enter')
                 openEdit(f, e.currentTarget as HTMLElement);
               if (editable && e.key === 'Delete') remove(f);
@@ -657,7 +658,8 @@ export default function FlavorsClient({
                 value={chatInput}
                 onChange={(e) => setChatInput(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') sendChat();
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing)
+                    sendChat();
                 }}
                 placeholder="Type your answer..."
                 className="flex-1 rounded border px-2 py-1"

--- a/app/(app)/ingredients/client.tsx
+++ b/app/(app)/ingredients/client.tsx
@@ -700,7 +700,8 @@ export default function IngredientsClient({
                 value={chatInput}
                 onChange={(e) => setChatInput(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') sendChat();
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing)
+                    sendChat();
                 }}
                 placeholder="Type your answer..."
                 className="flex-1 rounded border px-2 py-1"
@@ -761,7 +762,8 @@ export default function IngredientsClient({
                 value={improveChatInput}
                 onChange={(e) => setImproveChatInput(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') sendImproveChat();
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing)
+                    sendImproveChat();
                 }}
                 placeholder="Type your answer..."
                 className="flex-1 rounded border px-2 py-1"

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -85,8 +85,14 @@ interface Props {
   reportContext?: {
     heading: HeadingReport | null;
     daily: Pick<DailyReport, 'date' | 'bad' | 'observations'>[];
-    weekly: Pick<WeeklyReport, 'startDate' | 'endDate' | 'bad' | 'observations'>[];
-    monthly: Pick<MonthlyReport, 'startDate' | 'endDate' | 'bad' | 'observations'>[];
+    weekly: Pick<
+      WeeklyReport,
+      'startDate' | 'endDate' | 'bad' | 'observations'
+    >[];
+    monthly: Pick<
+      MonthlyReport,
+      'startDate' | 'endDate' | 'bad' | 'observations'
+    >[];
   };
 }
 
@@ -217,7 +223,9 @@ export default function EditorClient({
       messages: Array.isArray(thread?.messages) ? thread!.messages : [],
     };
   }, [initialPlan, live]);
-  let initialMsgs = savedThread.messages.length ? savedThread.messages : [welcome];
+  let initialMsgs = savedThread.messages.length
+    ? savedThread.messages
+    : [welcome];
   if (snapshotDate) {
     const snap = new Date(snapshotDate);
     snap.setDate(snap.getDate() + 1);
@@ -490,9 +498,13 @@ export default function EditorClient({
     if (rc.heading) {
       lines.push(`Overview: ${rc.heading.overview}`);
       if (rc.heading.shortTerm?.length)
-        lines.push(`Heading towards short term: ${rc.heading.shortTerm.join('; ')}`);
+        lines.push(
+          `Heading towards short term: ${rc.heading.shortTerm.join('; ')}`,
+        );
       if (rc.heading.longTerm?.length)
-        lines.push(`Heading towards long term: ${rc.heading.longTerm.join('; ')}`);
+        lines.push(
+          `Heading towards long term: ${rc.heading.longTerm.join('; ')}`,
+        );
       if (rc.heading.feedback?.length)
         lines.push(`Feedback: ${rc.heading.feedback.join('; ')}`);
     }
@@ -582,7 +594,9 @@ export default function EditorClient({
     });
     const done = blocks.filter((b) => minutesFromIso(b.end) <= now);
     const upcoming = blocks.filter((b) => minutesFromIso(b.start) > now);
-    const curStr = current.length ? current.map(summarizeBlock).join(' | ') : 'none';
+    const curStr = current.length
+      ? current.map(summarizeBlock).join(' | ')
+      : 'none';
     const doneStr = done.length ? done.map(summarizeBlock).join(' | ') : 'none';
     const upStr = upcoming.length
       ? upcoming.map(summarizeBlock).join(' | ')
@@ -740,21 +754,16 @@ export default function EditorClient({
             const presetMap = new Map(presets.map((p) => [p.id, p]));
             let assignments: ColorAssignment[] | null = null;
             try {
-              const colorRes = await fetch(
-                '/api/planning/color-assessment',
-                {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({
-                    activities: parsed,
-                    presets: presets.map((p) => ({ id: p.id, name: p.name })),
-                  }),
-                },
-              );
+              const colorRes = await fetch('/api/planning/color-assessment', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  activities: parsed,
+                  presets: presets.map((p) => ({ id: p.id, name: p.name })),
+                }),
+              });
               const colorData = await colorRes.json();
-              assignments = parseColorAssignments(
-                colorData.response as string,
-              );
+              assignments = parseColorAssignments(colorData.response as string);
             } catch {
               assignments = null;
             }
@@ -2769,7 +2778,8 @@ export default function EditorClient({
                   value={chatInput}
                   onChange={(e) => setChatInput(e.target.value)}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter') sendChat();
+                    if (e.key === 'Enter' && !e.nativeEvent.isComposing)
+                      sendChat();
                   }}
                   placeholder="Type your answer..."
                   className="flex-1 rounded border px-2 py-1"

--- a/components/cake/cake-3d.tsx
+++ b/components/cake/cake-3d.tsx
@@ -98,10 +98,9 @@ export function Cake3D({
               aria-label={slice.label}
               role="link"
               tabIndex={0}
-              onClick={() =>
-                router.push(hrefFor(slice.slug as Section, ctx))
-              }
+              onClick={() => router.push(hrefFor(slice.slug as Section, ctx))}
               onKeyDown={(e) => {
+                if (e.nativeEvent.isComposing) return;
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
                   router.push(hrefFor(slice.slug as Section, ctx));


### PR DESCRIPTION
## Summary
- guard Enter/Space key handlers against `isComposing` so IME users don't lose characters
- update changelog

## Testing
- `pnpm exec prettier -w components/cake/cake-3d.tsx app/(app)/flavors/client.tsx app/(app)/flavors/[flavorId]/subflavors/client.tsx app/(app)/ingredients/client.tsx app/(app)/planning/next/client.tsx UPDATE.md`
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: ELIFECYCLE Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b59d3ebc30832a9b3e387feff80742