### PR TITLE
fix: allow frozen review blocks to stay editable

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -292,3 +292,6 @@
 - 2025-10-29: Displayed original activity description during planning review to aid feedback writing and added test coverage.
 - 2025-10-29: Displayed error message on failed login attempts and added test coverage.
 - 2025-10-30: Added script and helper to reset user passwords by ID and documented usage.
+- 2025-10-30: Added 12H extra review time setting with reason capture, froze review/daily rapport date until noon when active, and surfaced status with a clickable indicator across owner, viewer, and historical views.
+- 2025-10-30: Tweaked 12H extra review time so activating it locks today’s review for tomorrow morning instead of reaching back to yesterday.
+- 2025-10-30: Allowed 12H extra review time days to review every block once the calendar moves to the next day.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -128,6 +128,7 @@ export default function EditorClient({
   // library instead of the plan owner's.
   const currentUserId = viewerId != null ? String(viewerId) : userId;
   const mode = live ? 'live' : 'next';
+  const reviewDayHasPassed = review && today > date;
   // Persist plans per-user and per-date. Live and review modes share the
   // same key while future planning uses its own so adjustments remain across
   // calendar days even if the network request fails.
@@ -919,7 +920,7 @@ export default function EditorClient({
   }, [blocks, review]);
 
   useEffect(() => {
-    if (!review) return;
+    if (!review || reviewDayHasPassed) return;
     const now = nowMinute;
     setReviews((prev) => {
       const next: Record<
@@ -935,7 +936,7 @@ export default function EditorClient({
       }
       return next;
     });
-  }, [nowMinute, blocks, review, minutesFromIso]);
+  }, [nowMinute, blocks, review, minutesFromIso, reviewDayHasPassed]);
 
   function updateBlock(id: string, updates: Partial<PlanBlock>) {
     if (review) return;
@@ -1602,7 +1603,7 @@ export default function EditorClient({
                       zIndex: z,
                       color: textColor,
                       cursor: review
-                        ? !live || nowMinute >= minutesFromIso(b.end)
+                        ? !live || reviewDayHasPassed || nowMinute >= minutesFromIso(b.end)
                           ? 'pointer'
                           : 'not-allowed'
                         : editable
@@ -1642,7 +1643,12 @@ export default function EditorClient({
                     onClick={(e) => {
                       e.stopPropagation();
                       if (draggingRef.current) return;
-                      if (review && live && nowMinute < minutesFromIso(b.end))
+                      if (
+                        review &&
+                        live &&
+                        !reviewDayHasPassed &&
+                        nowMinute < minutesFromIso(b.end)
+                      )
                         return;
                       openMeta(b.id);
                     }}

--- a/app/(app)/planning/page.tsx
+++ b/app/(app)/planning/page.tsx
@@ -5,6 +5,7 @@ import PlanningLanding from './client';
 import { cookies } from 'next/headers';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import { resolvePlanDate, toYMD } from '@/lib/plan-date';
+import { getActiveReviewExtraTime } from '@/lib/review-extra-time-store';
 
 export default async function PlanningPage({
   searchParams,
@@ -17,8 +18,10 @@ export default async function PlanningPage({
   const cookieStore = await cookies();
   const params = searchParams ? await searchParams : undefined;
   const req = { cookies: cookieStore, searchParams: params };
+  const extraTime = await getActiveReviewExtraTime(me.id);
   const liveInfo = resolvePlanDate('live', me, req);
   const nextInfo = resolvePlanDate('next', me, req);
+  const reviewInfo = resolvePlanDate('review', { ...me, reviewExtraTime: extraTime }, req);
   const liveLabel = liveInfo.date.toLocaleDateString('en-US', {
     weekday: 'long',
     month: 'short',
@@ -30,6 +33,12 @@ export default async function PlanningPage({
     month: 'short',
     day: 'numeric',
     timeZone: nextInfo.tz,
+  });
+  const reviewLabel = reviewInfo.date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    timeZone: reviewInfo.tz,
   });
   const todayStr = toYMD(liveInfo.today, liveInfo.tz);
   const overrideLabel = liveInfo.override
@@ -44,7 +53,7 @@ export default async function PlanningPage({
         today={todayStr}
         nextLabel={nextLabel}
         liveLabel={liveLabel}
-        reviewLabel={liveLabel}
+        reviewLabel={reviewLabel}
       />
     </>
   );

--- a/app/(app)/planning/review/page.tsx
+++ b/app/(app)/planning/review/page.tsx
@@ -9,6 +9,7 @@ import EditorClient from '../next/client';
 import { listIngredients } from '@/lib/ingredients-store';
 import { listFlavors } from '@/lib/flavors-store';
 import { listAllSubflavors } from '@/lib/subflavors-store';
+import { getActiveReviewExtraTime } from '@/lib/review-extra-time-store';
 
 export const revalidate = 0;
 
@@ -23,7 +24,8 @@ export default async function PlanningReviewPage({
   const cookieStore = await cookies();
   const params = searchParams ? await searchParams : undefined;
   const showDailyAim = params?.showDailyAim === '1';
-  const info = resolvePlanDate('review', me, {
+  const extraTime = await getActiveReviewExtraTime(me.id);
+  const info = resolvePlanDate('review', { ...me, reviewExtraTime: extraTime }, {
     cookies: cookieStore,
     searchParams: params,
   });

--- a/app/(app)/settings/account/page.tsx
+++ b/app/(app)/settings/account/page.tsx
@@ -3,12 +3,19 @@
 import { useState, useEffect } from 'react';
 import { useViewContext } from '@/lib/view-context';
 import { COACH_TONES } from '@/lib/ai/coach-tone';
+import type { ReviewExtraTimeRecord } from '@/lib/review-extra-time-store';
+import { cn } from '@/lib/utils';
 
 export default function AccountSettingsPage() {
   const { editable } = useViewContext();
   const [visibility, setVisibility] = useState<'open' | 'closed' | 'private'>('open');
   const [coachTone, setCoachTone] = useState('tone_medium');
   const [saving, setSaving] = useState(false);
+  const [extraTime, setExtraTime] = useState<ReviewExtraTimeRecord | null>(null);
+  const [showExtraModal, setShowExtraModal] = useState(false);
+  const [extraReason, setExtraReason] = useState('');
+  const [activating, setActivating] = useState(false);
+  const [extraError, setExtraError] = useState('');
   useEffect(() => {
     fetch('/api/account/visibility')
       .then((res) => (res.ok ? res.json() : null))
@@ -16,6 +23,10 @@ export default function AccountSettingsPage() {
     fetch('/api/account/coach-tone')
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => setCoachTone(data?.coachTone ?? 'tone_medium'));
+    fetch('/api/account/review-extra-time')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setExtraTime(data?.reviewExtraTime ?? null))
+      .catch(() => setExtraTime(null));
   }, []);
 
   async function save() {
@@ -33,6 +44,41 @@ export default function AccountSettingsPage() {
       }),
     ]);
     setSaving(false);
+  }
+
+  async function activateExtraTime() {
+    const reason = extraReason.trim();
+    if (!reason) {
+      setExtraError('Please share your reason for extending the review window.');
+      return;
+    }
+    setActivating(true);
+    setExtraError('');
+    try {
+      const res = await fetch('/api/account/review-extra-time', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        setExtraError(data?.error ?? 'Unable to activate extra time.');
+        setActivating(false);
+        return;
+      }
+      const data = await res.json().catch(() => null);
+      setExtraTime(data?.reviewExtraTime ?? null);
+      setExtraReason('');
+      setShowExtraModal(false);
+      setActivating(false);
+      if (typeof window !== 'undefined') {
+        window.setTimeout(() => window.location.reload(), 150);
+      }
+    } catch (error) {
+      console.error('activate extra time failed', error);
+      setExtraError('Unable to activate extra time.');
+      setActivating(false);
+    }
   }
 
   return (
@@ -75,6 +121,90 @@ export default function AccountSettingsPage() {
       >
         Save
       </button>
+      <div className="rounded-lg border border-orange-200 bg-orange-50 p-4 shadow-sm">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-orange-600">
+              12H extra review time
+            </h2>
+            <p className="text-sm text-neutral-700">
+              Freeze your review window until noon tomorrow when you know you’ll
+              finish late. Your review score still counts for the day you froze.
+            </p>
+            {extraTime && (
+              <p className="mt-2 text-xs text-orange-600">
+                {extraTime.active ? 'Currently active' : 'Last used'} for{' '}
+                {extraTime.frozenDate
+                  ? new Date(`${extraTime.frozenDate}T00:00:00`).toLocaleDateString(
+                      'en-GB',
+                      { dateStyle: 'medium' },
+                    )
+                  : 'a previous day'}
+                .
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={editable ? () => setShowExtraModal(true) : undefined}
+            disabled={!editable || activating}
+            className={cn(
+              'rounded-full px-4 py-2 text-sm font-semibold text-white shadow transition',
+              editable
+                ? 'bg-gradient-to-r from-orange-500 to-orange-400 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-orange-300'
+                : 'bg-zinc-400 opacity-60',
+            )}
+          >
+            12H extra time
+          </button>
+        </div>
+      </div>
+      {showExtraModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+            <h2 className="text-lg font-semibold text-orange-600">
+              Why do you need the extra 12 hours?
+            </h2>
+            <p className="mt-1 text-sm text-neutral-600">
+              Capture a quick note for yourself and others about why you’re
+              extending the review window.
+            </p>
+            <textarea
+              value={extraReason}
+              onChange={(e) => setExtraReason(e.target.value)}
+              disabled={activating}
+              className="mt-4 h-32 w-full resize-none rounded border border-orange-200 bg-orange-50 p-3 text-sm text-neutral-800 shadow-inner focus:outline-none focus:ring-2 focus:ring-orange-300"
+              placeholder="Because I finished work at 01:00 and still want to reflect on today…"
+            />
+            {extraError && (
+              <p className="mt-2 text-sm text-red-600" role="alert">
+                {extraError}
+              </p>
+            )}
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  if (activating) return;
+                  setShowExtraModal(false);
+                  setExtraError('');
+                }}
+                className="rounded px-4 py-2 text-sm font-medium text-neutral-600 hover:bg-neutral-100"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={activateExtraTime}
+                disabled={activating}
+                className="rounded bg-orange-500 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-orange-400 disabled:opacity-60"
+              >
+                {activating ? 'Activating…' : 'Activate'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/(view)/view/[viewId]/planning/page.tsx
+++ b/app/(view)/view/[viewId]/planning/page.tsx
@@ -4,6 +4,7 @@ import PlanningLanding from '@/app/(app)/planning/client';
 import { cookies } from 'next/headers';
 import { resolvePlanDate, toYMD } from '@/lib/plan-date';
 import TimeOverrideBadge from '@/components/time-override-badge';
+import { getActiveReviewExtraTime } from '@/lib/review-extra-time-store';
 
 export default async function ViewPlanningPage({
   params,
@@ -18,8 +19,10 @@ export default async function ViewPlanningPage({
   const cookieStore = await cookies();
   const paramsObj = searchParams ? await searchParams : undefined;
   const req = { cookies: cookieStore, searchParams: paramsObj };
+  const extraTime = await getActiveReviewExtraTime(user.id);
   const liveInfo = resolvePlanDate('live', user, req);
   const nextInfo = resolvePlanDate('next', user, req);
+  const reviewInfo = resolvePlanDate('review', { ...user, reviewExtraTime: extraTime }, req);
   const liveLabel = liveInfo.date.toLocaleDateString('en-US', {
     weekday: 'long',
     month: 'short',
@@ -31,6 +34,12 @@ export default async function ViewPlanningPage({
     month: 'short',
     day: 'numeric',
     timeZone: nextInfo.tz,
+  });
+  const reviewLabel = reviewInfo.date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+    timeZone: reviewInfo.tz,
   });
   const todayStr = toYMD(liveInfo.today, liveInfo.tz);
   const overrideLabel = liveInfo.override
@@ -45,7 +54,7 @@ export default async function ViewPlanningPage({
         today={todayStr}
         nextLabel={nextLabel}
         liveLabel={liveLabel}
-        reviewLabel={liveLabel}
+        reviewLabel={reviewLabel}
       />
     </section>
   );

--- a/app/(view)/view/[viewId]/planning/review/page.tsx
+++ b/app/(view)/view/[viewId]/planning/review/page.tsx
@@ -6,6 +6,7 @@ import { getPlanStrict } from '@/lib/plans-store';
 import TimeOverrideBadge from '@/components/time-override-badge';
 import EditorClient from '@/app/(app)/planning/next/client';
 import { listIngredients } from '@/lib/ingredients-store';
+import { getActiveReviewExtraTime } from '@/lib/review-extra-time-store';
 
 export const revalidate = 0;
 
@@ -21,7 +22,8 @@ export default async function ViewPlanningReviewPage({
   if (!user) notFound();
   const cookieStore = await cookies();
   const paramsObj = searchParams ? await searchParams : undefined;
-  const info = resolvePlanDate('review', user, {
+  const extraTime = await getActiveReviewExtraTime(user.id);
+  const info = resolvePlanDate('review', { ...user, reviewExtraTime: extraTime }, {
     cookies: cookieStore,
     searchParams: paramsObj,
   });

--- a/app/api/account/review-extra-time/route.ts
+++ b/app/api/account/review-extra-time/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { ensureUser, getUserById } from '@/lib/users';
+import { getUserTimeZone } from '@/lib/clock';
+import {
+  activateReviewExtraTime,
+  getActiveReviewExtraTime,
+  getReviewExtraTimeForDate,
+} from '@/lib/review-extra-time-store';
+import { canViewProfile } from '@/lib/profile';
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ reviewExtraTime: null }, { status: 401 });
+  }
+  const me = await ensureUser(session);
+  const userIdParam = Number(req.nextUrl.searchParams.get('userId'));
+  const targetUserId = Number.isFinite(userIdParam) && userIdParam > 0 ? userIdParam : me.id;
+  const snapshotDate = req.nextUrl.searchParams.get('snapshotDate') || undefined;
+  if (targetUserId !== me.id) {
+    const targetUser = await getUserById(targetUserId);
+    if (!targetUser) {
+      return NextResponse.json({ reviewExtraTime: null }, { status: 404 });
+    }
+    const allowed = await canViewProfile({
+      viewerId: me.id,
+      targetUser: {
+        id: targetUser.id,
+        accountVisibility: targetUser.accountVisibility as any,
+      },
+    });
+    if (!allowed) {
+      return NextResponse.json({ reviewExtraTime: null }, { status: 403 });
+    }
+  }
+  try {
+    const entry = snapshotDate
+      ? await getReviewExtraTimeForDate(targetUserId, snapshotDate)
+      : await getActiveReviewExtraTime(targetUserId);
+    return NextResponse.json({ reviewExtraTime: entry });
+  } catch (error) {
+    console.error('review-extra-time GET failed', { error, targetUserId, snapshotDate });
+    return NextResponse.json({ reviewExtraTime: null }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const me = await ensureUser(session);
+  let body: any = {};
+  try {
+    body = await req.json();
+  } catch {
+    body = {};
+  }
+  const reason = typeof body.reason === 'string' ? body.reason : '';
+  const tz = getUserTimeZone(me as any, {
+    cookies: req.cookies,
+    searchParams: Object.fromEntries(req.nextUrl.searchParams),
+  });
+  try {
+    const record = await activateReviewExtraTime({
+      userId: me.id,
+      tz,
+      reason,
+    });
+    return NextResponse.json({ reviewExtraTime: record });
+  } catch (error) {
+    console.error('review-extra-time POST failed', { error, userId: me.id });
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : 'Unable to activate extra time.';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/api/progress/daily-report/route.ts
+++ b/app/api/progress/daily-report/route.ts
@@ -11,6 +11,7 @@ import { getCoachTone } from '@/lib/ai/coach-tone';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
+import { getActiveReviewExtraTime } from '@/lib/review-extra-time-store';
 
 function buildSystemPrompt(toneId: string) {
   const tone = getCoachTone(toneId);
@@ -44,7 +45,11 @@ export async function POST(req: NextRequest) {
   const toneId =
     body.toneId || body.tone || userRow?.coachTone || 'tone_medium';
 
-  const { date: dateObj, tz } = resolvePlanDate('live', session?.user as any, {
+  const extraTime = await getActiveReviewExtraTime(userId);
+  const reviewUser = session?.user
+    ? { ...(session.user as any), reviewExtraTime: extraTime }
+    : { reviewExtraTime: extraTime };
+  const { date: dateObj, tz } = resolvePlanDate('review', reviewUser, {
     cookies: req.cookies,
     searchParams: Object.fromEntries(req.nextUrl.searchParams),
   });

--- a/components/app-nav.tsx
+++ b/components/app-nav.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { useViewContext } from '@/lib/view-context';
@@ -6,6 +7,7 @@ import { hrefFor, type Section } from '@/lib/navigation';
 import { Button } from '@/components/ui/button';
 import { Clock } from '@/components/clock';
 import { cn } from '@/lib/utils';
+import type { ReviewExtraTimeRecord } from '@/lib/review-extra-time-store';
 
 const labels: Record<Section, string> = {
   cake: 'Cake',
@@ -34,6 +36,36 @@ export function AppNav() {
   const pathname = usePathname();
   const router = useRouter();
   const signedIn = ctx.viewerId !== null;
+  const [extraTime, setExtraTime] = useState<ReviewExtraTimeRecord | null>(null);
+  const [showReason, setShowReason] = useState(false);
+  useEffect(() => {
+    if (!ctx.ownerId) {
+      setExtraTime(null);
+      return;
+    }
+    const params = new URLSearchParams({ userId: String(ctx.ownerId) });
+    if (ctx.mode === 'historical' && ctx.snapshotDate) {
+      params.set('snapshotDate', ctx.snapshotDate);
+    }
+    let cancelled = false;
+    fetch(`/api/account/review-extra-time?${params.toString()}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (cancelled) return;
+        setExtraTime(data?.reviewExtraTime ?? null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setExtraTime(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ctx.ownerId, ctx.mode, ctx.snapshotDate]);
+
+  useEffect(() => {
+    if (!extraTime) setShowReason(false);
+  }, [extraTime]);
   const sections: Section[] =
     ctx.mode === 'viewer'
       ? [
@@ -92,6 +124,82 @@ export function AppNav() {
         })}
       </ul>
       <div className="flex items-center gap-4 text-neutral-700">
+        {extraTime && (
+          <div className="relative">
+            <button
+              type="button"
+              id={`nav-extra-${ctx.ownerId}-${ctx.viewerId ?? 'guest'}`}
+              onClick={() => setShowReason((prev) => !prev)}
+              aria-expanded={showReason}
+              aria-controls="nav-extra-reason"
+              className={cn(
+                'flex items-center gap-2 rounded-full px-3 py-1 text-sm font-semibold text-white shadow transition hover:shadow-md focus:outline-none focus:ring-2 focus:ring-orange-300',
+                extraTime.active
+                  ? 'bg-gradient-to-r from-orange-500 to-orange-400'
+                  : 'bg-gradient-to-r from-zinc-500 to-zinc-400',
+              )}
+            >
+              <span
+                className={cn(
+                  'h-2 w-2 rounded-full',
+                  extraTime.active ? 'bg-green-200' : 'bg-white/70',
+                )}
+                aria-hidden
+              />
+              12H extra to review
+            </button>
+            {showReason && (
+              <div
+                id="nav-extra-reason"
+                role="dialog"
+                aria-modal="false"
+                className="absolute right-0 z-50 mt-2 w-72 rounded-lg border border-orange-100 bg-white p-4 text-sm text-neutral-700 shadow-xl"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <div className="font-semibold text-orange-600">
+                      Extra review time reason
+                    </div>
+                    <div className="text-xs text-neutral-500">
+                      {extraTime.active ? 'Active now' : 'Historical'}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setShowReason(false)}
+                    aria-label="Close extra time reason"
+                    className="text-neutral-400 transition hover:text-neutral-600"
+                  >
+                    ×
+                  </button>
+                </div>
+                <p className="mt-3 whitespace-pre-wrap leading-relaxed">
+                  {extraTime.reason}
+                </p>
+                {extraTime.frozenDate && (
+                  <p className="mt-3 text-xs text-neutral-500">
+                    Applies to the review for{' '}
+                    {new Date(`${extraTime.frozenDate}T00:00:00`).toLocaleDateString(
+                      'en-GB',
+                      { dateStyle: 'medium' },
+                    )}
+                    .
+                  </p>
+                )}
+                {extraTime.expiresAt && (
+                  <p className="text-xs text-neutral-500">
+                    {extraTime.active ? 'Active until ' : 'Window ended at '}
+                    {new Date(extraTime.expiresAt).toLocaleString('en-GB', {
+                      dateStyle: 'medium',
+                      timeStyle: 'short',
+                    })}
+                    .
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
         <Clock />
         {signedIn ? (
           <form action="/api/auth/signout" method="post">

--- a/drizzle/0032_create_review_extra_time.sql
+++ b/drizzle/0032_create_review_extra_time.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS review_extra_time (
+  id serial PRIMARY KEY,
+  user_id integer NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  reason text NOT NULL,
+  frozen_date date NOT NULL,
+  activated_at timestamp DEFAULT now(),
+  expires_at timestamp NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS review_extra_time_user_expires_idx
+  ON review_extra_time (user_id, expires_at DESC);
+
+CREATE INDEX IF NOT EXISTS review_extra_time_user_frozen_idx
+  ON review_extra_time (user_id, frozen_date DESC);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1756284819562,
       "tag": "0031_add_todos_due_at",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1756284819563,
+      "tag": "0032_create_review_extra_time",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -53,6 +53,17 @@ export const users = pgTable('users', {
   updatedAt: timestamp('updated_at').defaultNow(),
 });
 
+export const reviewExtraTime = pgTable('review_extra_time', {
+  id: serial('id').primaryKey(),
+  userId: integer('user_id')
+    .references(() => users.id)
+    .notNull(),
+  reason: text('reason').notNull(),
+  frozenDate: date('frozen_date').notNull(),
+  activatedAt: timestamp('activated_at').defaultNow(),
+  expiresAt: timestamp('expires_at').notNull(),
+});
+
 export const flavors = pgTable('flavors', {
   id: text('id').primaryKey(),
   userId: integer('user_id').references(() => users.id),

--- a/lib/plan-date.ts
+++ b/lib/plan-date.ts
@@ -26,6 +26,19 @@ export function resolvePlanDate(
   const tomorrow = addDays(today, 1, tz);
   let date = kind === 'next' ? tomorrow : today;
   let clamped = false;
+  if (kind === 'review') {
+    const extra = (user as any)?.reviewExtraTime as
+      | { frozenDate?: string; expiresAt?: string }
+      | undefined;
+    const expiresAt = extra?.expiresAt ? new Date(extra.expiresAt) : null;
+    if (extra?.frozenDate && (!expiresAt || expiresAt.getTime() > now.getTime())) {
+      try {
+        date = parseYMD(extra.frozenDate, tz);
+      } catch {
+        // ignore invalid frozen date
+      }
+    }
+  }
   if (kind === 'next') {
     const raw = first(req?.searchParams?.['date']);
     if (raw) {

--- a/lib/review-extra-time-store.ts
+++ b/lib/review-extra-time-store.ts
@@ -1,0 +1,121 @@
+import { db } from './db';
+import { reviewExtraTime } from './db/schema';
+import { and, desc, eq, gt } from 'drizzle-orm';
+import { addDays, getNow, startOfDay, toYMD } from './clock';
+
+export type ReviewExtraTimeRecord = {
+  id: number;
+  userId: number;
+  reason: string;
+  frozenDate: string;
+  activatedAt: string;
+  expiresAt: string;
+  active: boolean;
+};
+
+type ReviewExtraTimeRow = typeof reviewExtraTime.$inferSelect;
+
+type ActivationInput = {
+  userId: number;
+  tz: string;
+  reason: string;
+};
+
+function normalizeDateValue(value: string | Date | null | undefined): string {
+  if (!value) return '';
+  if (typeof value === 'string') return value.slice(0, 10);
+  return value.toISOString().slice(0, 10);
+}
+
+function mapRow(
+  row: ReviewExtraTimeRow | undefined,
+  now: Date,
+): ReviewExtraTimeRecord | null {
+  if (!row || !row.id || !row.userId) return null;
+  const activatedAt = row.activatedAt
+    ? new Date(row.activatedAt)
+    : new Date();
+  const expiresAt = row.expiresAt ? new Date(row.expiresAt) : new Date(0);
+  const frozenDate = normalizeDateValue(row.frozenDate);
+  return {
+    id: row.id,
+    userId: row.userId,
+    reason: row.reason ?? '',
+    frozenDate,
+    activatedAt: activatedAt.toISOString(),
+    expiresAt: expiresAt.toISOString(),
+    active: expiresAt.getTime() > now.getTime(),
+  };
+}
+
+export async function activateReviewExtraTime({
+  userId,
+  tz,
+  reason,
+}: ActivationInput): Promise<ReviewExtraTimeRecord> {
+  const trimmed = reason.trim();
+  if (!trimmed) {
+    throw new Error('Reason for extra time is required.');
+  }
+  if (trimmed.length > 2000) {
+    throw new Error('Reason is too long.');
+  }
+  const { now } = getNow(tz);
+  const today = startOfDay(now, tz);
+  // Always freeze the day being worked on so the review can spill into the
+  // following morning. Previously we looked back if the activation happened
+  // before noon, which meant enabling the extension ahead of time kept the
+  // review stuck on yesterday. Instead, keep the frozen date anchored to
+  // today and simply extend the window into tomorrow noon.
+  const frozenDate = today;
+  const frozenDateYmd = toYMD(frozenDate, tz);
+  const nextDayStart = addDays(frozenDate, 1, tz);
+  const expiresAt = new Date(nextDayStart.getTime() + 12 * 60 * 60 * 1000);
+  const [row] = await db
+    .insert(reviewExtraTime)
+    .values({
+      userId,
+      reason: trimmed,
+      frozenDate: frozenDateYmd,
+      activatedAt: now,
+      expiresAt,
+    })
+    .returning();
+  const mapped = mapRow(row, now);
+  if (!mapped) {
+    throw new Error('Failed to activate review extra time.');
+  }
+  return mapped;
+}
+
+export async function getActiveReviewExtraTime(
+  userId: number,
+): Promise<ReviewExtraTimeRecord | null> {
+  const now = new Date();
+  const [row] = await db
+    .select()
+    .from(reviewExtraTime)
+    .where(and(eq(reviewExtraTime.userId, userId), gt(reviewExtraTime.expiresAt, now)))
+    .orderBy(desc(reviewExtraTime.activatedAt))
+    .limit(1);
+  return mapRow(row, now);
+}
+
+export async function getReviewExtraTimeForDate(
+  userId: number,
+  frozenDate: string,
+): Promise<ReviewExtraTimeRecord | null> {
+  const now = new Date();
+  const [row] = await db
+    .select()
+    .from(reviewExtraTime)
+    .where(
+      and(
+        eq(reviewExtraTime.userId, userId),
+        eq(reviewExtraTime.frozenDate, frozenDate),
+      ),
+    )
+    .orderBy(desc(reviewExtraTime.activatedAt))
+    .limit(1);
+  return mapRow(row, now);
+}

--- a/lib/users.ts
+++ b/lib/users.ts
@@ -73,6 +73,11 @@ export async function getUserByHandle(handle: string) {
   return user ?? null;
 }
 
+export async function getUserById(id: number) {
+  const [user] = await db.select().from(users).where(eq(users.id, id));
+  return user ?? null;
+}
+
 export async function getUserByViewId(viewId: string) {
   const [user] = await db.select().from(users).where(eq(users.viewId, viewId));
   return user ?? null;


### PR DESCRIPTION
## Summary
- allow review pages to treat frozen days as fully elapsed so every block remains clickable the following morning
- update the changelog to document the review extra time behavior fix

## Testing
- pnpm lint
- pnpm tsc
- pnpm test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd095998b8832abd3c4ae96ded556d