### PR TITLE
feat: unlock time machine from settings

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -283,3 +283,4 @@
 - 2025-10-29: Introduced to-do lists with priority, icons, and snapshot support, accessible from planning via new To Do button.
 - 2025-10-29: Added dedicated Add To Do modal and rendered custom icons as images instead of raw strings.
 - 2025-10-29: Included user to-dos in planning next-day agent context and updated system prompt for activity planning guidance.
+- 2025-10-29: Added DEV option in settings to unlock the TimeMachine with code "Cake2025" for manual time overrides.

--- a/components/cake/cake-navigation.tsx
+++ b/components/cake/cake-navigation.tsx
@@ -208,7 +208,9 @@ export function CakeNavigation() {
       className="relative grid w-full justify-items-center"
       style={{ minHeight: 'calc(100vh - 64px)' }}
     >
-      {ctx.editable && <SettingsButton />}
+      {ctx.editable && (
+        <SettingsButton onOpenDev={() => setTimeMachineOpen(true)} />
+      )}
       <div
         className="grid w-full place-items-center"
         style={{ marginBottom: 'clamp(24px,3vh,36px)' }}

--- a/components/cake/settings-button.tsx
+++ b/components/cake/settings-button.tsx
@@ -5,6 +5,10 @@ import Link from 'next/link';
 import { signOut } from 'next-auth/react';
 import { useLogs } from '@/components/dev/logs-provider';
 
+interface Props {
+  onOpenDev?: () => void;
+}
+
 function GearIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg
@@ -22,7 +26,7 @@ function GearIcon(props: React.SVGProps<SVGSVGElement>) {
   );
 }
 
-export function SettingsButton() {
+export function SettingsButton({ onOpenDev }: Props) {
   const [open, setOpen] = useState(false);
   const [dark, setDark] = useState(false);
   const [followers, setFollowers] = useState(0);
@@ -89,6 +93,19 @@ export function SettingsButton() {
           >
             Account settings
           </Link>
+          {onOpenDev && (
+            <button
+              className="mb-2 w-full rounded bg-[var(--surface)] px-3 py-1 text-center hover:bg-[var(--accent)] hover:text-white"
+              onClick={() => {
+                const code = window.prompt('Enter dev code');
+                if (code === 'Cake2025') {
+                  onOpenDev();
+                }
+              }}
+            >
+              DEV
+            </button>
+          )}
           {unlocked ? (
             <button
               className="mb-2 w-full rounded bg-[var(--surface)] px-3 py-1 text-center hover:bg-[var(--accent)] hover:text-white"

--- a/components/dev/time-machine.tsx
+++ b/components/dev/time-machine.tsx
@@ -18,7 +18,7 @@ export function TimeMachine({ open, onClose }: Props) {
   if (!open) return null;
 
   function handleVerify() {
-    if (code.trim() === 'hsug') {
+    if (code.trim() === 'Cake2025') {
       setStage('time');
       setCode('');
       setError('');


### PR DESCRIPTION
## Summary
- add DEV option in settings that opens the TimeMachine after entering code
- verify time override with Cake2025

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: ELIFECYCLE Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fcff0158832a9dd8c9f29c5cb790