### PR TITLE
feat: add shared progress highlights

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -296,3 +296,4 @@
 - 2025-10-30: Tweaked 12H extra review time so activating it locks today’s review for tomorrow morning instead of reaching back to yesterday.
 - 2025-10-30: Allowed 12H extra review time days to review every block once the calendar moves to the next day.
 - 2025-10-30: Pointed daily rapport generation at the frozen review date during active extra time and returned to today once that report is saved.
+- 2025-10-30: Added collaborative progress highlights with color picker, instant text selection, and chronological highlight feeds across daily, weekly, monthly, and yearly overviews (including viewer mode support).

--- a/app/(view)/view/[viewId]/progress/overview/daily/highlights/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/daily/highlights/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { DailyHighlightsSection } from '@/app/progress/overview/daily/highlights/page';
+
+export default async function ViewDailyHighlightsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-daily-highlights-${user.id}`}>
+        <DailyHighlightsSection userId={user.id} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/(view)/view/[viewId]/progress/overview/monthly/highlights/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/monthly/highlights/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { MonthlyHighlightsSection } from '@/app/progress/overview/monthly/highlights/page';
+
+export default async function ViewMonthlyHighlightsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-monthly-highlights-${user.id}`}>
+        <MonthlyHighlightsSection userId={user.id} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/(view)/view/[viewId]/progress/overview/weekly/highlights/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/weekly/highlights/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { WeeklyHighlightsSection } from '@/app/progress/overview/weekly/highlights/page';
+
+export default async function ViewWeeklyHighlightsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-weekly-highlights-${user.id}`}>
+        <WeeklyHighlightsSection userId={user.id} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/(view)/view/[viewId]/progress/overview/yearly/highlights/page.tsx
+++ b/app/(view)/view/[viewId]/progress/overview/yearly/highlights/page.tsx
@@ -1,0 +1,36 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { YearlyHighlightsSection } from '@/app/progress/overview/yearly/highlights/page';
+
+export default async function ViewYearlyHighlightsPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+  if (sp?.at) notFound();
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-yearly-highlights-${user.id}`}>
+        <YearlyHighlightsSection userId={user.id} />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/api/progress/highlights/route.ts
+++ b/app/api/progress/highlights/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import {
+  saveReportHighlight,
+  type ReportHighlightType,
+} from '@/lib/report-highlights';
+
+const REPORT_TYPES: ReportHighlightType[] = [
+  'daily',
+  'weekly',
+  'monthly',
+  'yearly',
+];
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const user = await ensureUser(session);
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (typeof body !== 'object' || body === null) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const {
+    reportType,
+    targetSlug,
+    blockId,
+    startOffset,
+    endOffset,
+    color,
+    snippet,
+  } = body as Record<string, unknown>;
+
+  if (!REPORT_TYPES.includes(reportType as ReportHighlightType)) {
+    return NextResponse.json({ error: 'Unknown report type' }, { status: 400 });
+  }
+
+  try {
+    const highlight = await saveReportHighlight(user.id, {
+      reportType: reportType as ReportHighlightType,
+      targetSlug: String(targetSlug ?? ''),
+      blockId: String(blockId ?? ''),
+      startOffset: Number(startOffset ?? 0),
+      endOffset: Number(endOffset ?? 0),
+      color: String(color ?? ''),
+      snippet: String(snippet ?? ''),
+    });
+    return NextResponse.json({ highlight });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to save highlight';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/progress/overview/daily/highlights/page.tsx
+++ b/app/progress/overview/daily/highlights/page.tsx
@@ -1,0 +1,50 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { redirect } from 'next/navigation';
+import BackButton from '@/components/back-button';
+import { listReportHighlights } from '@/lib/report-highlights';
+import { listDailyReports } from '@/lib/daily-report-store';
+import { HighlightEntriesList } from '@/components/progress/highlight-entries';
+
+export async function DailyHighlightsSection({
+  userId,
+}: {
+  userId: number;
+}) {
+  const [highlights, reports] = await Promise.all([
+    listReportHighlights(userId, 'daily'),
+    listDailyReports(userId),
+  ]);
+  const reportMap = new Map(reports.map((r) => [r.slug, r]));
+  const entries = highlights.map((highlight) => {
+    const report = reportMap.get(highlight.targetSlug);
+    const title = report
+      ? `${report.date}${report.version > 1 ? ` (v${report.version})` : ''}`
+      : `Report ${highlight.targetSlug}`;
+    return {
+      id: highlight.id,
+      title,
+      snippet: highlight.snippet,
+      color: highlight.color,
+      createdAt: highlight.createdAt,
+      linkHref: `../${highlight.targetSlug}`,
+    };
+  });
+  return (
+    <main className="p-6">
+      <BackButton />
+      <h1 className="mb-4 text-2xl font-bold">Daily Highlights</h1>
+      <HighlightEntriesList
+        entries={entries}
+        emptyMessage="No highlights saved yet. Start marking your favorite moments from each day."
+      />
+    </main>
+  );
+}
+
+export default async function DailyHighlightsPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  return <DailyHighlightsSection userId={me.id} />;
+}

--- a/app/progress/overview/daily/page.tsx
+++ b/app/progress/overview/daily/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { redirect } from 'next/navigation';
@@ -7,6 +6,12 @@ import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
 import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
 import BackButton from '@/components/back-button';
