### PR TITLE
Add to-do deadlines with editing and countdown

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -286,3 +286,4 @@
 - 2025-10-29: Added DEV option in settings to unlock the TimeMachine with code "Cake2025" for manual time overrides.
 - 2025-10-29: Guarded planning autosave against stale responses to keep text from disappearing while typing.
 - 2025-10-29: Added completion and delete controls to to-do list, moving finished items under a green Completed section.
+- 2025-10-29: Introduced "finish before" deadlines on to-dos with color-coded time left and edit capability.

--- a/app/(app)/todos/actions.ts
+++ b/app/(app)/todos/actions.ts
@@ -30,6 +30,11 @@ function sanitize(form: FormData) {
       ? vis
       : 'public';
   }
+  if (form.has('dueAt')) {
+    const val = form.get('dueAt');
+    const d = val ? new Date(String(val)) : null;
+    if (d && !isNaN(d.getTime())) obj.dueAt = d.toISOString();
+  }
   if (form.has('completed')) {
     obj.completed = form.get('completed') === 'true';
   }

--- a/app/(app)/todos/client.tsx
+++ b/app/(app)/todos/client.tsx
@@ -1,7 +1,7 @@
 'use client';
 /* eslint-disable @next/next/no-img-element */
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import IconPicker from '@/components/icon-picker';
 import type { Todo, TodoInput, Visibility } from '@/types/todo';
 import { useViewContext } from '@/lib/view-context';
@@ -32,6 +32,30 @@ function iconSrc(ic: string) {
   return null;
 }
 
