### PR TITLE
feat: add complete and delete controls for to-dos

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -285,3 +285,4 @@
 - 2025-10-29: Included user to-dos in planning next-day agent context and updated system prompt for activity planning guidance.
 - 2025-10-29: Added DEV option in settings to unlock the TimeMachine with code "Cake2025" for manual time overrides.
 - 2025-10-29: Guarded planning autosave against stale responses to keep text from disappearing while typing.
+- 2025-10-29: Added completion and deletion controls for to-dos with green completed state.

--- a/app/(app)/todos/actions.ts
+++ b/app/(app)/todos/actions.ts
@@ -23,6 +23,9 @@ function sanitize(form: FormData) {
   )
     ? obj.visibility
     : 'public';
+  if (obj.completed !== undefined) {
+    obj.completed = String(obj.completed) === 'true';
+  }
   return obj;
 }
 

--- a/app/(app)/todos/client.tsx
+++ b/app/(app)/todos/client.tsx
@@ -5,13 +5,23 @@ import { useState } from 'react';
 import IconPicker from '@/components/icon-picker';
 import type { Todo, TodoInput, Visibility } from '@/types/todo';
 import { useViewContext } from '@/lib/view-context';
-import { createTodo as createAction } from './actions';
+import {
+  createTodo as createAction,
+  updateTodo as updateAction,
+  deleteTodo as deleteAction,
+} from './actions';
 import { Button } from '@/components/ui/button';
 
