### PR TITLE
fix: prevent planning text loss from stale autosaves

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -284,3 +284,4 @@
 - 2025-10-29: Added dedicated Add To Do modal and rendered custom icons as images instead of raw strings.
 - 2025-10-29: Included user to-dos in planning next-day agent context and updated system prompt for activity planning guidance.
 - 2025-10-29: Added DEV option in settings to unlock the TimeMachine with code "Cake2025" for manual time overrides.
+- 2025-10-29: Guarded planning autosave against stale responses to keep text from disappearing while typing.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -1104,6 +1104,7 @@ export default function EditorClient({
     if (serialized === lastSaved.current) return;
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(() => {
+      const reqSerialized = serialized;
       const payload: PlanBlockInput[] = blocks.map((b) => ({
         id: b.id,
         start: b.start,
@@ -1124,6 +1125,12 @@ export default function EditorClient({
         dailyIngredientIds,
         presetsSnapshot,
       ).then((plan) => {
+        const currentSerialized = JSON.stringify({
+          blocks: blocksRef.current,
+          dailyAim: dailyAimRef.current,
+          dailyIngredientIds: dailyIngredientIdsRef.current,
+        });
+        if (currentSerialized !== reqSerialized) return;
         const prevSelected =
           metaPinned && selectedId
             ? blocksRef.current.find((b) => b.id === selectedId)


### PR DESCRIPTION
## Summary
- prevent stale autosave responses from overwriting recent edits in planning editor
- log change in `UPDATE.md`

## Testing
- `pnpm lint`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68c11688b7c8832a91a32c3c28c2d924