### PR TITLE
feat: add to-do lists with snapshot support

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -280,3 +280,4 @@
 - 2025-10-29: Added settings toggle to enable or disable LLM logs with code 'cake2025'.
 - 2025-10-29: Synced client timezone via cookie and used it server-side to fix plan and snapshot date offsets.
 - 2025-10-29: Reloaded the app after applying TimeMachine overrides to keep server and client time in sync and prevent hydration mismatches.
+- 2025-10-29: Introduced to-do lists with priority, icons, and snapshot support, accessible from planning via new To Do button.

--- a/app/(app)/planning/client.tsx
+++ b/app/(app)/planning/client.tsx
@@ -68,6 +68,15 @@ export default function PlanningLanding({
     navigate('review');
   }
 
+  function handleTodo() {
+    if (editable) {
+      router.push('/todos');
+    } else if (viewId) {
+      const at = mode === 'historical' && snapshotDate ? `?at=${snapshotDate}` : '';
+      router.push(`/view/${viewId}/todos${at}`);
+    }
+  }
+
   return (
     <section
       id={`p1an-landing-${userId}`}
@@ -98,6 +107,13 @@ export default function PlanningLanding({
         onClick={handleReview}
       >
         Review Today’s Planning — {reviewLabel}
+      </Button>
+      <Button
+        id={`p1an-btn-todo-${userId}`}
+        title={tooltip}
+        onClick={handleTodo}
+      >
+        To Do
       </Button>
     </section>
   );

--- a/app/(app)/todos/actions.ts
+++ b/app/(app)/todos/actions.ts
@@ -1,0 +1,64 @@
+'use server';
+
+import {
+  createTodo as createStore,
+  updateTodo as updateStore,
+  deleteTodo as deleteStore,
+} from '@/lib/todos-store';
+import { assertOwner } from '@/lib/profile';
+import type { Todo } from '@/types/todo';
+import { revalidatePath } from 'next/cache';
+
+function sanitize(form: FormData) {
+  const obj: any = {};
+  for (const [key, value] of form.entries()) {
+    obj[key] = value as any;
+  }
+  obj.priority = clamp(Number(obj.priority));
+  obj.title = String(obj.title || '').slice(0, 80);
+  obj.description = (obj.description || '').toString();
+  obj.icon = typeof obj.icon === 'string' ? obj.icon : '✅';
+  obj.visibility = ['private', 'followers', 'friends', 'public'].includes(
+    obj.visibility,
+  )
+    ? obj.visibility
+    : 'public';
+  return obj;
+}
+
+function clamp(n: number) {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+export async function createTodo(
+  ownerId: number,
+  formData: FormData,
+): Promise<Todo> {
+  await assertOwner(ownerId, ownerId);
+  const data = sanitize(formData);
+  const todo = await createStore(String(ownerId), data);
+  revalidatePath('/todos');
+  return todo;
+}
+
+export async function updateTodo(
+  ownerId: number,
+  id: number,
+  formData: FormData,
+): Promise<Todo | null> {
+  await assertOwner(ownerId, ownerId);
+  const data = sanitize(formData);
+  const todo = await updateStore(String(ownerId), id, data);
+  revalidatePath('/todos');
+  return todo;
+}
+
+export async function deleteTodo(
+  ownerId: number,
+  id: number,
+): Promise<boolean> {
+  await assertOwner(ownerId, ownerId);
+  const ok = await deleteStore(String(ownerId), id);
+  revalidatePath('/todos');
+  return ok;
+}

--- a/app/(app)/todos/client.tsx
+++ b/app/(app)/todos/client.tsx
@@ -1,0 +1,139 @@
+'use client';
+/* eslint-disable @next/next/no-img-element */
+
+import { useState } from 'react';
+import IconPicker from '@/components/icon-picker';
+import type { Todo, TodoInput, Visibility } from '@/types/todo';
+import { useViewContext } from '@/lib/view-context';
+import { createTodo as createAction } from './actions';
+import { Button } from '@/components/ui/button';
+
+const VISIBILITIES: Visibility[] = ['private', 'followers', 'friends', 'public'];
+
+function sortTodos(list: Todo[]) {
+  return [...list].sort((a, b) => {
+    if (b.priority !== a.priority) return b.priority - a.priority;
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  });
+}
+
+export default function TodosClient({
+  userId,
+  initialTodos,
+}: {
+  userId: string;
+  initialTodos: Todo[];
+}) {
+  const { editable } = useViewContext();
+  const [todos, setTodos] = useState(() => sortTodos(initialTodos));
+  const [form, setForm] = useState<TodoInput>({
+    title: '',
+    description: '',
+    priority: 50,
+    icon: '✅',
+    visibility: 'public',
+  });
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!editable) return;
+    const fd = new FormData();
+    fd.append('title', form.title);
+    fd.append('description', form.description || '');
+    fd.append('priority', String(form.priority));
+    fd.append('icon', form.icon);
+    fd.append('visibility', form.visibility || 'public');
+    const todo = await createAction(Number(userId), fd);
+    setTodos((prev) => sortTodos([...prev, todo]));
+    setForm({ title: '', description: '', priority: 50, icon: '✅', visibility: 'public' });
+  }
+
+  return (
+    <div id={`todo-list-${userId}`} className="space-y-4 p-4">
+      {editable && (
+        <form
+          id={`todo-form-${userId}`}
+          onSubmit={handleSubmit}
+          className="space-y-2 rounded border p-4"
+        >
+          <div>
+            <label className="block text-sm font-medium" htmlFor={`todo-title-${userId}`}>
+              Title
+            </label>
+            <input
+              id={`todo-title-${userId}`}
+              className="w-full border p-1"
+              value={form.title}
+              maxLength={80}
+              required
+              onChange={(e) => setForm({ ...form, title: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium" htmlFor={`todo-desc-${userId}`}>
+              Description
+            </label>
+            <textarea
+              id={`todo-desc-${userId}`}
+              className="w-full border p-1"
+              value={form.description}
+              rows={3}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium" htmlFor={`todo-pri-${userId}`}>
+              Priority ({form.priority})
+            </label>
+            <input
+              id={`todo-pri-${userId}`}
+              type="range"
+              min={0}
+              max={100}
+              value={form.priority}
+              onChange={(e) => setForm({ ...form, priority: Number(e.target.value) })}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Icon</label>
+            <IconPicker
+              value={form.icon}
+              onChange={(ic) => setForm({ ...form, icon: ic })}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Visibility</label>
+            <select
+              id={`todo-vis-${userId}`}
+              className="border p-1"
+              value={form.visibility}
+              onChange={(e) => setForm({ ...form, visibility: e.target.value as Visibility })}
+            >
+              {VISIBILITIES.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
+          </div>
+          <Button id={`todo-submit-${userId}`} type="submit">
+            Add
+          </Button>
+        </form>
+      )}
+      <ul className="space-y-2">
+        {todos.map((t) => (
+          <li
+            key={t.id}
+            className="flex items-center gap-2 rounded border p-2"
+          >
+            <span>{t.icon}</span>
+            <span className="font-medium">{t.title}</span>
+            <span className="text-xs text-gray-500">{t.priority}</span>
+          </li>
+        ))}
+      </ul>
+      {todos.length === 0 && <p id={`todo-empty-${userId}`}>No to-dos yet.</p>}
+    </div>
+  );
+}

--- a/app/(app)/todos/page.tsx
+++ b/app/(app)/todos/page.tsx
@@ -1,0 +1,43 @@
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { listTodos } from '@/lib/todos-store';
+import TodosClient from './client';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import type { Todo } from '@/types/todo';
+
+export default async function TodosPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const sp = await searchParams;
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const at = sp?.at ? new Date(sp.at) : undefined;
+  const todos = await listTodos(String(me.id), me.id, at);
+  const ctx = buildViewContext({
+    ownerId: me.id,
+    viewerId: me.id,
+    mode: at ? 'historical' : 'owner',
+    viewId: me.viewId,
+    snapshotDate: sp?.at,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <TodosClient userId={String(me.id)} initialTodos={todos} />
+    </ViewContextProvider>
+  );
+}
+
+export function TodosHome({
+  userId,
+  initialTodos,
+}: {
+  userId: string;
+  initialTodos: Todo[];
+}) {
+  return <TodosClient userId={userId} initialTodos={initialTodos} />;
+}

--- a/app/(view)/view/[viewId]/todos/page.tsx
+++ b/app/(view)/view/[viewId]/todos/page.tsx
@@ -1,0 +1,39 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { listTodos } from '@/lib/todos-store';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { TodosHome } from '@/app/(app)/todos/page';
+
+export default async function ViewTodosPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  const at = sp?.at ? new Date(sp.at) : undefined;
+  const todos = await listTodos(String(user.id), viewerId, at);
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: at ? 'historical' : 'viewer',
+    viewId: user.viewId,
+    snapshotDate: sp?.at,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-todo-${user.id}`}>
+        <TodosHome userId={String(user.id)} initialTodos={todos} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/drizzle/0029_create_todos.sql
+++ b/drizzle/0029_create_todos.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS "todos" (
+  "id" serial PRIMARY KEY,
+  "user_id" integer REFERENCES users(id) NOT NULL,
+  "title" text NOT NULL,
+  "description" text,
+  "priority" integer,
+  "icon" text,
+  "visibility" text,
+  "created_at" timestamptz DEFAULT now(),
+  "updated_at" timestamptz DEFAULT now(),
+  UNIQUE (user_id, title)
+);
+
+CREATE TABLE IF NOT EXISTS "todo_revisions" (
+  "id" serial PRIMARY KEY,
+  "todo_id" integer REFERENCES todos(id) NOT NULL,
+  "snapshot_at" timestamptz DEFAULT now(),
+  "payload" jsonb NOT NULL
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -191,6 +191,13 @@
       "when": 1756284819559,
       "tag": "0026_add_users_coach_tone",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1756284819560,
+      "tag": "0029_create_todos",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -126,6 +126,39 @@ export const ingredientRevisions = pgTable('ingredient_revisions', {
   payload: jsonb('payload').notNull(),
 });
 
+export const todos = pgTable(
+  'todos',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    title: varchar('title', { length: 80 }).notNull(),
+    description: text('description'),
+    priority: integer('priority').default(0),
+    // Allow emoji or data URL
+    icon: text('icon'),
+    visibility: varchar('visibility', { length: 20 }).default('public'),
+    createdAt: timestamp('created_at').defaultNow(),
+    updatedAt: timestamp('updated_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserTitle: uniqueIndex('todos_user_title_unique').on(
+      table.userId,
+      table.title,
+    ),
+  }),
+);
+
+export const todoRevisions = pgTable('todo_revisions', {
+  id: serial('id').primaryKey(),
+  todoId: integer('todo_id')
+    .references(() => todos.id)
+    .notNull(),
+  snapshotAt: timestamp('snapshot_at').defaultNow(),
+  payload: jsonb('payload').notNull(),
+});
+
 export const follows = pgTable(
   'follows',
   {

--- a/lib/todos-store.ts
+++ b/lib/todos-store.ts
@@ -1,0 +1,240 @@
+import { db } from './db';
+import { todos, todoRevisions, follows } from './db/schema';
+import { eq, and, desc, lte } from 'drizzle-orm';
+import type { Todo, TodoInput, Visibility } from '@/types/todo';
+
+function sortTodos(list: Todo[]) {
+  return list.sort((a, b) => {
+    if (b.priority !== a.priority) return b.priority - a.priority;
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  });
+}
+
+function toTodo(row: typeof todos.$inferSelect): Todo {
+  return {
+    id: row.id,
+    userId: row.userId ?? 0,
+    title: row.title ?? '',
+    description: row.description ?? '',
+    priority: row.priority ?? 0,
+    icon: row.icon ?? '✅',
+    visibility: (row.visibility as Visibility) ?? 'public',
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+    updatedAt: row.updatedAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+async function canView(
+  viewerId: number | null,
+  ownerId: number,
+  vis: Visibility,
+) {
+  if (viewerId === ownerId) return true;
+  switch (vis) {
+    case 'public':
+      return true;
+    case 'followers':
+      if (!viewerId) return false;
+      const [f1] = await db
+        .select()
+        .from(follows)
+        .where(
+          and(
+            eq(follows.followerId, viewerId),
+            eq(follows.followingId, ownerId),
+          ),
+        );
+      return !!f1 && f1.status === 'accepted';
+    case 'friends':
+      if (!viewerId) return false;
+      const [f2] = await db
+        .select()
+        .from(follows)
+        .where(
+          and(
+            eq(follows.followerId, viewerId),
+            eq(follows.followingId, ownerId),
+          ),
+        );
+      const [f3] = await db
+        .select()
+        .from(follows)
+        .where(
+          and(
+            eq(follows.followerId, ownerId),
+            eq(follows.followingId, viewerId),
+          ),
+        );
+      return f2?.status === 'accepted' && f3?.status === 'accepted';
+    case 'private':
+    default:
+      return false;
+  }
+}
+
+export async function listTodos(
+  userId: string,
+  viewerId: number | null = null,
+  at?: Date,
+): Promise<Todo[]> {
+  const rows = await db
+    .select()
+    .from(todos)
+    .where(eq(todos.userId, Number(userId)));
+  const list: Todo[] = [];
+  for (const row of rows) {
+    if (
+      !(await canView(
+        viewerId,
+        row.userId ?? 0,
+        (row.visibility as Visibility) ?? 'public',
+      ))
+    )
+      continue;
+    let base = toTodo(row);
+    if (at) {
+      const [rev] = await db
+        .select()
+        .from(todoRevisions)
+        .where(
+          and(
+            eq(todoRevisions.todoId, row.id),
+            lte(todoRevisions.snapshotAt, at),
+          ),
+        )
+        .orderBy(desc(todoRevisions.snapshotAt))
+        .limit(1);
+      if (rev) {
+        base = { ...base, ...(rev.payload as any) };
+      }
+    }
+    list.push(base);
+  }
+  return sortTodos(list);
+}
+
+export async function getTodo(
+  userId: string,
+  id: number,
+  viewerId: number | null = null,
+  at?: Date,
+): Promise<Todo | null> {
+  const [row] = await db
+    .select()
+    .from(todos)
+    .where(and(eq(todos.userId, Number(userId)), eq(todos.id, id)));
+  if (!row) return null;
+  if (
+    !(await canView(
+      viewerId,
+      row.userId ?? 0,
+      (row.visibility as Visibility) ?? 'public',
+    ))
+  )
+    return null;
+  let base = toTodo(row);
+  if (at) {
+    const [rev] = await db
+      .select()
+      .from(todoRevisions)
+      .where(
+        and(
+          eq(todoRevisions.todoId, row.id),
+          lte(todoRevisions.snapshotAt, at),
+        ),
+      )
+      .orderBy(desc(todoRevisions.snapshotAt))
+      .limit(1);
+    if (rev) {
+      base = { ...base, ...(rev.payload as any) };
+    }
+  }
+  return base;
+}
+
+export async function createTodo(
+  userId: string,
+  input: TodoInput,
+): Promise<Todo> {
+  const now = new Date();
+  const [row] = await db
+    .insert(todos)
+    .values({
+      userId: Number(userId),
+      title: input.title.slice(0, 80),
+      description: input.description,
+      priority: clamp(input.priority),
+      icon: input.icon,
+      visibility: input.visibility ?? 'public',
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+  const todo = toTodo(row);
+  await db.insert(todoRevisions).values({
+    todoId: todo.id,
+    payload: {
+      title: todo.title,
+      description: todo.description,
+      priority: todo.priority,
+      icon: todo.icon,
+    },
+  });
+  return todo;
+}
+
+export async function updateTodo(
+  userId: string,
+  id: number,
+  input: Partial<TodoInput>,
+): Promise<Todo | null> {
+  const now = new Date();
+  const [row] = await db
+    .update(todos)
+    .set({
+      title: input.title ? input.title.slice(0, 80) : undefined,
+      description: input.description,
+      priority: input.priority !== undefined ? clamp(input.priority) : undefined,
+      icon: input.icon,
+      visibility: input.visibility,
+      updatedAt: now,
+    })
+    .where(and(eq(todos.userId, Number(userId)), eq(todos.id, id)))
+    .returning();
+  if (!row) return null;
+  const todo = toTodo(row);
+  await db.insert(todoRevisions).values({
+    todoId: todo.id,
+    payload: {
+      title: todo.title,
+      description: todo.description,
+      priority: todo.priority,
+      icon: todo.icon,
+    },
+  });
+  return todo;
+}
+
+export async function deleteTodo(
+  userId: string,
+  id: number,
+): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    const [exists] = await tx
+      .select({ id: todos.id })
+      .from(todos)
+      .where(and(eq(todos.userId, Number(userId)), eq(todos.id, id)))
+      .limit(1);
+    if (!exists) return false;
+    await tx.delete(todoRevisions).where(eq(todoRevisions.todoId, id));
+    await tx
+      .delete(todos)
+      .where(and(eq(todos.userId, Number(userId)), eq(todos.id, id)));
+    return true;
+  });
+}
+
+function clamp(n: number) {
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+

--- a/types/todo.ts
+++ b/types/todo.ts
@@ -1,0 +1,21 @@
+export type Visibility = 'private' | 'followers' | 'friends' | 'public';
+
+export interface Todo {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  priority: number;
+  icon: string;
+  visibility: Visibility;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TodoInput {
+  title: string;
+  description?: string;
+  priority: number;
+  icon: string;
+  visibility?: Visibility;
+}


### PR DESCRIPTION
## Summary
- add prioritized to-do lists with icons and daily snapshot revisions
- expose new To Do management page with viewer snapshot support
- link planning section to new to-do page via dedicated button

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: tests failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a83a5730832a84579a8ae3c3cc77