### PR TITLE
feat: add completion and deletion for todos

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -285,3 +285,4 @@
 - 2025-10-29: Included user to-dos in planning next-day agent context and updated system prompt for activity planning guidance.
 - 2025-10-29: Added DEV option in settings to unlock the TimeMachine with code "Cake2025" for manual time overrides.
 - 2025-10-29: Guarded planning autosave against stale responses to keep text from disappearing while typing.
+- 2025-10-29: Added completion and delete controls to to-do list, moving finished items under a green Completed section.

--- a/app/(app)/todos/actions.ts
+++ b/app/(app)/todos/actions.ts
@@ -11,18 +11,28 @@ import { revalidatePath } from 'next/cache';
 
 function sanitize(form: FormData) {
   const obj: any = {};
-  for (const [key, value] of form.entries()) {
-    obj[key] = value as any;
+  if (form.has('title')) {
+    obj.title = String(form.get('title') || '').slice(0, 80);
   }
-  obj.priority = clamp(Number(obj.priority));
-  obj.title = String(obj.title || '').slice(0, 80);
-  obj.description = (obj.description || '').toString();
-  obj.icon = typeof obj.icon === 'string' ? obj.icon : '✅';
-  obj.visibility = ['private', 'followers', 'friends', 'public'].includes(
-    obj.visibility,
-  )
-    ? obj.visibility
-    : 'public';
+  if (form.has('description')) {
+    obj.description = (form.get('description') || '').toString();
+  }
+  if (form.has('priority')) {
+    obj.priority = clamp(Number(form.get('priority')));
+  }
+  if (form.has('icon')) {
+    const ic = form.get('icon');
+    obj.icon = typeof ic === 'string' ? ic : '✅';
+  }
+  if (form.has('visibility')) {
+    const vis = form.get('visibility') as string;
+    obj.visibility = ['private', 'followers', 'friends', 'public'].includes(vis)
+      ? vis
+      : 'public';
+  }
+  if (form.has('completed')) {
+    obj.completed = form.get('completed') === 'true';
+  }
   return obj;
 }
 

--- a/app/(app)/todos/client.tsx
+++ b/app/(app)/todos/client.tsx
@@ -5,10 +5,19 @@ import { useState } from 'react';
 import IconPicker from '@/components/icon-picker';
 import type { Todo, TodoInput, Visibility } from '@/types/todo';
 import { useViewContext } from '@/lib/view-context';
-import { createTodo as createAction } from './actions';
+import {
+  createTodo as createAction,
+  updateTodo as updateAction,
+  deleteTodo as deleteAction,
+} from './actions';
 import { Button } from '@/components/ui/button';
 
-const VISIBILITIES: Visibility[] = ['private', 'followers', 'friends', 'public'];
+const VISIBILITIES: Visibility[] = [
+  'private',
+  'followers',
+  'friends',
+  'public',
+];
 
 function sortTodos(list: Todo[]) {
   return [...list].sort((a, b) => {
@@ -31,7 +40,7 @@ export default function TodosClient({
   initialTodos: Todo[];
 }) {
   const { editable } = useViewContext();
-  const [todos, setTodos] = useState(() => sortTodos(initialTodos));
+  const [todos, setTodos] = useState(() => initialTodos);
   const [form, setForm] = useState<TodoInput>({
     title: '',
     description: '',
@@ -51,7 +60,7 @@ export default function TodosClient({
     fd.append('icon', form.icon);
     fd.append('visibility', form.visibility || 'public');
     const todo = await createAction(Number(userId), fd);
-    setTodos((prev) => sortTodos([...prev, todo]));
+    setTodos((prev) => [...prev, todo]);
     setForm({
       title: '',
       description: '',
@@ -60,6 +69,24 @@ export default function TodosClient({
       visibility: 'public',
     });
     setOpen(false);
+  }
+
+  async function handleComplete(id: number) {
+    if (!editable) return;
+    const fd = new FormData();
+    fd.append('completed', 'true');
+    const todo = await updateAction(Number(userId), id, fd);
+    if (todo) {
+      setTodos((prev) => prev.map((t) => (t.id === id ? todo : t)));
+    }
+  }
+
+  async function handleDelete(id: number) {
+    if (!editable) return;
+    const ok = await deleteAction(Number(userId), id);
+    if (ok) {
+      setTodos((prev) => prev.filter((t) => t.id !== id));
+    }
   }
 
   return (
@@ -77,7 +104,10 @@ export default function TodosClient({
             className="w-full max-w-sm space-y-2 rounded bg-white p-6 shadow-lg"
           >
             <div>
-              <label className="block text-sm font-medium" htmlFor={`todo-title-${userId}`}>
+              <label
+                className="block text-sm font-medium"
+                htmlFor={`todo-title-${userId}`}
+              >
                 Title
               </label>
               <input
@@ -90,7 +120,10 @@ export default function TodosClient({
               />
             </div>
             <div>
-              <label className="block text-sm font-medium" htmlFor={`todo-desc-${userId}`}>
+              <label
+                className="block text-sm font-medium"
+                htmlFor={`todo-desc-${userId}`}
+              >
                 Description
               </label>
               <textarea
@@ -98,11 +131,16 @@ export default function TodosClient({
                 className="w-full border p-1"
                 value={form.description}
                 rows={3}
-                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                onChange={(e) =>
+                  setForm({ ...form, description: e.target.value })
+                }
               />
             </div>
             <div>
-              <label className="block text-sm font-medium" htmlFor={`todo-pri-${userId}`}>
+              <label
+                className="block text-sm font-medium"
+                htmlFor={`todo-pri-${userId}`}
+              >
                 Priority ({form.priority})
               </label>
               <input
@@ -111,7 +149,9 @@ export default function TodosClient({
                 min={0}
                 max={100}
                 value={form.priority}
-                onChange={(e) => setForm({ ...form, priority: Number(e.target.value) })}
+                onChange={(e) =>
+                  setForm({ ...form, priority: Number(e.target.value) })
+                }
               />
             </div>
             <div>
@@ -153,27 +193,89 @@ export default function TodosClient({
           </form>
         </div>
       )}
-      <ul className="space-y-2">
-        {todos.map((t) => (
-          <li
-            key={t.id}
-            className="flex items-center gap-2 rounded border p-2"
-          >
-            {iconSrc(t.icon) ? (
-              <img
-                src={iconSrc(t.icon) as string}
-                alt="icon"
-                className="h-6 w-6 rounded object-cover"
-              />
-            ) : (
-              <span>{t.icon}</span>
+      {(() => {
+        const active = sortTodos(todos.filter((t) => !t.completed));
+        const done = sortTodos(todos.filter((t) => t.completed));
+        return (
+          <>
+            <ul className="space-y-2">
+              {active.map((t) => (
+                <li
+                  key={t.id}
+                  className="flex items-center gap-2 rounded border p-2"
+                >
+                  {iconSrc(t.icon) ? (
+                    <img
+                      src={iconSrc(t.icon) as string}
+                      alt="icon"
+                      className="h-6 w-6 rounded object-cover"
+                    />
+                  ) : (
+                    <span>{t.icon}</span>
+                  )}
+                  <span className="flex-1 font-medium">{t.title}</span>
+                  <span className="text-xs text-gray-500">{t.priority}</span>
+                  {editable && (
+                    <>
+                      {!t.completed && (
+                        <Button size="sm" onClick={() => handleComplete(t.id)}>
+                          Completed
+                        </Button>
+                      )}
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleDelete(t.id)}
+                      >
+                        Delete
+                      </Button>
+                    </>
+                  )}
+                </li>
+              ))}
+            </ul>
+            {done.length > 0 && (
+              <>
+                <h3 className="mt-4 font-semibold">Completed</h3>
+                <ul className="space-y-2">
+                  {done.map((t) => (
+                    <li
+                      key={t.id}
+                      className="flex items-center gap-2 rounded border p-2 bg-green-100"
+                    >
+                      {iconSrc(t.icon) ? (
+                        <img
+                          src={iconSrc(t.icon) as string}
+                          alt="icon"
+                          className="h-6 w-6 rounded object-cover"
+                        />
+                      ) : (
+                        <span>{t.icon}</span>
+                      )}
+                      <span className="flex-1 font-medium">{t.title}</span>
+                      <span className="text-xs text-gray-500">
+                        {t.priority}
+                      </span>
+                      {editable && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleDelete(t.id)}
+                        >
+                          Delete
+                        </Button>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </>
             )}
-            <span className="font-medium">{t.title}</span>
-            <span className="text-xs text-gray-500">{t.priority}</span>
-          </li>
-        ))}
-      </ul>
-      {todos.length === 0 && <p id={`todo-empty-${userId}`}>No to-dos yet.</p>}
+            {todos.length === 0 && (
+              <p id={`todo-empty-${userId}`}>No to-dos yet.</p>
+            )}
+          </>
+        );
+      })()}
     </div>
   );
 }

--- a/drizzle/0030_add_todos_completed.sql
+++ b/drizzle/0030_add_todos_completed.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "todos" ADD COLUMN "completed" boolean DEFAULT false;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,8 +155,7 @@
       "when": 1756284819554,
       "tag": "0021_force_daily_reports_content_json",
       "breakpoints": true
-    }
-    ,
+    },
     {
       "idx": 22,
       "version": "7",
@@ -197,6 +196,13 @@
       "version": "7",
       "when": 1756284819560,
       "tag": "0029_create_todos",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1756284819561,
+      "tag": "0030_add_todos_completed",
       "breakpoints": true
     }
   ]

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -10,6 +10,7 @@ import {
   uniqueIndex,
   json,
   jsonb,
+  boolean,
 } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 
@@ -139,6 +140,7 @@ export const todos = pgTable(
     // Allow emoji or data URL
     icon: text('icon'),
     visibility: varchar('visibility', { length: 20 }).default('public'),
+    completed: boolean('completed').notNull().default(false),
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').defaultNow(),
   },

--- a/lib/todos-store.ts
+++ b/lib/todos-store.ts
@@ -19,6 +19,7 @@ function toTodo(row: typeof todos.$inferSelect): Todo {
     priority: row.priority ?? 0,
     icon: row.icon ?? '✅',
     visibility: (row.visibility as Visibility) ?? 'public',
+    completed: row.completed ?? false,
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
     updatedAt: row.updatedAt?.toISOString() ?? new Date().toISOString(),
   };
@@ -166,6 +167,7 @@ export async function createTodo(
       priority: clamp(input.priority),
       icon: input.icon,
       visibility: input.visibility ?? 'public',
+      completed: input.completed ?? false,
       createdAt: now,
       updatedAt: now,
     })
@@ -178,6 +180,7 @@ export async function createTodo(
       description: todo.description,
       priority: todo.priority,
       icon: todo.icon,
+      completed: todo.completed,
     },
   });
   return todo;
@@ -194,9 +197,11 @@ export async function updateTodo(
     .set({
       title: input.title ? input.title.slice(0, 80) : undefined,
       description: input.description,
-      priority: input.priority !== undefined ? clamp(input.priority) : undefined,
+      priority:
+        input.priority !== undefined ? clamp(input.priority) : undefined,
       icon: input.icon,
       visibility: input.visibility,
+      completed: input.completed !== undefined ? input.completed : undefined,
       updatedAt: now,
     })
     .where(and(eq(todos.userId, Number(userId)), eq(todos.id, id)))
@@ -210,15 +215,13 @@ export async function updateTodo(
       description: todo.description,
       priority: todo.priority,
       icon: todo.icon,
+      completed: todo.completed,
     },
   });
   return todo;
 }
 
-export async function deleteTodo(
-  userId: string,
-  id: number,
-): Promise<boolean> {
+export async function deleteTodo(userId: string, id: number): Promise<boolean> {
   return db.transaction(async (tx) => {
     const [exists] = await tx
       .select({ id: todos.id })
@@ -237,4 +240,3 @@ export async function deleteTodo(
 function clamp(n: number) {
   return Math.max(0, Math.min(100, Math.round(n)));
 }
-

--- a/types/todo.ts
+++ b/types/todo.ts
@@ -8,6 +8,7 @@ export interface Todo {
   priority: number;
   icon: string;
   visibility: Visibility;
+  completed: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -18,4 +19,5 @@ export interface TodoInput {
   priority: number;
   icon: string;
   visibility?: Visibility;
+  completed?: boolean;
 }


### PR DESCRIPTION
## Summary
- allow marking todos as completed with a new boolean field
- add delete action and UI buttons for todos
- show completed todos in a separate green section

## Testing
- `npx prettier --write types/todo.ts lib/db/schema.ts drizzle/meta/_journal.json lib/todos-store.ts "app/(app)/todos/actions.ts" "app/(app)/todos/client.tsx" UPDATE.md`
- `pnpm lint`
- `pnpm type-check` *(fails: Command "type-check" not found)*
- `pnpm test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68c1205b4134832a93cb669386a6eb96