+function toLocalInput(s: string) {
+  const d = new Date(s);
+  const off = d.getTimezoneOffset();
+  const local = new Date(d.getTime() - off * 60000);
+  return local.toISOString().slice(0, 16);
+}
+
+function formatTimeLeft(due: string, now: number) {
+  const ms = new Date(due).getTime() - now;
+  if (ms <= 0) return { text: 'Past due', className: 'text-red-500' };
+  const totalMinutes = Math.floor(ms / 60000);
+  const days = Math.floor(totalMinutes / (60 * 24));
+  const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+  const minutes = totalMinutes % 60;
+  let text = '';
+  if (days > 0) text = `${days}d ${hours}h`;
+  else if (hours > 0) text = `${hours}h ${minutes}m`;
+  else text = `${minutes}m`;
+  let className = 'text-green-500';
+  if (ms < 5 * 60 * 60 * 1000) className = 'text-red-500';
+  else if (ms < 2 * 24 * 60 * 60 * 1000) className = 'text-orange-500';
+  return { text, className };
+}
+
 export default function TodosClient({
   userId,
   initialTodos,
@@ -47,8 +71,16 @@ export default function TodosClient({
     priority: 50,
     icon: '✅',
     visibility: 'public',
+    dueAt: '',
   });
   const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<Todo | null>(null);
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60000);
+    return () => clearInterval(id);
+  }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -59,15 +91,29 @@ export default function TodosClient({
     fd.append('priority', String(form.priority));
     fd.append('icon', form.icon);
     fd.append('visibility', form.visibility || 'public');
-    const todo = await createAction(Number(userId), fd);
-    setTodos((prev) => [...prev, todo]);
+    if (form.dueAt) {
+      fd.append('dueAt', new Date(form.dueAt).toISOString());
+    }
+    if (editing) {
+      const todo = await updateAction(Number(userId), editing.id, fd);
+      if (todo) {
+        setTodos((prev) =>
+          prev.map((t) => (t.id === editing.id ? todo : t)),
+        );
+      }
+    } else {
+      const todo = await createAction(Number(userId), fd);
+      setTodos((prev) => [...prev, todo]);
+    }
     setForm({
       title: '',
       description: '',
       priority: 50,
       icon: '✅',
       visibility: 'public',
+      dueAt: '',
     });
+    setEditing(null);
     setOpen(false);
   }
 
@@ -89,10 +135,38 @@ export default function TodosClient({
     }
   }
 
+  function handleEdit(todo: Todo) {
+    if (!editable) return;
+    setEditing(todo);
+    setForm({
+      title: todo.title,
+      description: todo.description,
+      priority: todo.priority,
+      icon: todo.icon,
+      visibility: todo.visibility,
+      dueAt: todo.dueAt ? toLocalInput(todo.dueAt) : '',
+    });
+    setOpen(true);
+  }
+
   return (
     <div id={`todo-list-${userId}`} className="space-y-4 p-4">
       {editable && (
-        <Button id={`todo-add-${userId}`} onClick={() => setOpen(true)}>
+        <Button
+          id={`todo-add-${userId}`}
+          onClick={() => {
+            setEditing(null);
+            setForm({
+              title: '',
+              description: '',
+              priority: 50,
+              icon: '✅',
+              visibility: 'public',
+              dueAt: '',
+            });
+            setOpen(true);
+          }}
+        >
           + Add To Do
         </Button>
       )}
@@ -139,6 +213,21 @@ export default function TodosClient({
             <div>
               <label
                 className="block text-sm font-medium"
+                htmlFor={`todo-due-${userId}`}
+              >
+                Finish Before
+              </label>
+              <input
+                id={`todo-due-${userId}`}
+                type="datetime-local"
+                className="w-full border p-1"
+                value={form.dueAt}
+                onChange={(e) => setForm({ ...form, dueAt: e.target.value })}
+              />
+            </div>
+            <div>
+              <label
+                className="block text-sm font-medium"
                 htmlFor={`todo-pri-${userId}`}
               >
                 Priority ({form.priority})
@@ -180,7 +269,7 @@ export default function TodosClient({
             </div>
             <div className="flex gap-2">
               <Button id={`todo-submit-${userId}`} type="submit">
-                Add
+                {editing ? 'Save' : 'Add'}
               </Button>
               <Button
                 type="button"
@@ -199,64 +288,49 @@ export default function TodosClient({
         return (
           <>
             <ul className="space-y-2">
-              {active.map((t) => (
-                <li
-                  key={t.id}
-                  className="flex items-center gap-2 rounded border p-2"
-                >
-                  {iconSrc(t.icon) ? (
-                    <img
-                      src={iconSrc(t.icon) as string}
-                      alt="icon"
-                      className="h-6 w-6 rounded object-cover"
-                    />
-                  ) : (
-                    <span>{t.icon}</span>
-                  )}
-                  <span className="flex-1 font-medium">{t.title}</span>
-                  <span className="text-xs text-gray-500">{t.priority}</span>
-                  {editable && (
-                    <>
-                      {!t.completed && (
-                        <Button size="sm" onClick={() => handleComplete(t.id)}>
-                          Completed
+              {active.map((t) => {
+                const info = t.dueAt ? formatTimeLeft(t.dueAt, now) : null;
+                return (
+                  <li
+                    key={t.id}
+                    className="flex items-center gap-2 rounded border p-2"
+                  >
+                    {iconSrc(t.icon) ? (
+                      <img
+                        src={iconSrc(t.icon) as string}
+                        alt="icon"
+                        className="h-6 w-6 rounded object-cover"
+                      />
+                    ) : (
+                      <span>{t.icon}</span>
+                    )}
+                    <div className="flex-1">
+                      <span className="font-medium">{t.title}</span>
+                      {t.dueAt && (
+                        <span className={`block text-xs ${info!.className}`}>
+                          Finish before {new Date(t.dueAt).toLocaleString()} (
+                          {info!.text} left)
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-xs text-gray-500">{t.priority}</span>
+                    {editable && (
+                      <>
+                        {!t.completed && (
+                          <Button
+                            size="sm"
+                            onClick={() => handleComplete(t.id)}
+                          >
+                            Completed
+                          </Button>
+                        )}
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleEdit(t)}
+                        >
+                          Edit
                         </Button>
-                      )}
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => handleDelete(t.id)}
-                      >
-                        Delete
-                      </Button>
-                    </>
-                  )}
-                </li>
-              ))}
-            </ul>
-            {done.length > 0 && (
-              <>
-                <h3 className="mt-4 font-semibold">Completed</h3>
-                <ul className="space-y-2">
-                  {done.map((t) => (
-                    <li
-                      key={t.id}
-                      className="flex items-center gap-2 rounded border p-2 bg-green-100"
-                    >
-                      {iconSrc(t.icon) ? (
-                        <img
-                          src={iconSrc(t.icon) as string}
-                          alt="icon"
-                          className="h-6 w-6 rounded object-cover"
-                        />
-                      ) : (
-                        <span>{t.icon}</span>
-                      )}
-                      <span className="flex-1 font-medium">{t.title}</span>
-                      <span className="text-xs text-gray-500">
-                        {t.priority}
-                      </span>
-                      {editable && (
                         <Button
                           size="sm"
                           variant="outline"
@@ -264,9 +338,67 @@ export default function TodosClient({
                         >
                           Delete
                         </Button>
-                      )}
-                    </li>
-                  ))}
+                      </>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+            {done.length > 0 && (
+              <>
+                <h3 className="mt-4 font-semibold">Completed</h3>
+                <ul className="space-y-2">
+                  {done.map((t) => {
+                    const info = t.dueAt ? formatTimeLeft(t.dueAt, now) : null;
+                    return (
+                      <li
+                        key={t.id}
+                        className="flex items-center gap-2 rounded border p-2 bg-green-100"
+                      >
+                        {iconSrc(t.icon) ? (
+                          <img
+                            src={iconSrc(t.icon) as string}
+                            alt="icon"
+                            className="h-6 w-6 rounded object-cover"
+                          />
+                        ) : (
+                          <span>{t.icon}</span>
+                        )}
+                        <div className="flex-1">
+                          <span className="font-medium">{t.title}</span>
+                          {t.dueAt && (
+                            <span
+                              className={`block text-xs ${info!.className}`}
+                            >
+                              Finish before {new Date(t.dueAt).toLocaleString()} (
+                              {info!.text} left)
+                            </span>
+                          )}
+                        </div>
+                        <span className="text-xs text-gray-500">
+                          {t.priority}
+                        </span>
+                        {editable && (
+                          <>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => handleEdit(t)}
+                            >
+                              Edit
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => handleDelete(t.id)}
+                            >
+                              Delete
+                            </Button>
+                          </>
+                        )}
+                      </li>
+                    );
+                  })}
                 </ul>
               </>
             )}

--- a/drizzle/0031_add_todos_due_at.sql
+++ b/drizzle/0031_add_todos_due_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "todos" ADD COLUMN "due_at" timestamp;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1756284819561,
       "tag": "0030_add_todos_completed",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1756284819562,
+      "tag": "0031_add_todos_due_at",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -141,6 +141,7 @@ export const todos = pgTable(
     icon: text('icon'),
     visibility: varchar('visibility', { length: 20 }).default('public'),
     completed: boolean('completed').notNull().default(false),
+    dueAt: timestamp('due_at'),
     createdAt: timestamp('created_at').defaultNow(),
     updatedAt: timestamp('updated_at').defaultNow(),
   },

--- a/lib/todos-store.ts
+++ b/lib/todos-store.ts
@@ -20,6 +20,7 @@ function toTodo(row: typeof todos.$inferSelect): Todo {
     icon: row.icon ?? '✅',
     visibility: (row.visibility as Visibility) ?? 'public',
     completed: row.completed ?? false,
+    dueAt: row.dueAt?.toISOString() ?? null,
     createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
     updatedAt: row.updatedAt?.toISOString() ?? new Date().toISOString(),
   };
@@ -168,6 +169,7 @@ export async function createTodo(
       icon: input.icon,
       visibility: input.visibility ?? 'public',
       completed: input.completed ?? false,
+      dueAt: input.dueAt ? new Date(input.dueAt) : undefined,
       createdAt: now,
       updatedAt: now,
     })
@@ -181,6 +183,7 @@ export async function createTodo(
       priority: todo.priority,
       icon: todo.icon,
       completed: todo.completed,
+      dueAt: todo.dueAt,
     },
   });
   return todo;
@@ -202,6 +205,7 @@ export async function updateTodo(
       icon: input.icon,
       visibility: input.visibility,
       completed: input.completed !== undefined ? input.completed : undefined,
+      dueAt: input.dueAt ? new Date(input.dueAt) : undefined,
       updatedAt: now,
     })
     .where(and(eq(todos.userId, Number(userId)), eq(todos.id, id)))
@@ -216,6 +220,7 @@ export async function updateTodo(
       priority: todo.priority,
       icon: todo.icon,
       completed: todo.completed,
+      dueAt: todo.dueAt,
     },
   });
   return todo;

--- a/types/todo.ts
+++ b/types/todo.ts
@@ -9,6 +9,7 @@ export interface Todo {
   icon: string;
   visibility: Visibility;
   completed: boolean;
+  dueAt: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -20,4 +21,5 @@ export interface TodoInput {
   icon: string;
   visibility?: Visibility;
   completed?: boolean;
+  dueAt?: string;
 }


### PR DESCRIPTION
## Summary
- add `dueAt` column to todos and wire through server actions
- show "Finish Before" field with color-coded time-left countdown
- allow editing existing to-dos

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_68c1258df290832a97b1c1d69c31a874