### PR TITLE
feat: show login error message

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -290,3 +290,4 @@
 - 2025-10-29: Excluded completed to-dos from planning and live agent prompts and added time-until-due context for each remaining task.
 - 2025-10-29: Added exact due times to to-do context and noted planning date with pre-deadline scheduling guidance for planning agent.
 - 2025-10-29: Displayed original activity description during planning review to aid feedback writing and added test coverage.
+- 2025-10-29: Displayed error message on failed login attempts and added test coverage.

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -2,12 +2,15 @@
 
 import { signIn } from 'next-auth/react';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 
 export default function SignInPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const router = useRouter();
 
   return (
     <main className="flex min-h-screen items-center justify-center p-6">
@@ -16,12 +19,22 @@ export default function SignInPage() {
         <form
           onSubmit={async (e) => {
             e.preventDefault();
-            await signIn('credentials', {
-              email,
-              password,
-              redirect: true,
-              callbackUrl: '/flavors',
-            });
+            setError('');
+            try {
+              const res = await signIn('credentials', {
+                email,
+                password,
+                redirect: false,
+                callbackUrl: '/flavors',
+              });
+              if (!res || res.error) {
+                setError('Invalid email or password');
+                return;
+              }
+              if (res.url) router.push(res.url);
+            } catch {
+              setError('Invalid email or password');
+            }
           }}
           className="flex flex-col gap-4"
         >
@@ -40,6 +53,11 @@ export default function SignInPage() {
             className="border p-2"
           />
           <Button type="submit">Enter</Button>
+          {error && (
+            <p className="text-sm text-red-600" role="alert">
+              {error}
+            </p>
+          )}
         </form>
         <p className="mt-4 text-center">
           <Link href="/signup" className="text-blue-600">

--- a/tests/signin-error.spec.ts
+++ b/tests/signin-error.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3001';
+
+test('shows error message on invalid login', async ({ page }) => {
+  await page.goto(`${BASE_URL}/signin`);
+  await page.getByPlaceholder('Email').fill('wrong@example.com');
+  await page.getByPlaceholder('Password').fill('wrongpass');
+  await page.getByRole('button', { name: 'Enter' }).click();
+  await expect(
+    page.getByRole('alert', { name: 'Invalid email or password' }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- display error message when sign-in fails
- cover invalid login with Playwright spec

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test tests/signin-error.spec.ts` *(fails: getByRole('alert') not found, NextAuth missing config)*

------
https://chatgpt.com/codex/tasks/task_e_68c154007408832a83bf542752fa0434