+import { listHighlightsForTargets } from '@/lib/report-highlights';
+import type {
+  ReportOverviewItem,
+  ReportOverviewReportItem,
+} from '@/types/report-overview';
+import ReportOverviewClient from '@/components/progress/report-overview-client';
 
 export async function DailyReportsHome({ userId }: { userId: number }) {
   const [reports, snapshots] = await Promise.all([
@@ -20,123 +25,50 @@ export async function DailyReportsHome({ userId }: { userId: number }) {
   const allDates = Array.from(
     new Set([...snapshots, ...reports.map((r) => r.date)]),
   ).sort((a, b) => (a < b ? 1 : -1));
-  const items = allDates.map(
-    (date) => reportMap.get(date) ?? { date, missing: true as const },
-  );
+  const items: ReportOverviewItem[] = allDates.map((date) => {
+    const report = reportMap.get(date);
+    if (!report) {
+      return {
+        type: 'missing',
+        key: date,
+        title: date,
+        message: 'This day the user did not generate a daily assessment.',
+      } as ReportOverviewItem;
+    }
+    const tone = getCoachTone(report.coachTone).name;
+    const difficulty = getDifficultyLabel(report.score);
+    return {
+      type: 'report',
+      key: report.slug,
+      slug: report.slug,
+      title: report.date,
+      version: report.version,
+      summary: report.summary,
+      good: report.good,
+      bad: report.bad,
+      observations: report.observations,
+      toneName: tone,
+      score: report.score,
+      difficultyLabel: difficulty,
+      linkHref: report.slug,
+    } as ReportOverviewItem;
+  });
+  const slugs = items
+    .filter((item) => item.type === 'report')
+    .map((item) => (item as ReportOverviewReportItem).slug);
+  const highlights = await listHighlightsForTargets(userId, 'daily', slugs);
   return (
     <main className="p-6">
       <BackButton />
       <h1 className="mb-4 text-2xl font-bold">Daily Reports</h1>
-      <ul className="space-y-4" id={`d41lyrep-list-${userId}`}>
-        {items.map((r) =>
-          'missing' in r ? (
-            <li
-              key={r.date}
-              className="rounded border p-4"
-              id={`d41lyrep-miss-${r.date}-${userId}`}
-            >
-              <div className="flex items-center justify-between">
-                <h2 className="font-semibold">{r.date}</h2>
-                <span className="font-semibold text-red-600">
-                  No Assessment
-                </span>
-              </div>
-              <p className="mt-2 text-sm text-zinc-600">
-                This day the user did not generate a daily assessment.
-              </p>
-            </li>
-          ) : (
-            <li
-              key={r.slug}
-              className="rounded border p-4"
-              id={`d41lyrep-item-${r.slug}-${userId}`}
-            >
-              <div className="flex items-center justify-between">
-                <h2
-                  className="font-semibold"
-                  id={`d41lyrep-date-${r.slug}-${userId}`}
-                >
-                  {r.date}
-                  {r.version > 1 && (
-                    <span className="ml-1">(v{r.version})</span>
-                  )}
-                </h2>
-                <div className="flex items-center gap-2">
-                  <span
-                    className="font-semibold"
-                    id={`d41lyrep-tone-${r.slug}-${userId}`}
-                  >
-                    {getCoachTone(r.coachTone).name}
-                  </span>
-                  <span
-                    className="font-semibold"
-                    id={`d41lyrep-score-${r.slug}-${userId}`}
-                  >
-                    {r.score}
-                  </span>
-                  <span
-                    className="ml-1 text-sm text-zinc-600"
-                    id={`d41lyrep-diff-${r.slug}-${userId}`}
-                  >
-                    {getDifficultyLabel(r.score)}
-                  </span>
-                </div>
-              </div>
-              {r.summary && (
-                <p
-                  className="mt-2 whitespace-pre-wrap"
-                  id={`d41lyrep-sum-${r.slug}-${userId}`}
-                >
-                  {r.summary}
-                </p>
-              )}
-              {r.good.length > 0 && (
-                <div className="mt-2" id={`d41lyrep-good-${r.slug}-${userId}`}>
-                  <h3 className="font-semibold">What went well</h3>
-                  <ul className="list-disc pl-4">
-                    {r.good.map((g, i) => (
-                      <li key={i} id={`d41lyrep-good-${i}-${r.slug}-${userId}`}>
-                        {g}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {r.bad.length > 0 && (
-                <div className="mt-2" id={`d41lyrep-bad-${r.slug}-${userId}`}>
-                  <h3 className="font-semibold">What went bad</h3>
-                  <ul className="list-disc pl-4">
-                    {r.bad.map((b, i) => (
-                      <li key={i} id={`d41lyrep-bad-${i}-${r.slug}-${userId}`}>
-                        {b}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              {r.observations.length > 0 && (
-                <div className="mt-2" id={`d41lyrep-obs-${r.slug}-${userId}`}>
-                  <h3 className="font-semibold">Observations</h3>
-                  <ul className="list-disc pl-4">
-                    {r.observations.map((o, i) => (
-                      <li key={i} id={`d41lyrep-obs-${i}-${r.slug}-${userId}`}>
-                        {o}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              <Link
-                href={r.slug}
-                className="mt-2 block text-sm text-orange-600 hover:underline"
-                id={`d41lyrep-link-${r.slug}-${userId}`}
-              >
-                View details
-              </Link>
-            </li>
-          ),
-        )}
-      </ul>
+      <ReportOverviewClient
+        userId={userId}
+        reportType="daily"
+        idPrefix="d41lyrep"
+        items={items}
+        initialHighlights={highlights}
+        highlightLink="highlights"
+      />
     </main>
   );
 }

--- a/app/progress/overview/monthly/highlights/page.tsx
+++ b/app/progress/overview/monthly/highlights/page.tsx
@@ -1,0 +1,50 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { redirect } from 'next/navigation';
+import BackButton from '@/components/back-button';
+import { listReportHighlights } from '@/lib/report-highlights';
+import { listMonthlyReports } from '@/lib/monthly-report-store';
+import { HighlightEntriesList } from '@/components/progress/highlight-entries';
+
+export async function MonthlyHighlightsSection({
+  userId,
+}: {
+  userId: number;
+}) {
+  const [highlights, reports] = await Promise.all([
+    listReportHighlights(userId, 'monthly'),
+    listMonthlyReports(userId),
+  ]);
+  const reportMap = new Map(reports.map((r) => [r.slug, r]));
+  const entries = highlights.map((highlight) => {
+    const report = reportMap.get(highlight.targetSlug);
+    const title = report
+      ? `${report.startDate} – ${report.endDate}${report.version > 1 ? ` (v${report.version})` : ''}`
+      : `Month ${highlight.targetSlug}`;
+    return {
+      id: highlight.id,
+      title,
+      snippet: highlight.snippet,
+      color: highlight.color,
+      createdAt: highlight.createdAt,
+      linkHref: `../${highlight.targetSlug}`,
+    };
+  });
+  return (
+    <main className="p-6">
+      <BackButton />
+      <h1 className="mb-4 text-2xl font-bold">Monthly Highlights</h1>
+      <HighlightEntriesList
+        entries={entries}
+        emptyMessage="No monthly highlights yet. Capture the standout insights from each month to celebrate progress."
+      />
+    </main>
+  );
+}
+
+export default async function MonthlyHighlightsPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  return <MonthlyHighlightsSection userId={me.id} />;
+}

--- a/app/progress/overview/monthly/page.tsx
+++ b/app/progress/overview/monthly/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { redirect } from 'next/navigation';
@@ -8,6 +7,12 @@ import { listDailyReportDates } from '@/lib/daily-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
 import BackButton from '@/components/back-button';
+import { listHighlightsForTargets } from '@/lib/report-highlights';
+import type {
+  ReportOverviewItem,
+  ReportOverviewReportItem,
+} from '@/types/report-overview';
+import ReportOverviewClient from '@/components/progress/report-overview-client';
 
 function slugFromRange(start: string, end: string): string {
   const [ys, ms, ds] = start.split('-');
@@ -55,124 +60,53 @@ export async function MonthlyReportsHome({ userId }: { userId: number }) {
     list.push({ start, end, report: reportMap.get(key) });
   }
 
+  const prevMonthIso = prevMonthStart.toISOString().slice(0, 10);
+  const items: ReportOverviewItem[] = [];
+  for (const m of list) {
+    if (m.report) {
+      const r = m.report;
+      items.push({
+        type: 'report',
+        key: r.slug,
+        slug: r.slug,
+        title: `${r.startDate} – ${r.endDate}`,
+        version: r.version,
+        summary: r.summary,
+        good: r.good,
+        bad: r.bad,
+        observations: r.observations,
+        toneName: getCoachTone(r.coachTone).name,
+        score: r.score,
+        difficultyLabel: getDifficultyLabel(r.score),
+        linkHref: r.slug,
+      } as ReportOverviewItem);
+      continue;
+    }
+    if (m.start >= prevMonthIso) continue;
+    const slug = slugFromRange(m.start, m.end);
+    items.push({
+      type: 'missing',
+      key: slug,
+      title: `${m.start} – ${m.end}`,
+      message: 'This month the user did not generate a monthly assessment.',
+    } as ReportOverviewItem);
+  }
+  const slugs = items
+    .filter((item) => item.type === 'report')
+    .map((item) => (item as ReportOverviewReportItem).slug);
+  const highlights = await listHighlightsForTargets(userId, 'monthly', slugs);
   return (
     <main className="p-6">
       <BackButton />
       <h1 className="mb-4 text-2xl font-bold">Monthly Reports</h1>
-      <ul className="space-y-4" id={`m0nthlyrep-list-${userId}`}>
-        {list.map((m) => {
-          if (m.report) {
-            const r = m.report;
-            return (
-              <li
-                key={r.slug}
-                className="rounded border p-4"
-                id={`m0nthlyrep-item-${r.slug}-${userId}`}
-              >
-                <div className="flex items-center justify-between">
-                  <h2
-                    className="font-semibold"
-                    id={`m0nthlyrep-date-${r.slug}-${userId}`}
-                  >
-                    {r.startDate} – {r.endDate}
-                    {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
-                  </h2>
-                  <div className="flex items-center gap-2">
-                    <span
-                      className="font-semibold"
-                      id={`m0nthlyrep-tone-${r.slug}-${userId}`}
-                    >
-                      {getCoachTone(r.coachTone).name}
-                    </span>
-                    <span
-                      className="font-semibold"
-                      id={`m0nthlyrep-score-${r.slug}-${userId}`}
-                    >
-                      {r.score}
-                    </span>
-                    <span
-                      className="ml-1 text-sm text-zinc-600"
-                      id={`m0nthlyrep-diff-${r.slug}-${userId}`}
-                    >
-                      {getDifficultyLabel(r.score)}
-                    </span>
-                  </div>
-                </div>
-                {r.summary && (
-                  <p
-                    className="mt-2 whitespace-pre-wrap"
-                    id={`m0nthlyrep-sum-${r.slug}-${userId}`}
-                  >
-                    {r.summary}
-                  </p>
-                )}
-                {r.good.length > 0 && (
-                  <div className="mt-2" id={`m0nthlyrep-good-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">What went well</h3>
-                    <ul className="list-disc pl-4">
-                      {r.good.map((g, i) => (
-                        <li key={i} id={`m0nthlyrep-good-${i}-${r.slug}-${userId}`}>
-                          {g}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {r.bad.length > 0 && (
-                  <div className="mt-2" id={`m0nthlyrep-bad-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">What went bad</h3>
-                    <ul className="list-disc pl-4">
-                      {r.bad.map((b, i) => (
-                        <li key={i} id={`m0nthlyrep-bad-${i}-${r.slug}-${userId}`}>
-                          {b}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {r.observations.length > 0 && (
-                  <div className="mt-2" id={`m0nthlyrep-obs-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">Observations</h3>
-                    <ul className="list-disc pl-4">
-                      {r.observations.map((o, i) => (
-                        <li key={i} id={`m0nthlyrep-obs-${i}-${r.slug}-${userId}`}>
-                          {o}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                <Link
-                  href={r.slug}
-                  className="mt-2 block text-sm text-orange-600 hover:underline"
-                  id={`m0nthlyrep-link-${r.slug}-${userId}`}
-                >
-                  View details
-                </Link>
-              </li>
-            );
-          }
-          if (m.start >= prevMonthStart.toISOString().slice(0, 10)) return null;
-          const slug = slugFromRange(m.start, m.end);
-          return (
-            <li
-              key={slug}
-              className="rounded border p-4"
-              id={`m0nthlyrep-miss-${slug}-${userId}`}
-            >
-              <h2
-                className="font-semibold"
-                id={`m0nthlyrep-date-${slug}-${userId}`}
-              >
-                {m.start} – {m.end}
-              </h2>
-              <p className="mt-2" id={`m0nthlyrep-miss-msg-${slug}-${userId}`}>
-                This month the user did not generate a monthly assessment.
-              </p>
-            </li>
-          );
-        })}
-      </ul>
+      <ReportOverviewClient
+        userId={userId}
+        reportType="monthly"
+        idPrefix="m0nthlyrep"
+        items={items}
+        initialHighlights={highlights}
+        highlightLink="highlights"
+      />
     </main>
   );
 }

--- a/app/progress/overview/weekly/highlights/page.tsx
+++ b/app/progress/overview/weekly/highlights/page.tsx
@@ -1,0 +1,50 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { redirect } from 'next/navigation';
+import BackButton from '@/components/back-button';
+import { listReportHighlights } from '@/lib/report-highlights';
+import { listWeeklyReports } from '@/lib/weekly-report-store';
+import { HighlightEntriesList } from '@/components/progress/highlight-entries';
+
+export async function WeeklyHighlightsSection({
+  userId,
+}: {
+  userId: number;
+}) {
+  const [highlights, reports] = await Promise.all([
+    listReportHighlights(userId, 'weekly'),
+    listWeeklyReports(userId),
+  ]);
+  const reportMap = new Map(reports.map((r) => [r.slug, r]));
+  const entries = highlights.map((highlight) => {
+    const report = reportMap.get(highlight.targetSlug);
+    const title = report
+      ? `${report.startDate} – ${report.endDate}${report.version > 1 ? ` (v${report.version})` : ''}`
+      : `Week ${highlight.targetSlug}`;
+    return {
+      id: highlight.id,
+      title,
+      snippet: highlight.snippet,
+      color: highlight.color,
+      createdAt: highlight.createdAt,
+      linkHref: `../${highlight.targetSlug}`,
+    };
+  });
+  return (
+    <main className="p-6">
+      <BackButton />
+      <h1 className="mb-4 text-2xl font-bold">Weekly Highlights</h1>
+      <HighlightEntriesList
+        entries={entries}
+        emptyMessage="No weekly highlights captured yet. Highlight your biggest wins to revisit them later."
+      />
+    </main>
+  );
+}
+
+export default async function WeeklyHighlightsPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  return <WeeklyHighlightsSection userId={me.id} />;
+}

--- a/app/progress/overview/weekly/page.tsx
+++ b/app/progress/overview/weekly/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { redirect } from 'next/navigation';
@@ -7,6 +6,12 @@ import { listDailyReportDates } from '@/lib/daily-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
 import BackButton from '@/components/back-button';
+import { listHighlightsForTargets } from '@/lib/report-highlights';
+import type {
+  ReportOverviewItem,
+  ReportOverviewReportItem,
+} from '@/types/report-overview';
+import ReportOverviewClient from '@/components/progress/report-overview-client';
 
 function slugFromRange(start: string, end: string): string {
   const [ys, ms, ds] = start.split('-');
@@ -63,128 +68,53 @@ export async function WeeklyReportsHome({ userId }: { userId: number }) {
     weeks.push({ start, end, report: reportMap.get(start) });
   }
 
+  const prevWeekIso = prevWeekStart.toISOString().slice(0, 10);
+  const items: ReportOverviewItem[] = [];
+  for (const w of weeks) {
+    if (w.report) {
+      const r = w.report;
+      items.push({
+        type: 'report',
+        key: r.slug,
+        slug: r.slug,
+        title: `${r.startDate} – ${r.endDate}`,
+        version: r.version,
+        summary: r.summary,
+        good: r.good,
+        bad: r.bad,
+        observations: r.observations,
+        toneName: getCoachTone(r.coachTone).name,
+        score: r.score,
+        difficultyLabel: getDifficultyLabel(r.score),
+        linkHref: r.slug,
+      } as ReportOverviewItem);
+      continue;
+    }
+    if (w.start >= prevWeekIso) continue;
+    const slug = slugFromRange(w.start, w.end);
+    items.push({
+      type: 'missing',
+      key: slug,
+      title: `${w.start} – ${w.end}`,
+      message: 'This week the user did not generate a weekly assessment.',
+    } as ReportOverviewItem);
+  }
+  const slugs = items
+    .filter((item) => item.type === 'report')
+    .map((item) => (item as ReportOverviewReportItem).slug);
+  const highlights = await listHighlightsForTargets(userId, 'weekly', slugs);
   return (
     <main className="p-6">
       <BackButton />
       <h1 className="mb-4 text-2xl font-bold">Weekly Reports</h1>
-      <ul className="space-y-4" id={`w33klyrep-list-${userId}`}>
-        {weeks.map((w) => {
-          if (w.report) {
-            const r = w.report;
-            return (
-              <li
-                key={r.slug}
-                className="rounded border p-4"
-                id={`w33klyrep-item-${r.slug}-${userId}`}
-              >
-                <div className="flex items-center justify-between">
-                  <h2
-                    className="font-semibold"
-                    id={`w33klyrep-date-${r.slug}-${userId}`}
-                  >
-                    {r.startDate} – {r.endDate}
-                    {r.version > 1 && (
-                      <span className="ml-1">(v{r.version})</span>
-                    )}
-                  </h2>
-                  <div className="flex items-center gap-2">
-                    <span
-                      className="font-semibold"
-                      id={`w33klyrep-tone-${r.slug}-${userId}`}
-                    >
-                      {getCoachTone(r.coachTone).name}
-                    </span>
-                    <span
-                      className="font-semibold"
-                      id={`w33klyrep-score-${r.slug}-${userId}`}
-                    >
-                      {r.score}
-                    </span>
-                    <span
-                      className="ml-1 text-sm text-zinc-600"
-                      id={`w33klyrep-diff-${r.slug}-${userId}`}
-                    >
-                      {getDifficultyLabel(r.score)}
-                    </span>
-                  </div>
-                </div>
-                {r.summary && (
-                  <p
-                    className="mt-2 whitespace-pre-wrap"
-                    id={`w33klyrep-sum-${r.slug}-${userId}`}
-                  >
-                    {r.summary}
-                  </p>
-                )}
-                {r.good.length > 0 && (
-                  <div className="mt-2" id={`w33klyrep-good-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">What went well</h3>
-                    <ul className="list-disc pl-4">
-                      {r.good.map((g, i) => (
-                        <li key={i} id={`w33klyrep-good-${i}-${r.slug}-${userId}`}>
-                          {g}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {r.bad.length > 0 && (
-                  <div className="mt-2" id={`w33klyrep-bad-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">What went bad</h3>
-                    <ul className="list-disc pl-4">
-                      {r.bad.map((b, i) => (
-                        <li key={i} id={`w33klyrep-bad-${i}-${r.slug}-${userId}`}>
-                          {b}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {r.observations.length > 0 && (
-                  <div className="mt-2" id={`w33klyrep-obs-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">Observations</h3>
-                    <ul className="list-disc pl-4">
-                      {r.observations.map((o, i) => (
-                        <li key={i} id={`w33klyrep-obs-${i}-${r.slug}-${userId}`}>
-                          {o}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                <Link
-                  href={r.slug}
-                  className="mt-2 block text-sm text-orange-600 hover:underline"
-                  id={`w33klyrep-link-${r.slug}-${userId}`}
-                >
-                  View details
-                </Link>
-              </li>
-            );
-          }
-
-          // No report exists for this week. Only show placeholder for weeks older than previous week
-          if (w.start >= prevWeekStart.toISOString().slice(0, 10)) return null;
-          const slug = slugFromRange(w.start, w.end);
-          return (
-            <li
-              key={slug}
-              className="rounded border p-4"
-              id={`w33klyrep-miss-${slug}-${userId}`}
-            >
-              <h2
-                className="font-semibold"
-                id={`w33klyrep-date-${slug}-${userId}`}
-              >
-                {w.start} – {w.end}
-              </h2>
-              <p className="mt-2" id={`w33klyrep-miss-msg-${slug}-${userId}`}>
-                This week the user did not generate a weekly assessment.
-              </p>
-            </li>
-          );
-        })}
-      </ul>
+      <ReportOverviewClient
+        userId={userId}
+        reportType="weekly"
+        idPrefix="w33klyrep"
+        items={items}
+        initialHighlights={highlights}
+        highlightLink="highlights"
+      />
     </main>
   );
 }

--- a/app/progress/overview/yearly/highlights/page.tsx
+++ b/app/progress/overview/yearly/highlights/page.tsx
@@ -1,0 +1,50 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { redirect } from 'next/navigation';
+import BackButton from '@/components/back-button';
+import { listReportHighlights } from '@/lib/report-highlights';
+import { listYearlyReports } from '@/lib/yearly-report-store';
+import { HighlightEntriesList } from '@/components/progress/highlight-entries';
+
+export async function YearlyHighlightsSection({
+  userId,
+}: {
+  userId: number;
+}) {
+  const [highlights, reports] = await Promise.all([
+    listReportHighlights(userId, 'yearly'),
+    listYearlyReports(userId),
+  ]);
+  const reportMap = new Map(reports.map((r) => [r.slug, r]));
+  const entries = highlights.map((highlight) => {
+    const report = reportMap.get(highlight.targetSlug);
+    const title = report
+      ? `${report.startDate} – ${report.endDate}${report.version > 1 ? ` (v${report.version})` : ''}`
+      : `Year ${highlight.targetSlug}`;
+    return {
+      id: highlight.id,
+      title,
+      snippet: highlight.snippet,
+      color: highlight.color,
+      createdAt: highlight.createdAt,
+      linkHref: `../${highlight.targetSlug}`,
+    };
+  });
+  return (
+    <main className="p-6">
+      <BackButton />
+      <h1 className="mb-4 text-2xl font-bold">Yearly Highlights</h1>
+      <HighlightEntriesList
+        entries={entries}
+        emptyMessage="No yearly highlights yet. Capture the defining milestones from each year to track long-term momentum."
+      />
+    </main>
+  );
+}
+
+export default async function YearlyHighlightsPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  return <YearlyHighlightsSection userId={me.id} />;
+}

--- a/app/progress/overview/yearly/page.tsx
+++ b/app/progress/overview/yearly/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { redirect } from 'next/navigation';
@@ -9,6 +8,12 @@ import { listDailyReportDates } from '@/lib/daily-report-store';
 import { getCoachTone } from '@/lib/ai/coach-tone';
 import { getDifficultyLabel } from '@/lib/ai/difficulty';
 import BackButton from '@/components/back-button';
+import { listHighlightsForTargets } from '@/lib/report-highlights';
+import type {
+  ReportOverviewItem,
+  ReportOverviewReportItem,
+} from '@/types/report-overview';
+import ReportOverviewClient from '@/components/progress/report-overview-client';
 
 function slugFromRange(start: string, end: string): string {
   const [ys, ms, ds] = start.split('-');
@@ -49,126 +54,53 @@ export async function YearlyReportsHome({ userId }: { userId: number }) {
     list.push({ start, end, report: reportMap.get(String(y)) });
   }
 
+  const items: ReportOverviewItem[] = [];
+  for (const y of list) {
+    if (y.report) {
+      const r = y.report;
+      items.push({
+        type: 'report',
+        key: r.slug,
+        slug: r.slug,
+        title: `${r.startDate} – ${r.endDate}`,
+        version: r.version,
+        summary: r.summary,
+        good: r.good,
+        bad: r.bad,
+        observations: r.observations,
+        toneName: getCoachTone(r.coachTone).name,
+        score: r.score,
+        difficultyLabel: getDifficultyLabel(r.score),
+        linkHref: r.slug,
+      } as ReportOverviewItem);
+      continue;
+    }
+    const year = y.start.slice(0, 4);
+    if (Number(year) === currentYear - 1 && now.getUTCMonth() === 0) continue;
+    const slug = slugFromRange(y.start, y.end);
+    items.push({
+      type: 'missing',
+      key: slug,
+      title: `${y.start} – ${y.end}`,
+      message: 'This year the user did not generate a yearly assessment.',
+    } as ReportOverviewItem);
+  }
+  const slugs = items
+    .filter((item) => item.type === 'report')
+    .map((item) => (item as ReportOverviewReportItem).slug);
+  const highlights = await listHighlightsForTargets(userId, 'yearly', slugs);
   return (
     <main className="p-6">
       <BackButton />
       <h1 className="mb-4 text-2xl font-bold">Yearly Reports</h1>
-      <ul className="space-y-4" id={`y3arlyrep-list-${userId}`}>
-        {list.map((y) => {
-          if (y.report) {
-            const r = y.report;
-            return (
-              <li
-                key={r.slug}
-                className="rounded border p-4"
-                id={`y3arlyrep-item-${r.slug}-${userId}`}
-              >
-                <div className="flex items-center justify-between">
-                  <h2
-                    className="font-semibold"
-                    id={`y3arlyrep-date-${r.slug}-${userId}`}
-                  >
-                    {r.startDate} – {r.endDate}
-                    {r.version > 1 && <span className="ml-1">(v{r.version})</span>}
-                  </h2>
-                  <div className="flex items-center gap-2">
-                    <span
-                      className="font-semibold"
-                      id={`y3arlyrep-tone-${r.slug}-${userId}`}
-                    >
-                      {getCoachTone(r.coachTone).name}
-                    </span>
-                    <span
-                      className="font-semibold"
-                      id={`y3arlyrep-score-${r.slug}-${userId}`}
-                    >
-                      {r.score}
-                    </span>
-                    <span
-                      className="ml-1 text-sm text-zinc-600"
-                      id={`y3arlyrep-diff-${r.slug}-${userId}`}
-                    >
-                      {getDifficultyLabel(r.score)}
-                    </span>
-                  </div>
-                </div>
-                {r.summary && (
-                  <p
-                    className="mt-2 whitespace-pre-wrap"
-                    id={`y3arlyrep-sum-${r.slug}-${userId}`}
-                  >
-                    {r.summary}
-                  </p>
-                )}
-                {r.good.length > 0 && (
-                  <div className="mt-2" id={`y3arlyrep-good-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">What went well</h3>
-                    <ul className="list-disc pl-4">
-                      {r.good.map((g, i) => (
-                        <li key={i} id={`y3arlyrep-good-${i}-${r.slug}-${userId}`}>
-                          {g}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {r.bad.length > 0 && (
-                  <div className="mt-2" id={`y3arlyrep-bad-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">What went bad</h3>
-                    <ul className="list-disc pl-4">
-                      {r.bad.map((b, i) => (
-                        <li key={i} id={`y3arlyrep-bad-${i}-${r.slug}-${userId}`}>
-                          {b}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                {r.observations.length > 0 && (
-                  <div className="mt-2" id={`y3arlyrep-obs-${r.slug}-${userId}`}>
-                    <h3 className="font-semibold">Observations</h3>
-                    <ul className="list-disc pl-4">
-                      {r.observations.map((o, i) => (
-                        <li key={i} id={`y3arlyrep-obs-${i}-${r.slug}-${userId}`}>
-                          {o}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                )}
-                <Link
-                  href={r.slug}
-                  className="mt-2 block text-sm text-orange-600 hover:underline"
-                  id={`y3arlyrep-link-${r.slug}-${userId}`}
-                >
-                  View details
-                </Link>
-              </li>
-            );
-          }
-          const year = y.start.slice(0, 4);
-          if (Number(year) === currentYear - 1 && now.getUTCMonth() === 0)
-            return null;
-          const slug = slugFromRange(y.start, y.end);
-          return (
-            <li
-              key={slug}
-              className="rounded border p-4"
-              id={`y3arlyrep-miss-${slug}-${userId}`}
-            >
-              <h2
-                className="font-semibold"
-                id={`y3arlyrep-date-${slug}-${userId}`}
-              >
-                {y.start} – {y.end}
-              </h2>
-              <p className="mt-2" id={`y3arlyrep-miss-msg-${slug}-${userId}`}>
-                This year the user did not generate a yearly assessment.
-              </p>
-            </li>
-          );
-        })}
-      </ul>
+      <ReportOverviewClient
+        userId={userId}
+        reportType="yearly"
+        idPrefix="y3arlyrep"
+        items={items}
+        initialHighlights={highlights}
+        highlightLink="highlights"
+      />
     </main>
   );
 }

--- a/components/progress/highlight-entries.tsx
+++ b/components/progress/highlight-entries.tsx
@@ -1,0 +1,75 @@
+import Link from 'next/link';
+
+export interface HighlightListEntry {
+  id: number;
+  title: string;
+  snippet: string;
+  color: string;
+  createdAt: string;
+  linkHref: string;
+  subtitle?: string;
+}
+
+function formatDateTime(value: string): string {
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+export function HighlightEntriesList({
+  entries,
+  emptyMessage,
+}: {
+  entries: HighlightListEntry[];
+  emptyMessage: string;
+}) {
+  if (entries.length === 0) {
+    return <p className="text-sm text-zinc-600">{emptyMessage}</p>;
+  }
+  return (
+    <ul className="space-y-4">
+      {entries.map((entry) => (
+        <li key={entry.id} className="rounded border p-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="font-semibold">{entry.title}</p>
+              {entry.subtitle && (
+                <p className="text-sm text-zinc-500">{entry.subtitle}</p>
+              )}
+            </div>
+            <span className="text-sm text-zinc-500">
+              {formatDateTime(entry.createdAt)}
+            </span>
+          </div>
+          <div className="mt-3 flex items-center gap-3">
+            <span
+              className="inline-block h-4 w-4 rounded-full"
+              style={{ backgroundColor: entry.color }}
+              aria-hidden="true"
+            />
+            <span
+              className="rounded px-2 py-1 text-sm font-medium"
+              style={{
+                backgroundColor: entry.color,
+                color: '#111827',
+              }}
+            >
+              {entry.snippet}
+            </span>
+          </div>
+          <Link
+            href={entry.linkHref}
+            className="mt-3 inline-block text-sm text-orange-600 hover:underline"
+          >
+            View in context
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/progress/highlightable-text.tsx
+++ b/components/progress/highlightable-text.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useMemo, useRef, useCallback, type CSSProperties } from 'react';
+import clsx from 'clsx';
+import { useHighlightingContext } from './highlighting-context';
+
+interface HighlightRange {
+  id: number;
+  startOffset: number;
+  endOffset: number;
+  color: string;
+  snippet: string;
+  createdAt: string;
+}
+
+type HighlightElement = 'span' | 'p' | 'h2' | 'li';
+
+interface HighlightableTextProps {
+  as?: HighlightElement;
+  id?: string;
+  className?: string;
+  style?: CSSProperties;
+  text: string;
+  targetSlug: string;
+  blockId: string;
+  highlights?: HighlightRange[];
+}
+
+interface Segment {
+  text: string;
+  color?: string;
+}
+
+function buildSegments(text: string, highlights: HighlightRange[] = []): Segment[] {
+  if (!text) return [{ text }];
+  if (!highlights || highlights.length === 0) return [{ text }];
+  const sorted = [...highlights]
+    .map((h) => ({
+      ...h,
+      startOffset: Math.max(0, Math.min(text.length, h.startOffset)),
+      endOffset: Math.max(0, Math.min(text.length, h.endOffset)),
+    }))
+    .filter((h) => h.endOffset > h.startOffset)
+    .sort((a, b) => a.startOffset - b.startOffset);
+  const segments: Segment[] = [];
+  let cursor = 0;
+  for (const h of sorted) {
+    if (h.startOffset > cursor) {
+      segments.push({ text: text.slice(cursor, h.startOffset) });
+    }
+    segments.push({
+      text: text.slice(h.startOffset, h.endOffset),
+      color: h.color,
+    });
+    cursor = Math.max(cursor, h.endOffset);
+  }
+  if (cursor < text.length) {
+    segments.push({ text: text.slice(cursor) });
+  }
+  if (segments.length === 0) {
+    return [{ text }];
+  }
+  return segments;
+}
+
+function collectTextNodes(root: Node): Text[] {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const nodes: Text[] = [];
+  let current = walker.nextNode();
+  while (current) {
+    if (current.nodeType === Node.TEXT_NODE) {
+      nodes.push(current as Text);
+    }
+    current = walker.nextNode();
+  }
+  return nodes;
+}
+
+function getOffsets(container: HTMLElement, range: Range): { start: number; end: number } | null {
+  const textNodes = collectTextNodes(container);
+  let start = 0;
+  let end = 0;
+  let cursor = 0;
+  let startFound = false;
+  let endFound = false;
+  for (const node of textNodes) {
+    const length = node.textContent?.length ?? 0;
+    if (!startFound && node === range.startContainer) {
+      start = cursor + range.startOffset;
+      startFound = true;
+    }
+    if (!endFound && node === range.endContainer) {
+      end = cursor + range.endOffset;
+      endFound = true;
+      break;
+    }
+    cursor += length;
+  }
+  if (!startFound || !endFound) return null;
+  return { start, end };
+}
+
+export default function HighlightableText({
+  as: Element = 'span',
+  id,
+  className,
+  style,
+  text,
+  targetSlug,
+  blockId,
+  highlights = [],
+}: HighlightableTextProps) {
+  const containerRef = useRef<HTMLElement | null>(null);
+  const { highlightEnabled, editable, isSaving, createHighlight } =
+    useHighlightingContext();
+
+  const segments = useMemo(() => buildSegments(text, highlights), [text, highlights]);
+
+  const handleMouseUp = useCallback(async () => {
+    if (!editable || !highlightEnabled || isSaving) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+    const range = selection.getRangeAt(0);
+    if (!container.contains(range.startContainer) || !container.contains(range.endContainer)) {
+      return;
+    }
+    const snippet = selection.toString();
+    if (!snippet.trim()) return;
+    const offsets = getOffsets(container, range);
+    if (!offsets) return;
+    selection.removeAllRanges();
+    await createHighlight({
+      targetSlug,
+      blockId,
+      startOffset: offsets.start,
+      endOffset: offsets.end,
+      snippet,
+    });
+  }, [editable, highlightEnabled, isSaving, targetSlug, blockId, createHighlight]);
+
+  return (
+    <Element
+      id={id}
+      className={clsx(className, {
+        'cursor-text': editable && highlightEnabled,
+      })}
+      style={style}
+      ref={(node: HTMLElement | null) => {
+        containerRef.current = node;
+      }}
+      onMouseUp={handleMouseUp}
+      data-highlight-block={blockId}
+    >
+      {segments.map((segment, index) =>
+        segment.color ? (
+          <span
+            key={index}
+            className="rounded px-1 py-0.5"
+            style={{
+              backgroundColor: segment.color,
+              color: '#111827',
+            }}
+          >
+            {segment.text}
+          </span>
+        ) : (
+          <span key={index}>{segment.text}</span>
+        ),
+      )}
+    </Element>
+  );
+}

--- a/components/progress/highlighting-context.tsx
+++ b/components/progress/highlighting-context.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  type PropsWithChildren,
+} from 'react';
+
+export interface HighlightCreationInput {
+  targetSlug: string;
+  blockId: string;
+  startOffset: number;
+  endOffset: number;
+  snippet: string;
+}
+
+export interface HighlightingContextValue {
+  highlightEnabled: boolean;
+  selectedColor: string;
+  editable: boolean;
+  isSaving: boolean;
+  createHighlight: (input: HighlightCreationInput) => Promise<void>;
+}
+
+const HighlightingContext = createContext<HighlightingContextValue | null>(
+  null,
+);
+
+export function HighlightingProvider({
+  value,
+  children,
+}: PropsWithChildren<{ value: HighlightingContextValue }>) {
+  return (
+    <HighlightingContext.Provider value={value}>
+      {children}
+    </HighlightingContext.Provider>
+  );
+}
+
+export function useHighlightingContext(): HighlightingContextValue {
+  const ctx = useContext(HighlightingContext);
+  if (!ctx) {
+    throw new Error('HighlightingContext is not available');
+  }
+  return ctx;
+}

--- a/components/progress/report-overview-client.tsx
+++ b/components/progress/report-overview-client.tsx
@@ -1,0 +1,389 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import Link from 'next/link';
+import clsx from 'clsx';
+import { useViewContext } from '@/lib/view-context';
+import type {
+  ReportHighlight,
+  ReportHighlightType,
+} from '@/lib/report-highlights';
+import type { ReportOverviewItem } from '@/types/report-overview';
+import HighlightableText from './highlightable-text';
+import {
+  HighlightingProvider,
+  type HighlightCreationInput,
+} from './highlighting-context';
+
+interface HighlightRange {
+  id: number;
+  startOffset: number;
+  endOffset: number;
+  color: string;
+  snippet: string;
+  createdAt: string;
+}
+
+type HighlightMap = Record<string, Record<string, HighlightRange[]>>;
+
+const HIGHLIGHT_COLORS = [
+  '#f97316',
+  '#facc15',
+  '#34d399',
+  '#60a5fa',
+  '#f472b6',
+  '#a855f7',
+];
+
+function groupHighlights(highlights: ReportHighlight[]): HighlightMap {
+  const map: HighlightMap = {};
+  for (const h of highlights) {
+    if (!h.targetSlug || !h.blockId) continue;
+    const slugMap = map[h.targetSlug] ?? (map[h.targetSlug] = {});
+    const blockArr = slugMap[h.blockId] ?? (slugMap[h.blockId] = []);
+    blockArr.push({
+      id: h.id,
+      startOffset: h.startOffset,
+      endOffset: h.endOffset,
+      color: h.color,
+      snippet: h.snippet,
+      createdAt: h.createdAt,
+    });
+  }
+  for (const slug of Object.keys(map)) {
+    const block = map[slug];
+    for (const key of Object.keys(block)) {
+      block[key].sort((a, b) => a.startOffset - b.startOffset);
+    }
+  }
+  return map;
+}
+
+function addHighlight(map: HighlightMap, highlight: ReportHighlight): HighlightMap {
+  const next: HighlightMap = { ...map };
+  const slugMap = { ...(next[highlight.targetSlug] ?? {}) };
+  const existing = [...(slugMap[highlight.blockId] ?? [])];
+  const replacement: HighlightRange = {
+    id: highlight.id,
+    startOffset: highlight.startOffset,
+    endOffset: highlight.endOffset,
+    color: highlight.color,
+    snippet: highlight.snippet,
+    createdAt: highlight.createdAt,
+  };
+  const filtered = existing.filter(
+    (h) => !(h.startOffset === replacement.startOffset && h.endOffset === replacement.endOffset),
+  );
+  filtered.push(replacement);
+  filtered.sort((a, b) => a.startOffset - b.startOffset);
+  slugMap[highlight.blockId] = filtered;
+  next[highlight.targetSlug] = slugMap;
+  return next;
+}
+
+interface ReportOverviewClientProps {
+  userId: number;
+  reportType: ReportHighlightType;
+  idPrefix: string;
+  items: ReportOverviewItem[];
+  initialHighlights: ReportHighlight[];
+  highlightLink: string;
+}
+
+export default function ReportOverviewClient({
+  userId,
+  reportType,
+  idPrefix,
+  items,
+  initialHighlights,
+  highlightLink,
+}: ReportOverviewClientProps) {
+  const { editable } = useViewContext();
+  const [highlightMap, setHighlightMap] = useState<HighlightMap>(() =>
+    groupHighlights(initialHighlights),
+  );
+  const [highlightMode, setHighlightMode] = useState(false);
+  const [selectedColor, setSelectedColor] = useState(HIGHLIGHT_COLORS[0]);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleCreateHighlight = useCallback(
+    async (input: HighlightCreationInput) => {
+      setErrorMessage(null);
+      setStatusMessage(null);
+      setIsSaving(true);
+      try {
+        const res = await fetch('/api/progress/highlights', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            ...input,
+            color: selectedColor,
+            reportType,
+          }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(
+            typeof data?.error === 'string'
+              ? data.error
+              : 'Failed to save highlight',
+          );
+        }
+        const highlight = data.highlight as ReportHighlight;
+        setHighlightMap((prev) => addHighlight(prev, highlight));
+        setStatusMessage('Highlight saved');
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Failed to save highlight';
+        setErrorMessage(message);
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [reportType, selectedColor],
+  );
+
+  const toggleHighlightMode = useCallback(() => {
+    if (!editable) return;
+    setHighlightMode((prev) => !prev);
+    setErrorMessage(null);
+    setStatusMessage(null);
+  }, [editable]);
+
+  const highlightContext = useMemo(
+    () => ({
+      highlightEnabled: editable && highlightMode,
+      selectedColor,
+      editable,
+      isSaving,
+      createHighlight: handleCreateHighlight,
+    }),
+    [editable, highlightMode, selectedColor, isSaving, handleCreateHighlight],
+  );
+
+  const palette = editable && highlightMode;
+
+  return (
+    <HighlightingProvider value={highlightContext}>
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-3">
+          {editable && (
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                onClick={toggleHighlightMode}
+                className={clsx(
+                  'inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition',
+                  highlightMode
+                    ? 'border-orange-500 bg-orange-100 text-orange-700'
+                    : 'border-zinc-200 bg-white text-zinc-700 hover:border-orange-400 hover:text-orange-600',
+                )}
+                aria-pressed={highlightMode}
+                disabled={isSaving}
+              >
+                <span className="flex h-5 w-5 items-center justify-center rounded-full bg-orange-200 text-orange-700">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth={1.5}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="h-3.5 w-3.5"
+                  >
+                    <path d="M3 12c2.5-6.5 7.5-9 13-7.5 3 .8 4.5 3.5 3.5 5.8-1 2.3-3.3 3.3-5.5 3.3H9.5c-1.7 0-2.7 1.7-2 3.1l.3.7" />
+                    <path d="M7.5 21h2l1.5-3" />
+                  </svg>
+                </span>
+                Highlight
+              </button>
+              {palette && (
+                <div className="flex items-center gap-2">
+                  {HIGHLIGHT_COLORS.map((color) => (
+                    <button
+                      key={color}
+                      type="button"
+                      onClick={() => setSelectedColor(color)}
+                      className={clsx(
+                        'h-7 w-7 rounded-full border-2 transition hover:scale-110 focus:outline-none focus:ring-2 focus:ring-orange-400 focus:ring-offset-2',
+                        selectedColor === color
+                          ? 'border-zinc-900'
+                          : 'border-transparent',
+                      )}
+                      style={{ backgroundColor: color }}
+                      aria-label={`Use ${color} highlight color`}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+          <Link
+            href={highlightLink}
+            className="inline-flex items-center rounded-full border border-zinc-200 px-4 py-2 text-sm font-medium text-orange-600 transition hover:border-orange-400 hover:text-orange-700"
+          >
+            View highlights
+          </Link>
+        </div>
+        <div className="flex flex-col gap-1 text-sm">
+          {highlightMode && editable && (
+            <span className="text-zinc-500">
+              Select any text to save it. Highlights are shared instantly.
+            </span>
+          )}
+          {errorMessage && (
+            <span className="text-red-600">{errorMessage}</span>
+          )}
+          {statusMessage && !errorMessage && (
+            <span className="text-green-600">{statusMessage}</span>
+          )}
+        </div>
+      </div>
+      <ul className="space-y-4" id={`${idPrefix}-list-${userId}`}>
+        {items.map((item) => {
+          if (item.type === 'missing') {
+            return (
+              <li
+                key={item.key}
+                className="rounded border p-4"
+                id={`${idPrefix}-miss-${item.key}-${userId}`}
+              >
+                <h2 className="font-semibold">{item.title}</h2>
+                <p className="mt-2 text-sm text-zinc-600">{item.message}</p>
+              </li>
+            );
+          }
+          const slugHighlights = highlightMap[item.slug] ?? {};
+          const headerText =
+            item.version && item.version > 1
+              ? `${item.title} (v${item.version})`
+              : item.title;
+          return (
+            <li
+              key={item.key}
+              className="rounded border p-4"
+              id={`${idPrefix}-item-${item.slug}-${userId}`}
+            >
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <HighlightableText
+                  as="h2"
+                  id={`${idPrefix}-date-${item.slug}-${userId}`}
+                  className="font-semibold"
+                  text={headerText}
+                  targetSlug={item.slug}
+                  blockId="title"
+                  highlights={slugHighlights.title}
+                />
+                <div className="flex items-center gap-2">
+                  <HighlightableText
+                    as="span"
+                    id={`${idPrefix}-tone-${item.slug}-${userId}`}
+                    className="font-semibold"
+                    text={item.toneName}
+                    targetSlug={item.slug}
+                    blockId="tone"
+                    highlights={slugHighlights.tone}
+                  />
+                  <HighlightableText
+                    as="span"
+                    id={`${idPrefix}-score-${item.slug}-${userId}`}
+                    className="font-semibold"
+                    text={String(item.score)}
+                    targetSlug={item.slug}
+                    blockId="score"
+                    highlights={slugHighlights.score}
+                  />
+                  <HighlightableText
+                    as="span"
+                    id={`${idPrefix}-diff-${item.slug}-${userId}`}
+                    className="ml-1 text-sm text-zinc-600"
+                    text={item.difficultyLabel}
+                    targetSlug={item.slug}
+                    blockId="difficulty"
+                    highlights={slugHighlights.difficulty}
+                  />
+                </div>
+              </div>
+              {item.summary && (
+                <HighlightableText
+                  as="p"
+                  id={`${idPrefix}-sum-${item.slug}-${userId}`}
+                  className="mt-2 whitespace-pre-wrap"
+                  text={item.summary}
+                  targetSlug={item.slug}
+                  blockId="summary"
+                  highlights={slugHighlights.summary}
+                />
+              )}
+              {item.good.length > 0 && (
+                <div className="mt-2" id={`${idPrefix}-good-${item.slug}-${userId}`}>
+                  <h3 className="font-semibold">What went well</h3>
+                  <ul className="list-disc pl-4">
+                    {item.good.map((text, index) => (
+                      <HighlightableText
+                        key={index}
+                        as="li"
+                        id={`${idPrefix}-good-${index}-${item.slug}-${userId}`}
+                        text={text}
+                        targetSlug={item.slug}
+                        blockId={`good-${index}`}
+                        highlights={slugHighlights[`good-${index}`]}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {item.bad.length > 0 && (
+                <div className="mt-2" id={`${idPrefix}-bad-${item.slug}-${userId}`}>
+                  <h3 className="font-semibold">What went bad</h3>
+                  <ul className="list-disc pl-4">
+                    {item.bad.map((text, index) => (
+                      <HighlightableText
+                        key={index}
+                        as="li"
+                        id={`${idPrefix}-bad-${index}-${item.slug}-${userId}`}
+                        text={text}
+                        targetSlug={item.slug}
+                        blockId={`bad-${index}`}
+                        highlights={slugHighlights[`bad-${index}`]}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {item.observations.length > 0 && (
+                <div className="mt-2" id={`${idPrefix}-obs-${item.slug}-${userId}`}>
+                  <h3 className="font-semibold">Observations</h3>
+                  <ul className="list-disc pl-4">
+                    {item.observations.map((text, index) => (
+                      <HighlightableText
+                        key={index}
+                        as="li"
+                        id={`${idPrefix}-obs-${index}-${item.slug}-${userId}`}
+                        text={text}
+                        targetSlug={item.slug}
+                        blockId={`obs-${index}`}
+                        highlights={slugHighlights[`obs-${index}`]}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              )}
+              <Link
+                href={item.linkHref}
+                className="mt-2 block text-sm text-orange-600 hover:underline"
+                id={`${idPrefix}-link-${item.slug}-${userId}`}
+              >
+                View details
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </HighlightingProvider>
+  );
+}

--- a/drizzle/0033_create_report_highlights.sql
+++ b/drizzle/0033_create_report_highlights.sql
@@ -1,0 +1,20 @@
+CREATE TYPE report_highlight_type AS ENUM ('daily', 'weekly', 'monthly', 'yearly');
+
+CREATE TABLE report_highlights (
+    id serial PRIMARY KEY,
+    user_id integer NOT NULL REFERENCES users(id),
+    report_type report_highlight_type NOT NULL,
+    target_slug text NOT NULL,
+    block_id text NOT NULL,
+    start_offset integer NOT NULL,
+    end_offset integer NOT NULL,
+    color text NOT NULL,
+    snippet text NOT NULL,
+    created_at timestamp DEFAULT now()
+);
+
+CREATE UNIQUE INDEX report_highlights_unique_idx
+    ON report_highlights (user_id, report_type, target_slug, block_id, start_offset, end_offset);
+
+CREATE INDEX report_highlights_user_type_created_idx
+    ON report_highlights (user_id, report_type, created_at DESC);

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -8,6 +8,7 @@ import {
   integer,
   pgEnum,
   uniqueIndex,
+  index,
   json,
   jsonb,
   boolean,
@@ -30,6 +31,13 @@ export const notificationTypeEnum = pgEnum('notification_type', [
   'follow_accepted',
   'follow_declined',
   'unfollow',
+]);
+
+export const reportHighlightTypeEnum = pgEnum('report_highlight_type', [
+  'daily',
+  'weekly',
+  'monthly',
+  'yearly',
 ]);
 
 export const users = pgTable('users', {
@@ -383,6 +391,39 @@ export const yearlyReports = pgTable(
     uniqueUserYearVersion: uniqueIndex(
       'yearly_reports_user_year_version_unique',
     ).on(table.userId, table.startDate, table.version),
+  }),
+);
+
+export const reportHighlights = pgTable(
+  'report_highlights',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    reportType: reportHighlightTypeEnum('report_type').notNull(),
+    targetSlug: text('target_slug').notNull(),
+    blockId: text('block_id').notNull(),
+    startOffset: integer('start_offset').notNull(),
+    endOffset: integer('end_offset').notNull(),
+    color: text('color').notNull(),
+    snippet: text('snippet').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserTargetRange: uniqueIndex('report_highlights_unique_idx').on(
+      table.userId,
+      table.reportType,
+      table.targetSlug,
+      table.blockId,
+      table.startOffset,
+      table.endOffset,
+    ),
+    userTypeCreatedIdx: index('report_highlights_user_type_created_idx').on(
+      table.userId,
+      table.reportType,
+      table.createdAt,
+    ),
   }),
 );
 

--- a/lib/report-highlights.ts
+++ b/lib/report-highlights.ts
@@ -1,0 +1,169 @@
+import { db } from './db';
+import {
+  reportHighlights,
+  reportHighlightTypeEnum,
+} from './db/schema';
+import { and, desc, eq, inArray } from 'drizzle-orm';
+
+export type ReportHighlightType =
+  (typeof reportHighlightTypeEnum.enumValues)[number];
+
+export type ReportHighlightRow = typeof reportHighlights.$inferSelect;
+
+export interface ReportHighlight {
+  id: number;
+  userId: number;
+  reportType: ReportHighlightType;
+  targetSlug: string;
+  blockId: string;
+  startOffset: number;
+  endOffset: number;
+  color: string;
+  snippet: string;
+  createdAt: string;
+}
+
+export interface ReportHighlightInput {
+  reportType: ReportHighlightType;
+  targetSlug: string;
+  blockId: string;
+  startOffset: number;
+  endOffset: number;
+  color: string;
+  snippet: string;
+}
+
+function toHighlight(row: ReportHighlightRow): ReportHighlight {
+  return {
+    id: row.id,
+    userId: row.userId ?? 0,
+    reportType: row.reportType as ReportHighlightType,
+    targetSlug: row.targetSlug ?? '',
+    blockId: row.blockId ?? '',
+    startOffset: row.startOffset ?? 0,
+    endOffset: row.endOffset ?? 0,
+    color: row.color ?? '#f97316',
+    snippet: row.snippet ?? '',
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+  };
+}
+
+function sanitizeColor(color: string): string {
+  const trimmed = color.trim();
+  if (/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(trimmed)) {
+    return trimmed;
+  }
+  throw new Error('Invalid highlight color');
+}
+
+function sanitizeSnippet(snippet: string): string {
+  const trimmed = snippet.trim();
+  if (!trimmed) {
+    throw new Error('Cannot highlight empty text');
+  }
+  return trimmed.slice(0, 500);
+}
+
+function sanitizeOffsets(start: number, end: number): { start: number; end: number } {
+  const startOffset = Number.isFinite(start) ? Math.max(0, Math.floor(start)) : 0;
+  const endOffset = Number.isFinite(end) ? Math.max(0, Math.floor(end)) : 0;
+  if (endOffset <= startOffset) {
+    throw new Error('Highlight end must be after start');
+  }
+  if (endOffset - startOffset > 4000) {
+    throw new Error('Highlight selection is too large');
+  }
+  return { start: startOffset, end: endOffset };
+}
+
+function sanitizeTarget(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${label} is required`);
+  }
+  if (trimmed.length > 160) {
+    throw new Error(`${label} is too long`);
+  }
+  return trimmed;
+}
+
+export async function listReportHighlights(
+  userId: number,
+  reportType: ReportHighlightType,
+): Promise<ReportHighlight[]> {
+  const rows = await db
+    .select()
+    .from(reportHighlights)
+    .where(
+      and(
+        eq(reportHighlights.userId, userId),
+        eq(reportHighlights.reportType, reportType),
+      ),
+    )
+    .orderBy(desc(reportHighlights.createdAt));
+  return rows.map(toHighlight);
+}
+
+export async function listHighlightsForTargets(
+  userId: number,
+  reportType: ReportHighlightType,
+  targetSlugs: string[],
+): Promise<ReportHighlight[]> {
+  if (targetSlugs.length === 0) return [];
+  const rows = await db
+    .select()
+    .from(reportHighlights)
+    .where(
+      and(
+        eq(reportHighlights.userId, userId),
+        eq(reportHighlights.reportType, reportType),
+        inArray(reportHighlights.targetSlug, targetSlugs),
+      ),
+    )
+    .orderBy(reportHighlights.targetSlug, reportHighlights.startOffset);
+  return rows.map(toHighlight);
+}
+
+export async function saveReportHighlight(
+  userId: number,
+  input: ReportHighlightInput,
+): Promise<ReportHighlight> {
+  const { start, end } = sanitizeOffsets(input.startOffset, input.endOffset);
+  const snippet = sanitizeSnippet(input.snippet);
+  const targetSlug = sanitizeTarget(input.targetSlug, 'Target');
+  const blockId = sanitizeTarget(input.blockId, 'Block');
+  const color = sanitizeColor(input.color);
+
+  const now = new Date();
+  const [row] = await db
+    .insert(reportHighlights)
+    .values({
+      userId,
+      reportType: input.reportType,
+      targetSlug,
+      blockId,
+      startOffset: start,
+      endOffset: end,
+      color,
+      snippet,
+      createdAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        reportHighlights.userId,
+        reportHighlights.reportType,
+        reportHighlights.targetSlug,
+        reportHighlights.blockId,
+        reportHighlights.startOffset,
+        reportHighlights.endOffset,
+      ],
+      set: {
+        color,
+        snippet,
+        createdAt: now,
+      },
+    })
+    .returning();
+
+  return toHighlight(row);
+}

--- a/types/report-overview.ts
+++ b/types/report-overview.ts
@@ -1,0 +1,27 @@
+export interface ReportOverviewReportItem {
+  type: 'report';
+  key: string;
+  slug: string;
+  title: string;
+  version?: number;
+  summary: string;
+  good: string[];
+  bad: string[];
+  observations: string[];
+  toneName: string;
+  score: number;
+  difficultyLabel: string;
+  linkHref: string;
+}
+
+export interface ReportOverviewMissingItem {
+  type: 'missing';
+  key: string;
+  title: string;
+  message: string;
+}
+
+export type ReportOverviewItem =
+  | ReportOverviewReportItem
+  | ReportOverviewMissingItem;
+


### PR DESCRIPTION
## Summary
- add a persistent report_highlights table and API endpoint to store colored text selections
- refactor progress overview pages to use a new highlight-aware client component with color palette and shared state
- surface highlight feeds for daily, weekly, monthly, and yearly reports for owners and viewers

## Testing
- pnpm lint
- pnpm tsc
- pnpm test *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1bc2bedc832aa08622bf863abc66