### PR TITLE
fix: reload after time override to avoid hydration

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -279,3 +279,4 @@
 - 2025-10-28: Fixed redirect loop by sending unauthenticated users to the sign-in page.
 - 2025-10-29: Added settings toggle to enable or disable LLM logs with code 'cake2025'.
 - 2025-10-29: Synced client timezone via cookie and used it server-side to fix plan and snapshot date offsets.
+- 2025-10-29: Reloaded the app after applying TimeMachine overrides to keep server and client time in sync and prevent hydration mismatches.

--- a/components/dev/time-machine.tsx
+++ b/components/dev/time-machine.tsx
@@ -54,6 +54,8 @@ export function TimeMachine({ open, onClose }: Props) {
     const offset = target - RealDate.now();
     override(offset);
     handleClose();
+    // Reload to ensure server-rendered content uses the same offseted time.
+    window.location.reload();
   }
 
   function resetOverride() {
@@ -61,6 +63,8 @@ export function TimeMachine({ open, onClose }: Props) {
     (globalThis as any).Date = RealDate;
     localStorage.removeItem('timeOffset');
     document.cookie = 'timeOffset=; Max-Age=0; path=/';
+    // Refresh so both server and client revert to real time.
+    window.location.reload();
   }
 
   function resetToCurrentNl() {
@@ -75,6 +79,8 @@ export function TimeMachine({ open, onClose }: Props) {
     const offset = t - RealDate.now();
     override(offset);
     handleClose();
+    // Reload so subsequent renders use the Amsterdam time.
+    window.location.reload();
   }
 
   function handleClose() {


### PR DESCRIPTION
## Summary
- reload page after applying or clearing TimeMachine overrides so server-rendered HTML matches client time
- log change in UPDATE.md

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: numerous Playwright tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a14787e4832a9c66dca8fa426f3b