### PR TITLE
Add configurable 12-hour review extension

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -292,3 +292,5 @@
 - 2025-10-29: Displayed original activity description during planning review to aid feedback writing and added test coverage.
 - 2025-10-29: Displayed error message on failed login attempts and added test coverage.
 - 2025-10-30: Added script and helper to reset user passwords by ID and documented usage.
+
+- 2025-10-18: Added 12H review extension with reason capture, review date freezing across planning and reports, and a nav indicator that shows the active reason in live, viewer, and historical modes.

--- a/app/(app)/planning/page.tsx
+++ b/app/(app)/planning/page.tsx
@@ -5,6 +5,7 @@ import PlanningLanding from './client';
 import { cookies } from 'next/headers';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import { resolvePlanDate, toYMD } from '@/lib/plan-date';
+import { resolveReviewDate } from '@/lib/review-date';
 
 export default async function PlanningPage({
   searchParams,
@@ -19,6 +20,7 @@ export default async function PlanningPage({
   const req = { cookies: cookieStore, searchParams: params };
   const liveInfo = resolvePlanDate('live', me, req);
   const nextInfo = resolvePlanDate('next', me, req);
+  const reviewInfo = await resolveReviewDate(me, me.id, req);
   const liveLabel = liveInfo.date.toLocaleDateString('en-US', {
     weekday: 'long',
     month: 'short',
@@ -30,6 +32,12 @@ export default async function PlanningPage({
     month: 'short',
     day: 'numeric',
     timeZone: nextInfo.tz,
+  });
+  const reviewLabel = reviewInfo.date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    timeZone: reviewInfo.tz,
   });
   const todayStr = toYMD(liveInfo.today, liveInfo.tz);
   const overrideLabel = liveInfo.override
@@ -44,7 +52,7 @@ export default async function PlanningPage({
         today={todayStr}
         nextLabel={nextLabel}
         liveLabel={liveLabel}
-        reviewLabel={liveLabel}
+        reviewLabel={reviewLabel}
       />
     </>
   );

--- a/app/(app)/planning/review/page.tsx
+++ b/app/(app)/planning/review/page.tsx
@@ -2,13 +2,14 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { notFound } from 'next/navigation';
 import { cookies } from 'next/headers';
-import { resolvePlanDate, toYMD } from '@/lib/plan-date';
+import { toYMD } from '@/lib/plan-date';
 import { getPlanStrict } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from '../next/client';
 import { listIngredients } from '@/lib/ingredients-store';
 import { listFlavors } from '@/lib/flavors-store';
 import { listAllSubflavors } from '@/lib/subflavors-store';
+import { resolveReviewDate } from '@/lib/review-date';
 
 export const revalidate = 0;
 
@@ -23,11 +24,11 @@ export default async function PlanningReviewPage({
   const cookieStore = await cookies();
   const params = searchParams ? await searchParams : undefined;
   const showDailyAim = params?.showDailyAim === '1';
-  const info = resolvePlanDate('review', me, {
+  const info = await resolveReviewDate(me, me.id, {
     cookies: cookieStore,
     searchParams: params,
   });
-  const dateStr = toYMD(info.date, info.tz);
+  const dateStr = info.reviewYMD;
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getPlanStrict(me.id, dateStr);
   const ingredients = await listIngredients(String(me.id), me.id);

--- a/app/(app)/settings/account/page.tsx
+++ b/app/(app)/settings/account/page.tsx
@@ -9,6 +9,11 @@ export default function AccountSettingsPage() {
   const [visibility, setVisibility] = useState<'open' | 'closed' | 'private'>('open');
   const [coachTone, setCoachTone] = useState('tone_medium');
   const [saving, setSaving] = useState(false);
+  const [showExtraDialog, setShowExtraDialog] = useState(false);
+  const [extraReason, setExtraReason] = useState('');
+  const [extraError, setExtraError] = useState('');
+  const [activatingExtra, setActivatingExtra] = useState(false);
+  const [activationMessage, setActivationMessage] = useState('');
   useEffect(() => {
     fetch('/api/account/visibility')
       .then((res) => (res.ok ? res.json() : null))
@@ -33,6 +38,52 @@ export default function AccountSettingsPage() {
       }),
     ]);
     setSaving(false);
+  }
+
+  function openExtraDialog() {
+    setExtraReason('');
+    setExtraError('');
+    setShowExtraDialog(true);
+  }
+
+  function closeExtraDialog() {
+    if (activatingExtra) return;
+    setShowExtraDialog(false);
+  }
+
+  async function activateExtraTime() {
+    if (!editable) return;
+    const reason = extraReason.trim();
+    if (!reason) {
+      setExtraError('Please tell us why you need the extra time.');
+      return;
+    }
+    setActivatingExtra(true);
+    setExtraError('');
+    try {
+      const res = await fetch('/api/review-extension', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        setExtraError(data?.error || 'Unable to activate extra time.');
+        return;
+      }
+      setShowExtraDialog(false);
+      setExtraReason('');
+      setActivationMessage(
+        '12H extra time activated. Finish yesterday’s review before noon and the calendar will still turn green.',
+      );
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('review-extension:changed'));
+      }
+    } catch (err) {
+      setExtraError('Unable to activate extra time.');
+    } finally {
+      setActivatingExtra(false);
+    }
   }
 
   return (
@@ -68,6 +119,26 @@ export default function AccountSettingsPage() {
           ))}
         </select>
       </label>
+      <div className="space-y-3 rounded-lg border border-[var(--review)]/40 bg-[var(--review)]/5 p-4">
+        <h2 className="text-lg font-semibold text-[var(--review)]">
+          Need 12H extra review time?
+        </h2>
+        <p className="text-sm text-neutral-700">
+          Freeze yesterday’s review window until 12:00 the next day. Share your
+          reason before activating so everyone understands the context.
+        </p>
+        <button
+          type="button"
+          onClick={editable ? openExtraDialog : undefined}
+          disabled={!editable}
+          className="rounded bg-[var(--review)] px-4 py-2 text-sm font-semibold text-white shadow hover:opacity-90 disabled:opacity-50"
+        >
+          Activate 12H extra time
+        </button>
+        {activationMessage && (
+          <p className="text-sm text-green-600">{activationMessage}</p>
+        )}
+      </div>
       <button
         onClick={editable ? save : undefined}
         disabled={saving || !editable}
@@ -75,6 +146,55 @@ export default function AccountSettingsPage() {
       >
         Save
       </button>
+      {showExtraDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="extra-time-heading"
+            className="w-full max-w-lg rounded-xl bg-white p-6 shadow-2xl"
+          >
+            <h2
+              id="extra-time-heading"
+              className="text-lg font-semibold text-[var(--review)]"
+            >
+              Why do you need 12H extra time?
+            </h2>
+            <p className="mt-2 text-sm text-neutral-600">
+              This note is visible to viewers so they know why the review window
+              stayed open.
+            </p>
+            <textarea
+              value={extraReason}
+              onChange={(e) => setExtraReason(e.target.value)}
+              disabled={activatingExtra}
+              className="mt-4 h-40 w-full rounded border px-3 py-2 text-sm focus:outline-[var(--review)]"
+              placeholder="Share what kept you past midnight, or why you’re finishing the review now."
+            />
+            {extraError && (
+              <p className="mt-2 text-sm text-red-600">{extraError}</p>
+            )}
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeExtraDialog}
+                disabled={activatingExtra}
+                className="rounded border border-neutral-300 px-4 py-2 text-sm hover:bg-neutral-100 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={activateExtraTime}
+                disabled={activatingExtra}
+                className="rounded bg-[var(--review)] px-4 py-2 text-sm font-semibold text-white shadow hover:opacity-90 disabled:opacity-50"
+              >
+                {activatingExtra ? 'Activating…' : 'Activate extra time'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/(view)/view/[viewId]/planning/page.tsx
+++ b/app/(view)/view/[viewId]/planning/page.tsx
@@ -4,6 +4,7 @@ import PlanningLanding from '@/app/(app)/planning/client';
 import { cookies } from 'next/headers';
 import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import TimeOverrideBadge from '@/components/time-override-badge';
+import { resolveReviewDate } from '@/lib/review-date';
 
 export default async function ViewPlanningPage({
   params,
@@ -20,6 +21,7 @@ export default async function ViewPlanningPage({
   const req = { cookies: cookieStore, searchParams: paramsObj };
   const liveInfo = resolvePlanDate('live', user, req);
   const nextInfo = resolvePlanDate('next', user, req);
+  const reviewInfo = await resolveReviewDate(user, user.id, req);
   const liveLabel = liveInfo.date.toLocaleDateString('en-US', {
     weekday: 'long',
     month: 'short',
@@ -31,6 +33,12 @@ export default async function ViewPlanningPage({
     month: 'short',
     day: 'numeric',
     timeZone: nextInfo.tz,
+  });
+  const reviewLabel = reviewInfo.date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    timeZone: reviewInfo.tz,
   });
   const todayStr = toYMD(liveInfo.today, liveInfo.tz);
   const overrideLabel = liveInfo.override
@@ -45,7 +53,7 @@ export default async function ViewPlanningPage({
         today={todayStr}
         nextLabel={nextLabel}
         liveLabel={liveLabel}
-        reviewLabel={liveLabel}
+        reviewLabel={reviewLabel}
       />
     </section>
   );

--- a/app/(view)/view/[viewId]/planning/review/page.tsx
+++ b/app/(view)/view/[viewId]/planning/review/page.tsx
@@ -1,11 +1,12 @@
 import { getUserByViewId } from '@/lib/users';
 import { notFound } from 'next/navigation';
 import { cookies } from 'next/headers';
-import { resolvePlanDate, toYMD } from '@/lib/plan-date';
+import { toYMD } from '@/lib/plan-date';
 import { getPlanStrict } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from '@/app/(app)/planning/next/client';
 import { listIngredients } from '@/lib/ingredients-store';
+import { resolveReviewDate } from '@/lib/review-date';
 
 export const revalidate = 0;
 
@@ -21,11 +22,11 @@ export default async function ViewPlanningReviewPage({
   if (!user) notFound();
   const cookieStore = await cookies();
   const paramsObj = searchParams ? await searchParams : undefined;
-  const info = resolvePlanDate('review', user, {
+  const info = await resolveReviewDate(user, user.id, {
     cookies: cookieStore,
     searchParams: paramsObj,
   });
-  const dateStr = toYMD(info.date, info.tz);
+  const dateStr = info.reviewYMD;
   const todayStr = toYMD(info.today, info.tz);
   const plan = await getPlanStrict(user.id, dateStr);
   const ingredients = await listIngredients(String(user.id), null);

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -5,12 +5,12 @@ import { getPlanStrict } from '@/lib/plans-store';
 import { getIngredient } from '@/lib/ingredients-store';
 import { getFlavor } from '@/lib/flavors-store';
 import { getSubflavor } from '@/lib/subflavors-store';
-import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import { DEFAULT_LLM_SETUP } from '@/lib/llm/config';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
+import { resolveReviewDate } from '@/lib/review-date';
 
 function buildSystemPrompt(toneId: string) {
   const tone = getCoachTone(toneId);
@@ -44,13 +44,19 @@ export async function POST(req: NextRequest) {
   const toneId =
     body.toneId || body.tone || userRow?.coachTone || 'tone_medium';
 
-  const { date: dateObj, tz } = resolvePlanDate('live', session?.user as any, {
+  const reqInit = {
     cookies: req.cookies,
     searchParams: Object.fromEntries(req.nextUrl.searchParams),
-  });
-  const today = toYMD(dateObj, tz);
+  };
+  const reviewInfo = await resolveReviewDate(
+    (session?.user as any) || {},
+    userId,
+    reqInit,
+  );
+  const tz = reviewInfo.tz;
+  const defaultTarget = reviewInfo.reviewYMD;
   const targetDate =
-    typeof body.date === 'string' && body.date ? body.date : today;
+    typeof body.date === 'string' && body.date ? body.date : defaultTarget;
 
   const formatTime = (iso: string) =>
     new Intl.DateTimeFormat('en-US', {

--- a/app/api/review-extension/route.ts
+++ b/app/api/review-extension/route.ts
@@ -1,0 +1,142 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+import { canViewProfile } from '@/lib/profile';
+import {
+  getReviewExtensionForDate,
+  getActiveReviewExtension,
+  upsertReviewExtension,
+} from '@/lib/review-extension-store';
+import {
+  addDays,
+  getNow,
+  getUserTimeZone,
+  startOfDay,
+  toYMD,
+  type ReqInit,
+} from '@/lib/clock';
+
+function buildReqInit(req: NextRequest): ReqInit {
+  return {
+    cookies: req.cookies,
+    searchParams: Object.fromEntries(req.nextUrl.searchParams),
+  };
+}
+
+function responseFromRecord(
+  record:
+    | Awaited<ReturnType<typeof getActiveReviewExtension>>
+    | Awaited<ReturnType<typeof getReviewExtensionForDate>>,
+  mode: 'current' | 'historical',
+  active: boolean,
+) {
+  if (!record) return { visible: false };
+  return {
+    visible: true,
+    mode,
+    extension: {
+      reason: record.reason,
+      targetDate: record.targetDate,
+      expiresAt: record.expiresAt,
+      createdAt: record.createdAt,
+      active,
+    },
+  };
+}
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  const viewerId = session?.user?.id ? Number(session.user.id) : null;
+  const search = req.nextUrl.searchParams;
+  const userIdParam = search.get('userId');
+  const targetUserId = userIdParam ? Number(userIdParam) : viewerId;
+  if (!targetUserId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const [target] = await db
+    .select({
+      id: users.id,
+      accountVisibility: users.accountVisibility,
+    })
+    .from(users)
+    .where(eq(users.id, targetUserId));
+  if (!target) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+  if (viewerId !== targetUserId) {
+    const allowed = await canViewProfile({
+      viewerId,
+      targetUser: {
+        id: target.id,
+        accountVisibility: target.accountVisibility as any,
+      },
+    });
+    if (!allowed) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+  }
+  const reqInit = buildReqInit(req);
+  const tz = getUserTimeZone(target as any, reqInit);
+  const { now } = getNow(tz, reqInit);
+  const dateParam = search.get('date');
+  if (dateParam) {
+    const record = await getReviewExtensionForDate(targetUserId, dateParam);
+    return NextResponse.json(responseFromRecord(record, 'historical', false));
+  }
+  const record = await getActiveReviewExtension(targetUserId, now);
+  return NextResponse.json(
+    responseFromRecord(record, 'current', record ? true : false),
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const me = await ensureUser(session);
+  const reqInit = buildReqInit(req);
+  const tz = getUserTimeZone(me as any, reqInit);
+  const { now } = getNow(tz, reqInit);
+  let body: any = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const reason = (body?.reason ?? '').toString().trim();
+  if (!reason) {
+    return NextResponse.json(
+      { error: 'Please share a short reason for the extra time.' },
+      { status: 400 },
+    );
+  }
+  const limitedReason = reason.slice(0, 500);
+  const today = startOfDay(now, tz);
+  const midday = new Date(today.getTime() + 12 * 60 * 60 * 1000);
+  let targetStart = today;
+  if (now < midday) {
+    targetStart = addDays(today, -1, tz);
+  }
+  const targetDate = toYMD(targetStart, tz);
+  const nextDayStart = addDays(targetStart, 1, tz);
+  const expiresAt = new Date(nextDayStart.getTime() + 12 * 60 * 60 * 1000);
+  const record = await upsertReviewExtension({
+    userId: me.id,
+    targetDate,
+    reason: limitedReason,
+    expiresAt,
+  });
+  return NextResponse.json({
+    extension: {
+      reason: record.reason,
+      targetDate: record.targetDate,
+      expiresAt: record.expiresAt,
+      createdAt: record.createdAt,
+      active: true,
+    },
+  });
+}

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor, type Section } from '@/lib/navigation';
@@ -29,11 +30,25 @@ const underlineColors: Record<Section, string> = {
   progress: 'var(--accent)',
 };
 
+type ExtensionState = {
+  visible: boolean;
+  mode?: 'current' | 'historical';
+  extension?: {
+    reason: string;
+    targetDate: string;
+    expiresAt: string;
+    createdAt: string;
+    active: boolean;
+  };
+};
+
 export function AppNav() {
   const ctx = useViewContext();
   const pathname = usePathname();
   const router = useRouter();
   const signedIn = ctx.viewerId !== null;
+  const [extension, setExtension] = useState<ExtensionState>({ visible: false });
+  const [showReason, setShowReason] = useState(false);
   const sections: Section[] =
     ctx.mode === 'viewer'
       ? [
@@ -66,6 +81,63 @@ export function AppNav() {
             'progress',
           ];
 
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const params = new URLSearchParams();
+        params.set('userId', String(ctx.ownerId));
+        if (ctx.mode === 'historical' && ctx.snapshotDate) {
+          params.set('date', ctx.snapshotDate);
+        }
+        const qs = params.toString();
+        const res = await fetch(
+          `/api/review-extension${qs ? `?${qs}` : ''}`,
+          { cache: 'no-store' },
+        );
+        if (!res.ok) {
+          if (!cancelled) {
+            setExtension({ visible: false });
+            setShowReason(false);
+          }
+          return;
+        }
+        const data = (await res.json()) as ExtensionState;
+        if (!cancelled) {
+          setExtension(data);
+          if (!data?.visible) setShowReason(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setExtension((prev) => (prev?.visible ? prev : { visible: false }));
+        }
+      }
+    }
+    load();
+    const id = window.setInterval(load, 60_000);
+    const handler = () => load();
+    window.addEventListener('review-extension:changed', handler);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+      window.removeEventListener('review-extension:changed', handler);
+    };
+  }, [ctx.ownerId, ctx.mode, ctx.snapshotDate]);
+
+  const ext = extension.visible ? extension.extension : null;
+  const targetLabel = ext
+    ? new Date(`${ext.targetDate}T00:00:00Z`).toLocaleDateString(undefined, {
+        dateStyle: 'medium',
+      })
+    : '';
+  const expiresLabel =
+    ext && extension.mode === 'current'
+      ? new Date(ext.expiresAt).toLocaleString(undefined, {
+          dateStyle: 'medium',
+          timeStyle: 'short',
+        })
+      : '';
+
   return (
     <nav className="flex items-center justify-between bg-white p-4 shadow-sm">
       <ul className="flex gap-4 text-neutral-700">
@@ -92,6 +164,33 @@ export function AppNav() {
         })}
       </ul>
       <div className="flex items-center gap-4 text-neutral-700">
+        {ext && (
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setShowReason((v) => !v)}
+              aria-expanded={showReason}
+              className="rounded-full bg-[var(--review)] px-3 py-1 text-xs font-semibold text-white shadow transition hover:opacity-90"
+            >
+              12H extra to review
+            </button>
+            {showReason && (
+              <div className="absolute right-0 top-full z-50 mt-2 w-72 rounded-lg border border-[var(--review)]/40 bg-white p-3 text-sm shadow-xl">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[var(--review)]">
+                  Frozen on {targetLabel}
+                </p>
+                <p className="mt-2 whitespace-pre-wrap text-neutral-700">
+                  {ext.reason}
+                </p>
+                <p className="mt-3 text-xs text-neutral-500">
+                  {extension.mode === 'historical'
+                    ? 'Historical snapshot — this reason was recorded for that day.'
+                    : `Extra time active until ${expiresLabel}.`}
+                </p>
+              </div>
+            )}
+          </div>
+        )}
         <Clock />
         {signedIn ? (
           <form action="/api/auth/signout" method="post">

--- a/drizzle/0032_create_review_extensions.sql
+++ b/drizzle/0032_create_review_extensions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "review_extensions" (
+    "id" serial PRIMARY KEY,
+    "user_id" integer NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "target_date" date NOT NULL,
+    "reason" text NOT NULL,
+    "expires_at" timestamp NOT NULL,
+    "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "review_extensions_user_target_unique"
+    ON "review_extensions" ("user_id", "target_date");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1756284819562,
       "tag": "0031_add_todos_due_at",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1756284819563,
+      "tag": "0032_create_review_extensions",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -276,6 +276,26 @@ export const profileSnapshots = pgTable(
   }),
 );
 
+export const reviewExtensions = pgTable(
+  'review_extensions',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    targetDate: date('target_date').notNull(),
+    reason: text('reason').notNull(),
+    expiresAt: timestamp('expires_at').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserTarget: uniqueIndex('review_extensions_user_target_unique').on(
+      table.userId,
+      table.targetDate,
+    ),
+  }),
+);
+
 export const dailyReports = pgTable(
   'daily_reports',
   {

--- a/lib/review-date.ts
+++ b/lib/review-date.ts
@@ -1,0 +1,45 @@
+import { resolvePlanDate } from './plan-date';
+import { parseYMD, toYMD, type ReqInit } from './clock';
+import {
+  getActiveReviewExtension,
+  type ReviewExtensionRecord,
+} from './review-extension-store';
+
+export interface ReviewExtensionState
+  extends Pick<ReviewExtensionRecord, 'reason' | 'targetDate' | 'expiresAt' | 'createdAt'> {
+  active: boolean;
+}
+
+export type ReviewDateInfo = ReturnType<typeof resolvePlanDate> & {
+  reviewDate: Date;
+  reviewYMD: string;
+  extension?: ReviewExtensionState;
+};
+
+export async function resolveReviewDate(
+  user: { timeZone?: string } & Record<string, unknown>,
+  userId: number,
+  req?: ReqInit,
+): Promise<ReviewDateInfo> {
+  const base = resolvePlanDate('review', user, req);
+  let reviewDate = base.date;
+  let extensionInfo: ReviewExtensionState | undefined;
+  const extension = await getActiveReviewExtension(userId, base.now);
+  if (extension) {
+    reviewDate = parseYMD(extension.targetDate, base.tz);
+    extensionInfo = {
+      reason: extension.reason,
+      targetDate: extension.targetDate,
+      expiresAt: extension.expiresAt,
+      createdAt: extension.createdAt,
+      active: true,
+    };
+  }
+  return {
+    ...base,
+    date: reviewDate,
+    reviewDate,
+    reviewYMD: toYMD(reviewDate, base.tz),
+    extension: extensionInfo,
+  };
+}

--- a/lib/review-extension-store.ts
+++ b/lib/review-extension-store.ts
@@ -1,0 +1,104 @@
+import { db } from './db';
+import { reviewExtensions } from './db/schema';
+import { and, desc, eq, gt } from 'drizzle-orm';
+
+export interface ReviewExtensionRecord {
+  id: number;
+  userId: number;
+  targetDate: string;
+  reason: string;
+  expiresAt: string;
+  createdAt: string;
+}
+
+function toDateOnly(value: unknown): string {
+  if (!value) return '';
+  if (typeof value === 'string') return value.slice(0, 10);
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  return String(value).slice(0, 10);
+}
+
+function toIso(value: unknown): string {
+  if (!value) return new Date(0).toISOString();
+  if (value instanceof Date) return value.toISOString();
+  const asDate = new Date(value as any);
+  if (!Number.isNaN(asDate.getTime())) return asDate.toISOString();
+  return new Date(0).toISOString();
+}
+
+function mapRow(row: typeof reviewExtensions.$inferSelect): ReviewExtensionRecord {
+  return {
+    id: row.id,
+    userId: row.userId ?? 0,
+    targetDate: toDateOnly(row.targetDate),
+    reason: row.reason ?? '',
+    expiresAt: toIso(row.expiresAt),
+    createdAt: toIso(row.createdAt),
+  };
+}
+
+export async function upsertReviewExtension({
+  userId,
+  targetDate,
+  reason,
+  expiresAt,
+}: {
+  userId: number;
+  targetDate: string;
+  reason: string;
+  expiresAt: Date;
+}): Promise<ReviewExtensionRecord> {
+  const values = {
+    userId,
+    targetDate,
+    reason,
+    expiresAt,
+    createdAt: new Date(),
+  } as typeof reviewExtensions.$inferInsert;
+  const [row] = await db
+    .insert(reviewExtensions)
+    .values(values)
+    .onConflictDoUpdate({
+      target: [reviewExtensions.userId, reviewExtensions.targetDate],
+      set: {
+        reason: values.reason,
+        expiresAt: values.expiresAt,
+        createdAt: values.createdAt,
+      },
+    })
+    .returning();
+  return mapRow(row);
+}
+
+export async function getActiveReviewExtension(
+  userId: number,
+  now: Date,
+): Promise<ReviewExtensionRecord | null> {
+  const rows = await db
+    .select()
+    .from(reviewExtensions)
+    .where(and(eq(reviewExtensions.userId, userId), gt(reviewExtensions.expiresAt, now)))
+    .orderBy(desc(reviewExtensions.expiresAt))
+    .limit(1);
+  if (!rows.length) return null;
+  return mapRow(rows[0]);
+}
+
+export async function getReviewExtensionForDate(
+  userId: number,
+  targetDate: string,
+): Promise<ReviewExtensionRecord | null> {
+  const rows = await db
+    .select()
+    .from(reviewExtensions)
+    .where(
+      and(
+        eq(reviewExtensions.userId, userId),
+        eq(reviewExtensions.targetDate, targetDate),
+      ),
+    )
+    .orderBy(desc(reviewExtensions.createdAt))
+    .limit(1);
+  if (!rows.length) return null;
+  return mapRow(rows[0]);
+}


### PR DESCRIPTION
## Summary
- add a `review_extensions` table plus helpers to freeze the review date and persist the activation reason
- expose an `/api/review-extension` endpoint that lets owners request extra time and lets viewers (including historical snapshots) read the reason
- update planning, daily-report generation, navigation, and account settings UI to honor the extension window and surface the reason badge

## Testing
- pnpm lint
- pnpm tsc
- pnpm test *(fails: Playwright browsers not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68cd095998b8832abd3c4ae96ded556d