### PR TITLE
Add manual password reset utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,15 @@
 
 1. Place your favicon image at `public/Favicon_pieceofcake.png`.
 2. The app automatically references this file, so ensure the filename matches when deploying.
+
+## Manual password reset
+
+Use the provided script to set a new password for a user when you know their
+database ID.
+
+```
+pnpm tsx scripts/reset-password.ts <userId> <newPassword>
+```
+
+The script hashes the supplied password and updates the user record in the
+database.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -291,3 +291,4 @@
 - 2025-10-29: Added exact due times to to-do context and noted planning date with pre-deadline scheduling guidance for planning agent.
 - 2025-10-29: Displayed original activity description during planning review to aid feedback writing and added test coverage.
 - 2025-10-29: Displayed error message on failed login attempts and added test coverage.
+- 2025-10-30: Added script and helper to reset user passwords by ID and documented usage.

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -27,6 +27,23 @@ export function verifyPassword(password: string, hash: string): boolean {
   return timingSafeEqual(derived, keyBuf);
 }
 
+/**
+ * Manually reset a user's password.
+ * Intended for administrative scripts where the user has been identified
+ * by their numeric database ID.
+ */
+export async function resetUserPassword(userId: number, newPassword: string) {
+  if (!newPassword) throw new Error('New password required');
+  const passwordHash = hashPassword(newPassword);
+  const [user] = await db
+    .update(users)
+    .set({ passwordHash })
+    .where(eq(users.id, userId))
+    .returning({ id: users.id });
+  if (!user) throw new Error('User not found');
+  return user;
+}
+
 export async function createUser(input: NewUser) {
   const passwordHash = hashPassword(input.password);
   const [user] = await db

--- a/scripts/reset-password.ts
+++ b/scripts/reset-password.ts
@@ -1,0 +1,25 @@
+import { resetUserPassword } from '../lib/users';
+import { db } from '../lib/db';
+
+async function main() {
+  const [idArg, newPassword] = process.argv.slice(2);
+  if (!idArg || !newPassword) {
+    console.error(
+      'Usage: pnpm tsx scripts/reset-password.ts <userId> <newPassword>',
+    );
+    process.exit(1);
+  }
+  const userId = Number(idArg);
+  if (!Number.isInteger(userId)) {
+    console.error('userId must be a number');
+    process.exit(1);
+  }
+  await resetUserPassword(userId, newPassword);
+  console.log(`Password updated for user ${userId}`);
+  await (db as any).$client.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add helper to update user passwords by ID
- document and script a manual password reset workflow

## Testing
- `pnpm lint`
- `pnpm tsc`
- `pnpm test` *(fails: ELIFECYCLE Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c279693fe8832ab2f713937328164f