-const VISIBILITIES: Visibility[] = ['private', 'followers', 'friends', 'public'];
+const VISIBILITIES: Visibility[] = [
+  'private',
+  'followers',
+  'friends',
+  'public',
+];
 
 function sortTodos(list: Todo[]) {
   return [...list].sort((a, b) => {
+    if (a.completed !== b.completed) return a.completed ? 1 : -1;
     if (b.priority !== a.priority) return b.priority - a.priority;
     return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
   });
@@ -62,6 +72,26 @@ export default function TodosClient({
     setOpen(false);
   }
 
+  async function handleComplete(id: number) {
+    if (!editable) return;
+    const fd = new FormData();
+    fd.append('completed', 'true');
+    const updated = await updateAction(Number(userId), id, fd);
+    if (updated) {
+      setTodos((prev) =>
+        sortTodos(prev.map((t) => (t.id === id ? updated : t))),
+      );
+    }
+  }
+
+  async function handleDelete(id: number) {
+    if (!editable) return;
+    const ok = await deleteAction(Number(userId), id);
+    if (ok) {
+      setTodos((prev) => prev.filter((t) => t.id !== id));
+    }
+  }
+
   return (
     <div id={`todo-list-${userId}`} className="space-y-4 p-4">
       {editable && (
@@ -77,7 +107,10 @@ export default function TodosClient({
             className="w-full max-w-sm space-y-2 rounded bg-white p-6 shadow-lg"
           >
             <div>
-              <label className="block text-sm font-medium" htmlFor={`todo-title-${userId}`}>
+              <label
+                className="block text-sm font-medium"
+                htmlFor={`todo-title-${userId}`}
+              >
                 Title
               </label>
               <input
@@ -90,7 +123,10 @@ export default function TodosClient({
               />
             </div>
             <div>
-              <label className="block text-sm font-medium" htmlFor={`todo-desc-${userId}`}>
+              <label
+                className="block text-sm font-medium"
+                htmlFor={`todo-desc-${userId}`}
+              >
                 Description
               </label>
               <textarea
@@ -98,11 +134,16 @@ export default function TodosClient({
                 className="w-full border p-1"
                 value={form.description}
                 rows={3}
-                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                onChange={(e) =>
+                  setForm({ ...form, description: e.target.value })
+                }
               />
             </div>
             <div>
-              <label className="block text-sm font-medium" htmlFor={`todo-pri-${userId}`}>
+              <label
+                className="block text-sm font-medium"
+                htmlFor={`todo-pri-${userId}`}
+              >
                 Priority ({form.priority})
               </label>
               <input
@@ -111,7 +152,9 @@ export default function TodosClient({
                 min={0}
                 max={100}
                 value={form.priority}
-                onChange={(e) => setForm({ ...form, priority: Number(e.target.value) })}
+                onChange={(e) =>
+                  setForm({ ...form, priority: Number(e.target.value) })
+                }
               />
             </div>
             <div>
@@ -157,7 +200,9 @@ export default function TodosClient({
         {todos.map((t) => (
           <li
             key={t.id}
-            className="flex items-center gap-2 rounded border p-2"
+            className={`flex items-center gap-2 rounded border p-2 ${
+              t.completed ? 'bg-green-100' : ''
+            }`}
           >
             {iconSrc(t.icon) ? (
               <img
@@ -170,6 +215,26 @@ export default function TodosClient({
             )}
             <span className="font-medium">{t.title}</span>
             <span className="text-xs text-gray-500">{t.priority}</span>
+            {editable && !t.completed && (
+              <Button
+                id={`todo-complete-${t.id}`}
+                size="sm"
+                onClick={() => handleComplete(t.id)}
+              >
+                Completed
+              </Button>
+            )}
+            {editable && (
+              <Button
+                id={`todo-delete-${t.id}`}
+                size="sm"
+                variant="outline"
+                className="text-red-600"
+                onClick={() => handleDelete(t.id)}
+              >
+                Delete
+              </Button>
+            )}
           </li>
         ))}
       </ul>

--- a/drizzle/0030_add_todo_completed.sql
+++ b/drizzle/0030_add_todo_completed.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "todos" ADD COLUMN "completed" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,8 +155,7 @@
       "when": 1756284819554,
       "tag": "0021_force_daily_reports_content_json",
       "breakpoints": true
-    }
-    ,
+    },
     {
       "idx": 22,
       "version": "7",
@@ -197,6 +196,13 @@
       "version": "7",
       "when": 1756284819560,
       "tag": "0029_create_todos",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1756284819561,
+      "tag": "0030_add_todo_completed",
       "breakpoints": true
     }
   ]

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -10,6 +10,7 @@ import {
   uniqueIndex,
   json,
   jsonb,
+  boolean,
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 
@@ -139,6 +140,7 @@ export const todos = pgTable(
     // Allow emoji or data URL
     icon: text('icon'),
     visibility: varchar('visibility', { length: 20 }).default('public'),
+    completed: boolean('completed').default(false).notNull(),
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').defaultNow(),
   },

--- a/lib/todos-store.ts
+++ b/lib/todos-store.ts
@@ -5,6 +5,7 @@ import type { Todo, TodoInput, Visibility } from '@/types/todo';
 
 function sortTodos(list: Todo[]) {
   return list.sort((a, b) => {
+    if (a.completed !== b.completed) return a.completed ? 1 : -1;
     if (b.priority !== a.priority) return b.priority - a.priority;
     return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
   });
@@ -19,6 +20,7 @@ function toTodo(row: typeof todos.$inferSelect): Todo {
     priority: row.priority ?? 0,
     icon: row.icon ?? '✅',
     visibility: (row.visibility as Visibility) ?? 'public',
+    completed: row.completed ?? false,
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
     updatedAt: row.updatedAt?.toISOString() ?? new Date().toISOString(),
   };
@@ -166,6 +168,7 @@ export async function createTodo(
       priority: clamp(input.priority),
       icon: input.icon,
       visibility: input.visibility ?? 'public',
+      completed: input.completed ?? false,
       createdAt: now,
       updatedAt: now,
     })
@@ -178,6 +181,7 @@ export async function createTodo(
       description: todo.description,
       priority: todo.priority,
       icon: todo.icon,
+      completed: todo.completed,
     },
   });
   return todo;
@@ -194,9 +198,11 @@ export async function updateTodo(
     .set({
       title: input.title ? input.title.slice(0, 80) : undefined,
       description: input.description,
-      priority: input.priority !== undefined ? clamp(input.priority) : undefined,
+      priority:
+        input.priority !== undefined ? clamp(input.priority) : undefined,
       icon: input.icon,
       visibility: input.visibility,
+      completed: input.completed,
       updatedAt: now,
     })
     .where(and(eq(todos.userId, Number(userId)), eq(todos.id, id)))
@@ -210,15 +216,13 @@ export async function updateTodo(
       description: todo.description,
       priority: todo.priority,
       icon: todo.icon,
+      completed: todo.completed,
     },
   });
   return todo;
 }
 
-export async function deleteTodo(
-  userId: string,
-  id: number,
-): Promise<boolean> {
+export async function deleteTodo(userId: string, id: number): Promise<boolean> {
   return db.transaction(async (tx) => {
     const [exists] = await tx
       .select({ id: todos.id })
@@ -237,4 +241,3 @@ export async function deleteTodo(
 function clamp(n: number) {
   return Math.max(0, Math.min(100, Math.round(n)));
 }
-

--- a/tests/todos.spec.ts
+++ b/tests/todos.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+// Ensure users can complete and delete to-dos
+// by verifying UI state changes
+
+test('complete and delete todo', async ({ page }) => {
+  const handle = `user${Date.now()}`;
+  const email = `${handle}@example.com`;
+  const password = 'pass1234';
+  await page.goto('/signup');
+  await page.fill('input[placeholder="Name"]', 'Tester');
+  await page.fill('input[placeholder="Handle"]', handle);
+  await page.fill('input[placeholder="Email"]', email);
+  await page.fill('input[placeholder="Password"]', password);
+  await page.click('text=Sign Up');
+
+  await page.goto('/todos');
+  await page.click('button[id^="todo-add-"]');
+  await page.fill('input[id^="todo-title-"]', 'Task1');
+  await page.click('button[id^="todo-submit-"]');
+  const row = page.locator('li:has-text("Task1")');
+  await expect(row).toBeVisible();
+
+  await row.locator('button:has-text("Completed")').click();
+  await expect(row).toHaveClass(/bg-green-100/);
+
+  await row.locator('button:has-text("Delete")').click();
+  await expect(page.locator('li:has-text("Task1")')).toHaveCount(0);
+  await expect(page.locator('text=No to-dos yet.')).toBeVisible();
+});

--- a/types/todo.ts
+++ b/types/todo.ts
@@ -8,6 +8,7 @@ export interface Todo {
   priority: number;
   icon: string;
   visibility: Visibility;
+  completed: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -18,4 +19,5 @@ export interface TodoInput {
   priority: number;
   icon: string;
   visibility?: Visibility;
+  completed?: boolean;
 }


### PR DESCRIPTION
## Summary
- add completed flag to todos with migration
- allow completing and deleting todos in UI
- test completing and deleting a todo

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Could not download Playwright browsers, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1205b4134832a93cb669386a6eb96