### PR TITLE
feat: add activity block presets

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -301,3 +301,4 @@
 - 2025-10-30: Fixed highlight "View in context" routes for owners and viewers and resynced saved markup so overlays persist after revisiting overview pages.
 - 2025-10-30: Forced overview caches to refresh after highlight edits and lit up detail pages with the saved markup so "View in context" immediately shows colored snippets.
 - 2025-10-30: Added custom coach tone saving with completion feedback, fed custom briefs into all rapport prompts, and surfaced the stored tone snapshot on review and planning pages so users (and viewers) see the exact instructions used.
+- 2025-10-30: Added activity block presets with category management, save-from-metadata controls, and a custom timeslot library for quick insertion.

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -14,12 +14,15 @@ import type { ChatMessage, ChatThread } from '@/types/chat';
 import { savePlanAction } from './actions';
 import { cn } from '@/lib/utils';
 import ColorPresetPicker from '@/components/color-preset-picker';
+import BlockPresetLibrary from '@/components/block-preset-library';
+import BlockPresetSaveDialog from '@/components/block-preset-save-dialog';
 import {
   addUserColorPreset,
   getUserColorPresets,
   DEFAULT_COLOR_PRESETS,
   type ColorPreset,
 } from '@/lib/color-presets';
+import type { BlockPreset } from '@/lib/block-presets';
 import type {
   HeadingReport,
   DailyReport,
@@ -307,6 +310,13 @@ export default function EditorClient({
     return {};
   });
   const [showPresetPicker, setShowPresetPicker] = useState(false);
+  const [showBlockPresetLibrary, setShowBlockPresetLibrary] = useState(false);
+  const libraryContainerRef = useRef<HTMLDivElement | null>(null);
+  const [presetMenuOpen, setPresetMenuOpen] = useState(false);
+  const presetMenuRef = useRef<HTMLDivElement | null>(null);
+  const [presetDialogBlockId, setPresetDialogBlockId] = useState<string | null>(
+    null,
+  );
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [metaPinned, setMetaPinned] = useState(false);
   const openMeta = useCallback((id: string) => {
@@ -328,6 +338,38 @@ export default function EditorClient({
   useEffect(() => {
     setSelectFlavor(false);
   }, [selectedId]);
+  useEffect(() => {
+    if (!showBlockPresetLibrary) return;
+    function handleClick(event: MouseEvent) {
+      if (!libraryContainerRef.current) return;
+      if (!libraryContainerRef.current.contains(event.target as Node)) {
+        setShowBlockPresetLibrary(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [showBlockPresetLibrary]);
+  useEffect(() => {
+    if (!presetMenuOpen) return;
+    function handleClick(event: MouseEvent) {
+      if (!presetMenuRef.current) return;
+      if (!presetMenuRef.current.contains(event.target as Node)) {
+        setPresetMenuOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [presetMenuOpen]);
+  useEffect(() => {
+    setPresetMenuOpen(false);
+  }, [selected?.id]);
+  useEffect(() => {
+    if (!editable) {
+      setShowBlockPresetLibrary(false);
+      setPresetMenuOpen(false);
+      setPresetDialogBlockId(null);
+    }
+  }, [editable]);
   const unreviewedIngredientIds = useMemo(() => {
     if (!selected) return [] as number[];
     const reviewed = reviews[selected.id]?.ingredients || {};
@@ -475,15 +517,30 @@ export default function EditorClient({
     const m = String(min % 60).padStart(2, '0');
     return `${h}:${m}`;
   }
-  function isoFromMinutes(min: number) {
-    const base = new Date(`${date}T00:00:00`);
-    return new Date(base.getTime() + min * 60000).toISOString();
-  }
+  const isoFromMinutes = useCallback(
+    (min: number) => {
+      const base = new Date(`${date}T00:00:00`);
+      return new Date(base.getTime() + min * 60000).toISOString();
+    },
+    [date],
+  );
 
   function minutesFromTime(t: string) {
     const [h, m] = t.split(':').map((v) => parseInt(v, 10));
     return (h || 0) * 60 + (m || 0);
   }
+
+  const presetDialogBlock = useMemo(
+    () => blocks.find((b) => b.id === presetDialogBlockId) ?? null,
+    [blocks, presetDialogBlockId],
+  );
+  const presetDialogDuration = useMemo(() => {
+    if (!presetDialogBlock) return 0;
+    return (
+      minutesFromIso(presetDialogBlock.end) -
+      minutesFromIso(presetDialogBlock.start)
+    );
+  }, [presetDialogBlock, minutesFromIso]);
 
   function buildPlanBlocksContext(list: PlanBlock[]) {
     return list
@@ -1014,6 +1071,91 @@ export default function EditorClient({
     });
   }
 
+  const handlePresetSelected = useCallback(
+    (preset: BlockPreset) => {
+      if (!editable || review) return;
+      const safeDuration = Math.max(
+        15,
+        Math.min(MAX_MINUTES, Math.round(preset.duration || 0)),
+      );
+      const sorted = [...blocks].sort(
+        (a, b) => minutesFromIso(a.start) - minutesFromIso(b.start),
+      );
+      const isFree = (start: number, end: number) =>
+        !sorted.some(
+          (b) =>
+            Math.max(start, minutesFromIso(b.start)) <
+            Math.min(end, minutesFromIso(b.end)),
+        );
+      const findSlot = (duration: number) => {
+        let cursor = startMinute;
+        while (cursor + duration <= endMinute) {
+          if (isFree(cursor, cursor + duration)) return cursor;
+          cursor += 15;
+        }
+        return null;
+      };
+      let candidate = findSlot(safeDuration);
+      if (candidate === null) {
+        const minStart = Math.max(0, Math.min(startMinute, MAX_MINUTES - safeDuration));
+        const maxStart = Math.max(
+          minStart,
+          Math.min(endMinute, MAX_MINUTES) - safeDuration,
+        );
+        if (maxStart <= minStart) {
+          candidate = minStart;
+        } else {
+          const steps = Math.floor((maxStart - minStart) / 15);
+          const randomStep = steps > 0 ? Math.floor(Math.random() * (steps + 1)) : 0;
+          candidate = minStart + randomStep * 15;
+        }
+      }
+      if (candidate === null) {
+        alert('No space available for this preset. Please adjust your timeline.');
+        return;
+      }
+      const start = Math.max(0, Math.min(candidate, MAX_MINUTES - safeDuration));
+      const end = Math.min(start + safeDuration, MAX_MINUTES);
+      const nowIso = new Date().toISOString();
+      const id = crypto.randomUUID();
+      const newBlock: PlanBlock = {
+        id,
+        planId: initialPlan?.id || '',
+        start: isoFromMinutes(start),
+        end: isoFromMinutes(end),
+        title: preset.title || preset.name,
+        description: preset.description,
+        color: preset.color || COLORS[0],
+        colorPreset: preset.colorPreset || '',
+        ingredientIds: [...(preset.ingredientIds ?? [])],
+        flavorIds: [...(preset.flavorIds ?? [])],
+        subflavorIds: [...(preset.subflavorIds ?? [])],
+        createdAt: nowIso,
+        updatedAt: nowIso,
+      };
+      setBlocks((prev) => [...prev, newBlock]);
+      setShowBlockPresetLibrary(false);
+      openMeta(id);
+    },
+    [
+      editable,
+      review,
+      blocks,
+      minutesFromIso,
+      startMinute,
+      endMinute,
+      initialPlan?.id,
+      setBlocks,
+      setShowBlockPresetLibrary,
+      isoFromMinutes,
+      openMeta,
+    ],
+  );
+
+  const handlePresetSaved = useCallback((preset: BlockPreset) => {
+    alert(`Saved "${preset.name}" to your activity presets.`);
+  }, []);
+
   function addBlock() {
     if (!editable || review) return;
     const sorted = [...blocks].sort(
@@ -1465,23 +1607,54 @@ export default function EditorClient({
             ) : null}
             {!review &&
               (editable ? (
-                <button
-                  id={`p1an-add-top-${userId}`}
-                  onClick={() => addBlock()}
-                  disabled={!editable}
-                  className="rounded border px-2 py-1"
-                >
-                  + Add timeslot
-                </button>
+                <>
+                  <button
+                    id={`p1an-add-top-${userId}`}
+                    onClick={() => addBlock()}
+                    disabled={!editable}
+                    className="rounded border px-2 py-1"
+                  >
+                    + Add timeslot
+                  </button>
+                  <div ref={libraryContainerRef} className="relative">
+                    <button
+                      id={`p1an-add-preset-${userId}`}
+                      className="rounded border px-2 py-1"
+                      onClick={() => setShowBlockPresetLibrary((s) => !s)}
+                    >
+                      Add custom timeslot
+                    </button>
+                    {showBlockPresetLibrary && (
+                      <div className="absolute right-0 z-20 mt-2">
+                        <BlockPresetLibrary
+                          userId={currentUserId}
+                          editable={editable}
+                          onSelect={handlePresetSelected}
+                          onClose={() => setShowBlockPresetLibrary(false)}
+                        />
+                      </div>
+                    )}
+                  </div>
+                </>
               ) : (
-                <button
-                  id={`p1an-add-top-${userId}`}
-                  className="rounded border px-2 py-1"
-                  disabled
-                  title="Read-only in viewing mode"
-                >
-                  + Add timeslot
-                </button>
+                <>
+                  <button
+                    id={`p1an-add-top-${userId}`}
+                    className="rounded border px-2 py-1"
+                    disabled
+                    title="Read-only in viewing mode"
+                  >
+                    + Add timeslot
+                  </button>
+                  <button
+                    id={`p1an-add-preset-${userId}`}
+                    className="rounded border px-2 py-1"
+                    disabled
+                    title="Read-only in viewing mode"
+                  >
+                    Add custom timeslot
+                  </button>
+                </>
               ))}
             <button
               id={`p1an-range-btn-${userId}`}
@@ -1749,8 +1922,40 @@ export default function EditorClient({
           >
             {review ? (
               <>
-                <div className="mb-2 text-sm text-gray-500">
-                  {editable ? null : 'Read-only (viewing mode)'}
+                <div className="mb-2 flex items-start justify-between text-sm text-gray-500">
+                  <span>{editable ? '' : 'Read-only (viewing mode)'}</span>
+                  {editable && (
+                    <div ref={presetMenuRef} className="relative">
+                      <button
+                        id={`p1an-meta-menu-${selected.id}-${userId}`}
+                        aria-label="Activity options"
+                        className="rounded px-2 py-1 text-lg leading-none text-gray-600 hover:bg-gray-200"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          setPresetMenuOpen((s) => !s);
+                        }}
+                      >
+                        ⋮
+                      </button>
+                      {presetMenuOpen && (
+                        <div className="absolute right-0 z-20 mt-1 w-48 rounded border bg-white py-1 text-sm shadow-lg">
+                          <button
+                            id={`p1an-meta-save-${selected.id}-${userId}`}
+                            className="flex w-full items-center px-3 py-2 text-left hover:bg-gray-100"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              setPresetDialogBlockId(selected.id);
+                              setPresetMenuOpen(false);
+                            }}
+                          >
+                            Save activity block
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </div>
                 <div className="mb-4">
                   <div
@@ -2883,6 +3088,15 @@ export default function EditorClient({
             )}
           </div>
         </div>
+      )}
+      {presetDialogBlock && editable && (
+        <BlockPresetSaveDialog
+          userId={currentUserId}
+          block={presetDialogBlock}
+          duration={presetDialogDuration}
+          onClose={() => setPresetDialogBlockId(null)}
+          onSaved={handlePresetSaved}
+        />
       )}
       {aiOpen && (
         <div className="fixed inset-0 z-[1000000] flex items-center justify-center bg-black/20 backdrop-blur-md">

--- a/components/block-preset-library.tsx
+++ b/components/block-preset-library.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import {
+  addBlockPresetCategory,
+  blockPresetStorageKey,
+  getBlockPresetState,
+  type BlockPreset,
+} from '@/lib/block-presets';
+
+const UNCATEGORIZED_ID = '__uncategorized';
+
+interface BlockPresetLibraryProps {
+  userId: string;
+  editable: boolean;
+  onSelect: (preset: BlockPreset) => void;
+  onClose: () => void;
+}
+
+function formatDuration(minutes: number) {
+  const safe = Math.max(0, Math.round(minutes));
+  const h = Math.floor(safe / 60);
+  const m = safe % 60;
+  if (h && m) return `${h}h ${m}m`;
+  if (h) return `${h}h`;
+  return `${m}m`;
+}
+
+export default function BlockPresetLibrary({
+  userId,
+  editable,
+  onSelect,
+  onClose,
+}: BlockPresetLibraryProps) {
+  const [state, setState] = useState(() => getBlockPresetState(userId));
+  const [search, setSearch] = useState('');
+  const [filters, setFilters] = useState<string[]>([]);
+  const [newCategory, setNewCategory] = useState('');
+
+  useEffect(() => {
+    setState(getBlockPresetState(userId));
+  }, [userId]);
+
+  useEffect(() => {
+    function handleStorage(e: StorageEvent) {
+      if (e.key === blockPresetStorageKey(userId)) {
+        setState(getBlockPresetState(userId));
+      }
+    }
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [userId]);
+
+  const categoryLookup = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const cat of state.categories) {
+      map.set(cat.id, cat.name);
+    }
+    return map;
+  }, [state.categories]);
+
+  const normalizedSearch = search.trim().toLowerCase();
+
+  const filteredPresets = useMemo(() => {
+    let list = [...state.presets];
+    if (filters.length > 0) {
+      list = list.filter((preset) => {
+        const ids = preset.categories.length
+          ? preset.categories
+          : [UNCATEGORIZED_ID];
+        return filters.every((id) => ids.includes(id));
+      });
+    }
+    if (normalizedSearch) {
+      list = list.filter((preset) => {
+        const haystack = [preset.name, preset.title, preset.description]
+          .filter(Boolean)
+          .map((value) => value.toLowerCase());
+        return haystack.some((value) => value.includes(normalizedSearch));
+      });
+    }
+    return list;
+  }, [state.presets, filters, normalizedSearch]);
+
+  const sections = useMemo(() => {
+    if (filters.length > 0) {
+      return [
+        {
+          id: 'filtered',
+          title: 'Filtered presets',
+          presets: filteredPresets,
+        },
+      ];
+    }
+    const map = new Map<string, BlockPreset[]>();
+    for (const preset of filteredPresets) {
+      const ids = preset.categories.length
+        ? preset.categories
+        : [UNCATEGORIZED_ID];
+      for (const id of ids) {
+        if (!map.has(id)) map.set(id, []);
+        map.get(id)!.push(preset);
+      }
+    }
+    const ordered: { id: string; title: string; presets: BlockPreset[] }[] = [];
+    for (const cat of state.categories) {
+      ordered.push({
+        id: cat.id,
+        title: cat.name,
+        presets: map.get(cat.id) ?? [],
+      });
+      map.delete(cat.id);
+    }
+    if (map.has(UNCATEGORIZED_ID) || filteredPresets.some((p) => p.categories.length === 0)) {
+      ordered.push({
+        id: UNCATEGORIZED_ID,
+        title: 'Uncategorized',
+        presets: map.get(UNCATEGORIZED_ID) ?? [],
+      });
+      map.delete(UNCATEGORIZED_ID);
+    }
+    for (const [id, presets] of map.entries()) {
+      ordered.push({
+        id,
+        title: categoryLookup.get(id) ?? 'Other',
+        presets,
+      });
+    }
+    return ordered;
+  }, [filteredPresets, filters, state.categories, categoryLookup]);
+
+  const activeFilterCount = filters.length;
+
+  function toggleFilter(id: string) {
+    setFilters((prev) =>
+      prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id],
+    );
+  }
+
+  function handleAddCategory() {
+    const trimmed = newCategory.trim();
+    if (!trimmed) return;
+    try {
+      const created = addBlockPresetCategory(userId, trimmed);
+      setState((prev) => {
+        if (prev.categories.some((cat) => cat.id === created.id)) return prev;
+        return {
+          categories: [...prev.categories, created],
+          presets: prev.presets,
+        };
+      });
+      setNewCategory('');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to add category';
+      alert(message);
+    }
+  }
+
+  return (
+    <div className="w-80 max-w-[calc(100vw-3rem)] rounded border bg-white p-3 text-sm shadow-lg">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="font-semibold">Saved activity blocks</span>
+        <Button size="sm" variant="outline" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+      <input
+        className="w-full rounded border px-2 py-1 text-sm"
+        placeholder="Search presets"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      <div className="mt-2 flex flex-wrap gap-1">
+        <button
+          className={cn(
+            'rounded border px-2 py-1 text-xs',
+            activeFilterCount === 0
+              ? 'border-orange-400 bg-orange-50 text-orange-600'
+              : 'border-gray-300 text-gray-600 hover:bg-gray-100',
+          )}
+          onClick={() => setFilters([])}
+        >
+          All
+        </button>
+        {state.categories.map((category) => (
+          <button
+            key={category.id}
+            className={cn(
+              'rounded border px-2 py-1 text-xs',
+              filters.includes(category.id)
+                ? 'border-orange-400 bg-orange-50 text-orange-600'
+                : 'border-gray-300 text-gray-600 hover:bg-gray-100',
+            )}
+            onClick={() => toggleFilter(category.id)}
+          >
+            {category.name}
+          </button>
+        ))}
+        <button
+          className={cn(
+            'rounded border px-2 py-1 text-xs',
+            filters.includes(UNCATEGORIZED_ID)
+              ? 'border-orange-400 bg-orange-50 text-orange-600'
+              : 'border-gray-300 text-gray-600 hover:bg-gray-100',
+          )}
+          onClick={() => toggleFilter(UNCATEGORIZED_ID)}
+        >
+          Uncategorized
+        </button>
+      </div>
+      {activeFilterCount > 0 && filteredPresets.length === 0 ? (
+        <div className="mt-3 rounded border border-dashed p-3 text-center text-xs text-gray-500">
+          No presets match your filters.
+        </div>
+      ) : null}
+      <div className="mt-3 max-h-64 overflow-y-auto pr-1">
+        {sections.map((section) => (
+          <div key={section.id} className="mb-3 last:mb-0">
+            {filters.length === 0 && (
+              <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                {section.title}
+              </div>
+            )}
+            {section.presets.length > 0 ? (
+              section.presets.map((preset) => (
+                <div key={preset.id} className="mb-2 rounded border p-2 last:mb-0">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span
+                          className="h-3 w-3 rounded"
+                          style={{ background: preset.color }}
+                        />
+                        <span className="font-medium">{preset.name}</span>
+                      </div>
+                      {preset.title && preset.title !== preset.name ? (
+                        <div className="mt-1 text-xs text-gray-500">
+                          Activity title: {preset.title}
+                        </div>
+                      ) : null}
+                      {preset.description ? (
+                        <div className="mt-1 whitespace-pre-wrap text-xs text-gray-600">
+                          {preset.description}
+                        </div>
+                      ) : null}
+                      <div className="mt-1 text-[11px] uppercase tracking-wide text-gray-500">
+                        Duration: {formatDuration(preset.duration)}
+                      </div>
+                      {preset.categories.length > 0 ? (
+                        <div className="mt-2 flex flex-wrap gap-1 text-[10px] text-gray-500">
+                          {preset.categories.map((categoryId) => (
+                            <span
+                              key={`${preset.id}-${categoryId}`}
+                              className="rounded bg-gray-200 px-1.5 py-0.5"
+                            >
+                              {categoryLookup.get(categoryId) ?? 'Other'}
+                            </span>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                    <Button size="sm" onClick={() => onSelect(preset)}>
+                      Add
+                    </Button>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="rounded border border-dashed p-3 text-xs text-gray-500">
+                No presets in this category yet.
+              </div>
+            )}
+          </div>
+        ))}
+        {sections.length === 0 && (
+          <div className="rounded border border-dashed p-3 text-center text-xs text-gray-500">
+            No presets saved yet. Open an activity and choose “Save activity block” to
+            build your library.
+          </div>
+        )}
+      </div>
+      {editable && (
+        <div className="mt-3 border-t pt-3">
+          <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+            Create category
+          </div>
+          <div className="mt-1 flex items-center gap-2">
+            <input
+              className="flex-1 rounded border px-2 py-1 text-xs"
+              placeholder="e.g. Morning"
+              value={newCategory}
+              onChange={(e) => setNewCategory(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleAddCategory();
+                }
+              }}
+            />
+            <Button size="sm" onClick={handleAddCategory}>
+              Add
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/block-preset-save-dialog.tsx
+++ b/components/block-preset-save-dialog.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import {
+  addBlockPreset,
+  addBlockPresetCategory,
+  blockPresetStorageKey,
+  getBlockPresetState,
+  type BlockPreset,
+} from '@/lib/block-presets';
+import type { PlanBlock } from '@/types/plan';
+
+interface BlockPresetSaveDialogProps {
+  userId: string;
+  block: PlanBlock;
+  duration: number;
+  onClose: () => void;
+  onSaved?: (preset: BlockPreset) => void;
+}
+
+export default function BlockPresetSaveDialog({
+  userId,
+  block,
+  duration,
+  onClose,
+  onSaved,
+}: BlockPresetSaveDialogProps) {
+  const [state, setState] = useState(() => getBlockPresetState(userId));
+  const [name, setName] = useState(() => block.title?.trim() || 'Untitled activity');
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [newCategory, setNewCategory] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setState(getBlockPresetState(userId));
+  }, [userId]);
+
+  useEffect(() => {
+    function handleStorage(e: StorageEvent) {
+      if (e.key === blockPresetStorageKey(userId)) {
+        setState(getBlockPresetState(userId));
+      }
+    }
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [userId]);
+
+  useEffect(() => {
+    setName(block.title?.trim() || 'Untitled activity');
+    setSelectedCategories([]);
+    setError(null);
+  }, [block.id, block.title]);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const durationText = useMemo(() => {
+    const safe = Math.max(0, Math.round(duration));
+    const h = Math.floor(safe / 60);
+    const m = safe % 60;
+    if (h && m) return `${h}h ${m}m`;
+    if (h) return `${h}h`;
+    if (m) return `${m}m`;
+    return '0m';
+  }, [duration]);
+
+  function toggleCategory(id: string) {
+    setSelectedCategories((prev) =>
+      prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id],
+    );
+  }
+
+  function handleAddCategory() {
+    const trimmed = newCategory.trim();
+    if (!trimmed) return;
+    try {
+      const created = addBlockPresetCategory(userId, trimmed);
+      setState((prev) => {
+        if (prev.categories.some((cat) => cat.id === created.id)) return prev;
+        return {
+          categories: [...prev.categories, created],
+          presets: prev.presets,
+        };
+      });
+      setSelectedCategories((prev) =>
+        prev.includes(created.id) ? prev : [...prev, created.id],
+      );
+      setNewCategory('');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to add category';
+      alert(message);
+    }
+  }
+
+  function handleSave() {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError('Please give this preset a name.');
+      return;
+    }
+    if (duration <= 0) {
+      setError('Activity duration must be greater than zero.');
+      return;
+    }
+    const preset = addBlockPreset(userId, {
+      name: trimmed,
+      title: block.title,
+      description: block.description,
+      color: block.color,
+      colorPreset: block.colorPreset ?? '',
+      ingredientIds: [...(block.ingredientIds ?? [])],
+      flavorIds: [...(block.flavorIds ?? [])],
+      subflavorIds: [...(block.subflavorIds ?? [])],
+      duration,
+      categories: selectedCategories,
+    });
+    onSaved?.(preset);
+    onClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[200000] flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded bg-white p-4 text-sm shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-3 flex items-start justify-between gap-2">
+          <div>
+            <div className="text-base font-semibold">Save activity block</div>
+            <div className="text-xs text-gray-500">
+              {block.title?.trim() ? block.title : 'Untitled activity'}
+            </div>
+          </div>
+          <Button size="sm" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+        </div>
+        <label className="block text-xs font-semibold uppercase tracking-wide text-gray-500">
+          Preset name
+        </label>
+        <input
+          className="mt-1 w-full rounded border px-2 py-1 text-sm"
+          value={name}
+          maxLength={80}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <div className="mt-3">
+          <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+            Categories
+          </div>
+          {state.categories.length > 0 ? (
+            <div className="mt-1 flex flex-wrap gap-1">
+              {state.categories.map((category) => (
+                <button
+                  key={category.id}
+                  className={cn(
+                    'rounded border px-2 py-1 text-xs',
+                    selectedCategories.includes(category.id)
+                      ? 'border-orange-400 bg-orange-50 text-orange-600'
+                      : 'border-gray-300 text-gray-600 hover:bg-gray-100',
+                  )}
+                  onClick={() => toggleCategory(category.id)}
+                >
+                  {category.name}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="mt-1 rounded border border-dashed p-3 text-xs text-gray-500">
+              No categories yet. Add one below to organise your presets.
+            </div>
+          )}
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              className="flex-1 rounded border px-2 py-1 text-xs"
+              placeholder="Add a category"
+              value={newCategory}
+              onChange={(e) => setNewCategory(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleAddCategory();
+                }
+              }}
+            />
+            <Button size="sm" onClick={handleAddCategory}>
+              Add
+            </Button>
+          </div>
+        </div>
+        <div className="mt-4 rounded border bg-gray-50 p-3 text-xs text-gray-600">
+          <div>
+            <span className="font-semibold text-gray-700">Duration:</span> {durationText}
+          </div>
+          {block.description ? (
+            <div className="mt-2">
+              <div className="font-semibold text-gray-700">Description</div>
+              <div className="whitespace-pre-wrap text-gray-600">{block.description}</div>
+            </div>
+          ) : null}
+        </div>
+        {error ? (
+          <div className="mt-3 rounded border border-red-300 bg-red-50 p-2 text-xs text-red-600">
+            {error}
+          </div>
+        ) : null}
+        <div className="mt-4 flex justify-end gap-2">
+          <Button variant="outline" onClick={onClose}>
+            Close
+          </Button>
+          <Button onClick={handleSave}>Save activity block</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/block-presets.ts
+++ b/lib/block-presets.ts
@@ -1,0 +1,253 @@
+export interface BlockPresetCategory {
+  id: string;
+  name: string;
+  createdAt: string;
+}
+
+export interface BlockPreset {
+  id: string;
+  name: string;
+  title: string;
+  description: string;
+  color: string;
+  colorPreset?: string;
+  ingredientIds: number[];
+  flavorIds: string[];
+  subflavorIds: string[];
+  duration: number;
+  categories: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface BlockPresetState {
+  categories: BlockPresetCategory[];
+  presets: BlockPreset[];
+}
+
+const DEFAULT_STATE: BlockPresetState = { categories: [], presets: [] };
+
+function generateId() {
+  try {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      // @ts-ignore randomUUID existence checked above
+      return crypto.randomUUID() as string;
+    }
+  } catch {
+    // ignore and fall back
+  }
+  return Math.random().toString(36).slice(2, 11);
+}
+
+export function blockPresetStorageKey(userId: string) {
+  return `block-presets-${userId}`;
+}
+
+function sanitizeCategory(raw: any): BlockPresetCategory | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const name = typeof raw.name === 'string' ? raw.name.trim() : '';
+  if (!name) return null;
+  const id = typeof raw.id === 'string' && raw.id ? raw.id : generateId();
+  const createdAt =
+    typeof raw.createdAt === 'string' ? raw.createdAt : new Date().toISOString();
+  return { id, name, createdAt };
+}
+
+function sanitizePreset(raw: any): BlockPreset | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const name = typeof raw.name === 'string' ? raw.name.trim() : '';
+  const title = typeof raw.title === 'string' ? raw.title : '';
+  const description =
+    typeof raw.description === 'string' ? raw.description : '';
+  const color = typeof raw.color === 'string' && raw.color ? raw.color : '#94A3B8';
+  const colorPreset = typeof raw.colorPreset === 'string' ? raw.colorPreset : '';
+  const ingredientIds = Array.isArray(raw.ingredientIds)
+    ? raw.ingredientIds.filter((n: any) => Number.isFinite(n)).map((n: number) => Number(n))
+    : [];
+  const flavorIds = Array.isArray(raw.flavorIds)
+    ? raw.flavorIds.filter((id: any) => typeof id === 'string')
+    : [];
+  const subflavorIds = Array.isArray(raw.subflavorIds)
+    ? raw.subflavorIds.filter((id: any) => typeof id === 'string')
+    : [];
+  const duration = Number.isFinite(raw.duration) ? Math.max(1, Number(raw.duration)) : 60;
+  const categories = Array.isArray(raw.categories)
+    ? raw.categories.filter((id: any) => typeof id === 'string')
+    : [];
+  const id = typeof raw.id === 'string' && raw.id ? raw.id : generateId();
+  const createdAt =
+    typeof raw.createdAt === 'string' ? raw.createdAt : new Date().toISOString();
+  const updatedAt =
+    typeof raw.updatedAt === 'string' ? raw.updatedAt : new Date().toISOString();
+  return {
+    id,
+    name: name || title || 'Untitled preset',
+    title,
+    description,
+    color,
+    colorPreset,
+    ingredientIds,
+    flavorIds,
+    subflavorIds,
+    duration,
+    categories,
+    createdAt,
+    updatedAt,
+  };
+}
+
+export function getBlockPresetState(userId: string): BlockPresetState {
+  if (typeof window === 'undefined') return DEFAULT_STATE;
+  try {
+    const raw = window.localStorage.getItem(blockPresetStorageKey(userId));
+    if (!raw) return DEFAULT_STATE;
+    const parsed = JSON.parse(raw);
+    const categories: BlockPresetCategory[] = [];
+    const presets: BlockPreset[] = [];
+    if (Array.isArray(parsed?.categories)) {
+      for (const cat of parsed.categories) {
+        const sanitized = sanitizeCategory(cat);
+        if (sanitized && !categories.some((c) => c.id === sanitized.id)) {
+          categories.push(sanitized);
+        }
+      }
+    }
+    if (Array.isArray(parsed?.presets)) {
+      for (const pre of parsed.presets) {
+        const sanitized = sanitizePreset(pre);
+        if (sanitized && !presets.some((p) => p.id === sanitized.id)) {
+          presets.push(sanitized);
+        }
+      }
+    }
+    return { categories, presets };
+  } catch {
+    return DEFAULT_STATE;
+  }
+}
+
+function dispatchStorageEvent(userId: string, state: BlockPresetState) {
+  try {
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: blockPresetStorageKey(userId),
+        newValue: JSON.stringify(state),
+      }),
+    );
+  } catch {
+    // ignore
+  }
+}
+
+export function saveBlockPresetState(userId: string, state: BlockPresetState) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(
+      blockPresetStorageKey(userId),
+      JSON.stringify(state),
+    );
+    dispatchStorageEvent(userId, state);
+  } catch {
+    // ignore storage errors
+  }
+}
+
+function upsertCategory(state: BlockPresetState, category: BlockPresetCategory) {
+  const existingIndex = state.categories.findIndex((c) => c.id === category.id);
+  if (existingIndex >= 0) {
+    state.categories[existingIndex] = category;
+  } else {
+    state.categories.push(category);
+  }
+}
+
+export function addBlockPresetCategory(
+  userId: string,
+  name: string,
+): BlockPresetCategory {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new Error('Category name is required.');
+  }
+  const state = getBlockPresetState(userId);
+  const existing = state.categories.find(
+    (c) => c.name.toLowerCase() === trimmed.toLowerCase(),
+  );
+  if (existing) return existing;
+  const category: BlockPresetCategory = {
+    id: generateId(),
+    name: trimmed,
+    createdAt: new Date().toISOString(),
+  };
+  upsertCategory(state, category);
+  saveBlockPresetState(userId, state);
+  return category;
+}
+
+export function addBlockPreset(
+  userId: string,
+  preset: Omit<BlockPreset, 'id' | 'createdAt' | 'updatedAt'> & {
+    id?: string;
+  },
+): BlockPreset {
+  const state = getBlockPresetState(userId);
+  const now = new Date().toISOString();
+  const withId: BlockPreset = {
+    id: preset.id ?? generateId(),
+    name: preset.name.trim() || preset.title || 'Untitled preset',
+    title: preset.title,
+    description: preset.description,
+    color: preset.color,
+    colorPreset: preset.colorPreset ?? '',
+    ingredientIds: [...preset.ingredientIds],
+    flavorIds: [...preset.flavorIds],
+    subflavorIds: [...preset.subflavorIds],
+    duration: Math.max(1, Math.round(preset.duration)),
+    categories: [...preset.categories],
+    createdAt: now,
+    updatedAt: now,
+  };
+  const existingIndex = state.presets.findIndex((p) => p.id === withId.id);
+  if (existingIndex >= 0) {
+    state.presets[existingIndex] = withId;
+  } else {
+    state.presets.push(withId);
+  }
+  saveBlockPresetState(userId, state);
+  return withId;
+}
+
+export function removeBlockPreset(userId: string, id: string) {
+  const state = getBlockPresetState(userId);
+  const next = state.presets.filter((p) => p.id !== id);
+  if (next.length === state.presets.length) return;
+  saveBlockPresetState(userId, { categories: state.categories, presets: next });
+}
+
+export function renameBlockPresetCategory(
+  userId: string,
+  categoryId: string,
+  name: string,
+) {
+  const trimmed = name.trim();
+  if (!trimmed) return;
+  const state = getBlockPresetState(userId);
+  const idx = state.categories.findIndex((c) => c.id === categoryId);
+  if (idx === -1) return;
+  state.categories[idx] = {
+    ...state.categories[idx],
+    name: trimmed,
+    updatedAt: new Date().toISOString(),
+  } as BlockPresetCategory & { updatedAt?: string };
+  saveBlockPresetState(userId, state);
+}
+
+export function removeBlockPresetCategory(userId: string, categoryId: string) {
+  const state = getBlockPresetState(userId);
+  const categories = state.categories.filter((c) => c.id !== categoryId);
+  const presets = state.presets.map((p) => ({
+    ...p,
+    categories: p.categories.filter((id) => id !== categoryId),
+  }));
+  saveBlockPresetState(userId, { categories, presets });
+}


### PR DESCRIPTION
## Summary
- add a local storage backed library for activity block presets with categories
- build a preset library panel and save dialog for planning activities
- integrate preset insertion and save controls into the planning UI and update the changelog

## Testing
- pnpm lint
- pnpm tsc
- pnpm test *(fails: Playwright browser bundle missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d160f2f5c4832a82b17f4fb7d78958