### PR TITLE
Add historical progress tracking views

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -302,3 +302,4 @@
 - 2025-10-30: Forced overview caches to refresh after highlight edits and lit up detail pages with the saved markup so "View in context" immediately shows colored snippets.
 - 2025-10-30: Added custom coach tone saving with completion feedback, fed custom briefs into all rapport prompts, and surfaced the stored tone snapshot on review and planning pages so users (and viewers) see the exact instructions used.
 - 2025-10-30: Added activity block presets with category tagging, save-from-metadata controls, and a custom timeslot library picker in the planner toolbar.
+- 2025-10-30: Completed streak and time-spent tracking with daily progress snapshots, viewer access controls, and historical routes.

--- a/app/(view)/view/[viewId]/progress/tracking/page.tsx
+++ b/app/(view)/view/[viewId]/progress/tracking/page.tsx
@@ -1,0 +1,84 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { notFound } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { buildViewContext } from '@/lib/profile';
+import { ViewContextProvider } from '@/lib/view-context';
+import { listFlavorsForViewer } from '@/lib/flavors-store';
+import { listSubflavorsForViewer } from '@/lib/subflavors-store';
+import { buildProgressTimeline, getTrackingStartDate } from '@/lib/progress-tracking-store';
+import { cookies } from 'next/headers';
+import { addDays, getNow, startOfDay, toYMD, getUserTimeZone } from '@/lib/clock';
+import TrackingClient from '@/components/progress/tracking-client';
+
+export default async function ViewTrackingPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ viewId: string }>;
+  searchParams?: Promise<{ at?: string }>;
+}) {
+  const { viewId } = await params;
+  const sp = await searchParams;
+  if (sp?.at) notFound();
+  const user = await getUserByViewId(viewId);
+  if (!user) notFound();
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(user as any, { cookies: cookieStore });
+  const { now } = getNow(tz, { cookies: cookieStore });
+  const todayDate = startOfDay(now, tz);
+  const today = toYMD(todayDate, tz);
+  const start = toYMD(addDays(todayDate, -365, tz), tz);
+
+  const flavors = await listFlavorsForViewer(String(user.id), viewerId);
+  const subflavors = await listSubflavorsForViewer(String(user.id), viewerId);
+
+  const timeline = await buildProgressTimeline({
+    userId: user.id,
+    tz,
+    startDate: start,
+    endDate: today,
+    flavors,
+    subflavors,
+    now,
+  });
+  const trackingStart = await getTrackingStartDate(user.id);
+
+  const ctx = buildViewContext({
+    ownerId: user.id,
+    viewerId: viewerId ?? null,
+    mode: 'viewer',
+    viewId: user.viewId,
+  });
+
+  return (
+    <ViewContextProvider value={ctx}>
+      <section id={`v13w-progress-tracking-${user.id}`} className="p-6">
+        <TrackingClient
+          today={today}
+          timeZone={tz}
+          trackingStart={trackingStart}
+          flavors={flavors.map((f) => ({
+            id: f.id,
+            name: f.name,
+            icon: f.icon,
+            color: f.color,
+            description: f.description,
+          }))}
+          subflavors={subflavors.map((s) => ({
+            id: s.id,
+            flavorId: s.flavorId,
+            name: s.name,
+            icon: s.icon,
+            color: s.color,
+            description: s.description,
+          }))}
+          timeline={timeline}
+        />
+      </section>
+    </ViewContextProvider>
+  );
+}

--- a/app/history/[viewId]/[date]/progress/tracking/page.tsx
+++ b/app/history/[viewId]/[date]/progress/tracking/page.tsx
@@ -1,0 +1,104 @@
+import { getUserByViewId, ensureUser } from '@/lib/users';
+import { auth } from '@/lib/auth';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { addDays, getUserTimeZone, parseYMD, toYMD } from '@/lib/clock';
+import TrackingClient from '@/components/progress/tracking-client';
+import {
+  buildProgressTimeline,
+  getTrackingStartDate,
+  normalizeSnapshotFlavors,
+  normalizeSnapshotSubflavors,
+} from '@/lib/progress-tracking-store';
+import { canViewerSeeFlavor } from '@/lib/flavors-store';
+import { canViewerSeeSubflavor } from '@/lib/subflavors-store';
+
+export default async function ViewHistoryTrackingPage({
+  params,
+}: {
+  params: Promise<{ viewId: string; date: string }>;
+}) {
+  const { viewId, date } = await params;
+  const owner = await getUserByViewId(viewId);
+  if (!owner) notFound();
+  const snapshot = await getProfileSnapshot(owner.id, date);
+  if (!snapshot) notFound();
+
+  const session = await auth();
+  const viewer = session ? await ensureUser(session) : null;
+  const viewerId = viewer ? viewer.id : null;
+
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(owner as any, { cookies: cookieStore });
+  const dayStart = parseYMD(date, tz);
+  const rangeStart = addDays(dayStart, -364, tz);
+  const startDate = toYMD(rangeStart, tz);
+  const endDate = date;
+  const now = new Date(addDays(dayStart, 1, tz).getTime() - 1);
+
+  const rawFlavors = normalizeSnapshotFlavors(snapshot.flavors, owner.id);
+  const flavorChecks = await Promise.all(
+    rawFlavors.map(async (flavor) => ({
+      flavor,
+      allowed: await canViewerSeeFlavor(viewerId, owner.id, flavor.visibility),
+    })),
+  );
+  const flavors = flavorChecks
+    .filter((item) => item.allowed)
+    .map((item) => item.flavor);
+  const visibleFlavorIds = new Set(flavors.map((flavor) => flavor.id));
+
+  const rawSubflavors = normalizeSnapshotSubflavors(snapshot.subflavors, owner.id);
+  const subChecks = await Promise.all(
+    rawSubflavors.map(async (sub) => ({
+      sub,
+      allowed:
+        visibleFlavorIds.has(sub.flavorId) &&
+        (await canViewerSeeSubflavor(viewerId, owner.id, sub.visibility)),
+    })),
+  );
+  const subflavors = subChecks
+    .filter((item) => item.allowed)
+    .map((item) => item.sub);
+
+  const timeline = await buildProgressTimeline({
+    userId: owner.id,
+    tz,
+    startDate,
+    endDate,
+    flavors,
+    subflavors,
+    now,
+  });
+  const trackingStart = await getTrackingStartDate(owner.id);
+
+  return (
+    <section
+      id={`hist-view-progress-tracking-${owner.id}-${date}`}
+      className="space-y-6"
+    >
+      <TrackingClient
+        today={date}
+        timeZone={tz}
+        trackingStart={trackingStart}
+        flavors={flavors.map((flavor) => ({
+          id: flavor.id,
+          name: flavor.name,
+          icon: flavor.icon,
+          color: flavor.color,
+          description: flavor.description,
+        }))}
+        subflavors={subflavors.map((sub) => ({
+          id: sub.id,
+          flavorId: sub.flavorId,
+          name: sub.name,
+          icon: sub.icon,
+          color: sub.color,
+          description: sub.description,
+        }))}
+        timeline={timeline}
+      />
+    </section>
+  );
+}

--- a/app/history/self/[date]/progress/tracking/page.tsx
+++ b/app/history/self/[date]/progress/tracking/page.tsx
@@ -1,0 +1,77 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { notFound } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { addDays, getUserTimeZone, parseYMD, toYMD } from '@/lib/clock';
+import TrackingClient from '@/components/progress/tracking-client';
+import {
+  buildProgressTimeline,
+  getTrackingStartDate,
+  normalizeSnapshotFlavors,
+  normalizeSnapshotSubflavors,
+} from '@/lib/progress-tracking-store';
+
+export default async function HistorySelfTrackingPage({
+  params,
+}: {
+  params: Promise<{ date: string }>;
+}) {
+  const { date } = await params;
+  const session = await auth();
+  if (!session) notFound();
+  const me = await ensureUser(session);
+  const snapshot = await getProfileSnapshot(me.id, date);
+  if (!snapshot) notFound();
+
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(me as any, { cookies: cookieStore });
+  const dayStart = parseYMD(date, tz);
+  const rangeStart = addDays(dayStart, -364, tz);
+  const startDate = toYMD(rangeStart, tz);
+  const endDate = date;
+  const now = new Date(addDays(dayStart, 1, tz).getTime() - 1);
+
+  const flavors = normalizeSnapshotFlavors(snapshot.flavors, me.id);
+  const subflavors = normalizeSnapshotSubflavors(snapshot.subflavors, me.id);
+
+  const timeline = await buildProgressTimeline({
+    userId: me.id,
+    tz,
+    startDate,
+    endDate,
+    flavors,
+    subflavors,
+    now,
+  });
+  const trackingStart = await getTrackingStartDate(me.id);
+
+  return (
+    <section
+      id={`hist-self-progress-tracking-${me.id}-${date}`}
+      className="space-y-6"
+    >
+      <TrackingClient
+        today={date}
+        timeZone={tz}
+        trackingStart={trackingStart}
+        flavors={flavors.map((flavor) => ({
+          id: flavor.id,
+          name: flavor.name,
+          icon: flavor.icon,
+          color: flavor.color,
+          description: flavor.description,
+        }))}
+        subflavors={subflavors.map((sub) => ({
+          id: sub.id,
+          flavorId: sub.flavorId,
+          name: sub.name,
+          icon: sub.icon,
+          color: sub.color,
+          description: sub.description,
+        }))}
+        timeline={timeline}
+      />
+    </section>
+  );
+}

--- a/app/progress/layout.tsx
+++ b/app/progress/layout.tsx
@@ -3,6 +3,7 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { buildViewContext } from '@/lib/profile';
 import { ensureDailyProfileSnapshot } from '@/lib/profile-snapshots';
+import { ensureDailyProgressSnapshot } from '@/lib/progress-tracking-store';
 import { getUserTimeZone } from '@/lib/clock';
 import { cookies } from 'next/headers';
 import { ViewContextProvider } from '@/lib/view-context';
@@ -21,6 +22,7 @@ export default async function ProgressLayout({
   const cookieStore = await cookies();
   const tz = getUserTimeZone(me as any, { cookies: cookieStore });
   await ensureDailyProfileSnapshot(me.id, tz);
+  await ensureDailyProgressSnapshot(me.id, tz);
   const ctx = buildViewContext({
     ownerId: me.id,
     viewerId: me.id,

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -9,18 +9,24 @@ export function ProgressHome() {
   return (
     <main className="p-6">
       <BackButton href={hrefFor('/', ctx)} />
-      <div className="space-x-4">
+      <div className="mt-4 flex flex-wrap gap-3">
         <Link
           href={hrefFor('/progress/statistics', ctx)}
-          className="bg-orange-500 text-white px-4 py-2 rounded"
+          className="rounded bg-orange-500 px-4 py-2 font-semibold text-white shadow-sm shadow-orange-200 transition hover:bg-orange-600"
         >
           Statistics
         </Link>
         <Link
           href={hrefFor('/progress/overview', ctx)}
-          className="bg-orange-500 text-white px-4 py-2 rounded"
+          className="rounded bg-orange-500 px-4 py-2 font-semibold text-white shadow-sm shadow-orange-200 transition hover:bg-orange-600"
         >
           Overview
+        </Link>
+        <Link
+          href={hrefFor('/progress/tracking', ctx)}
+          className="rounded bg-orange-500 px-4 py-2 font-semibold text-white shadow-sm shadow-orange-200 transition hover:bg-orange-600"
+        >
+          Tracking
         </Link>
       </div>
     </main>

--- a/app/progress/tracking/page.tsx
+++ b/app/progress/tracking/page.tsx
@@ -1,0 +1,69 @@
+import { redirect } from 'next/navigation';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import BackButton from '@/components/back-button';
+import { cookies } from 'next/headers';
+import { addDays, getNow, startOfDay, toYMD, getUserTimeZone } from '@/lib/clock';
+import { listFlavors } from '@/lib/flavors-store';
+import { listAllSubflavors } from '@/lib/subflavors-store';
+import TrackingClient from '@/components/progress/tracking-client';
+import { buildProgressTimeline, getTrackingStartDate } from '@/lib/progress-tracking-store';
+
+export default async function ProgressTrackingPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(me as any, { cookies: cookieStore });
+  const { now } = getNow(tz, { cookies: cookieStore });
+  const todayDate = startOfDay(now, tz);
+  const today = toYMD(todayDate, tz);
+  const start = toYMD(addDays(todayDate, -365, tz), tz);
+  const flavors = await listFlavors(String(me.id));
+  const subflavors = await listAllSubflavors(String(me.id));
+  const timeline = await buildProgressTimeline({
+    userId: me.id,
+    tz,
+    startDate: start,
+    endDate: today,
+    flavors,
+    subflavors,
+    now,
+  });
+  const trackingStart = await getTrackingStartDate(me.id);
+
+  return (
+    <main className="space-y-6 p-6">
+      <BackButton />
+      <div className="space-y-4">
+        <h1 className="text-3xl font-bold text-orange-600">Progress tracking</h1>
+        <p className="max-w-2xl text-sm text-gray-600">
+          Keep a playful bird&apos;s-eye view of your flavours and time. Switch
+          between streaks and time spent to celebrate the momentum behind your
+          cake.
+        </p>
+      </div>
+      <TrackingClient
+        today={today}
+        timeZone={tz}
+        trackingStart={trackingStart}
+        flavors={flavors.map((f) => ({
+          id: f.id,
+          name: f.name,
+          icon: f.icon,
+          color: f.color,
+          description: f.description,
+        }))}
+        subflavors={subflavors.map((s) => ({
+          id: s.id,
+          flavorId: s.flavorId,
+          name: s.name,
+          icon: s.icon,
+          color: s.color,
+          description: s.description,
+        }))}
+        timeline={timeline}
+      />
+    </main>
+  );
+}

--- a/components/progress/tracking-client.tsx
+++ b/components/progress/tracking-client.tsx
@@ -1,0 +1,805 @@
+'use client';
+
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import type { DailyProgressRecord } from '@/lib/progress-tracking-store';
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts';
+import { cn } from '@/lib/utils';
+
+type FlavorInfo = {
+  id: string;
+  name: string;
+  icon: string;
+  color: string;
+  description: string;
+};
+
+type SubflavorInfo = {
+  id: string;
+  flavorId: string;
+  name: string;
+  icon: string;
+  color: string;
+  description: string;
+};
+
+type Props = {
+  today: string;
+  timeZone: string;
+  trackingStart: string | null;
+  flavors: FlavorInfo[];
+  subflavors: SubflavorInfo[];
+  timeline: DailyProgressRecord[];
+};
+
+type StatusType = 'done' | 'planned' | 'missed' | 'notStarted';
+
+type AutoConfig = {
+  enabled: boolean;
+  baseDays: number;
+  anchor: string;
+};
+
+const DAY_OPTIONS = [
+  { value: 7, label: '7 days' },
+  { value: 14, label: '14 days' },
+  { value: 30, label: '30 days' },
+  { value: 60, label: '60 days' },
+  { value: 90, label: '90 days' },
+  { value: 180, label: '180 days' },
+  { value: 365, label: '365 days' },
+];
+
+const TIME_RANGES = [
+  { key: '1d', label: '1 day', days: 1 },
+  { key: '7d', label: '7 days', days: 7 },
+  { key: '1m', label: '1 month', days: 30 },
+  { key: '2m', label: '2 months', days: 60 },
+  { key: '6m', label: 'Half year', days: 182 },
+  { key: '1y', label: '1 year', days: 365 },
+];
+
+const AUTO_STORAGE_KEY = 'apoc-tracking-auto';
+const HIDDEN_STORAGE_KEY = 'apoc-tracking-hidden';
+
+const dayFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+});
+
+const weekdayFormatter = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+});
+
+function createDateFromYMD(date: string) {
+  const [y, m, d] = date.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+function shiftDate(date: string, offset: number) {
+  const base = createDateFromYMD(date);
+  const shifted = new Date(base.getTime() + offset * 86_400_000);
+  return shifted.toISOString().slice(0, 10);
+}
+
+function diffInDays(start: string, end: string) {
+  const startDate = createDateFromYMD(start);
+  const endDate = createDateFromYMD(end);
+  return Math.floor((endDate.getTime() - startDate.getTime()) / 86_400_000);
+}
+
+function clampDays(value: number | undefined) {
+  if (!value || !Number.isFinite(value)) return 30;
+  const rounded = Math.round(value);
+  if (rounded < 1) return 1;
+  if (rounded > 365) return 365;
+  return rounded;
+}
+
+function formatDayLabel(date: string) {
+  return dayFormatter.format(createDateFromYMD(date));
+}
+
+function formatWeekday(date: string) {
+  return weekdayFormatter.format(createDateFromYMD(date));
+}
+
+function statusTitle(status: StatusType) {
+  switch (status) {
+    case 'done':
+      return 'Completed';
+    case 'planned':
+      return 'Planned';
+    case 'notStarted':
+      return 'Tracking not started';
+    default:
+      return 'Missed';
+  }
+}
+
+function StatusCell({ status, isToday }: { status: StatusType; isToday: boolean }) {
+  const base = 'flex h-9 w-9 items-center justify-center text-sm font-semibold transition-colors';
+  const ring = isToday ? 'ring-2 ring-orange-300 ring-offset-2' : '';
+  if (status === 'done') {
+    return (
+      <div
+        className={cn(
+          base,
+          'rounded-full bg-emerald-500 text-white shadow-sm shadow-emerald-200',
+          ring,
+        )}
+        title={statusTitle(status)}
+      >
+        ✓
+      </div>
+    );
+  }
+  if (status === 'planned') {
+    return (
+      <div
+        className={cn(
+          base,
+          'rounded-md border border-orange-400 bg-orange-50 text-orange-600 shadow-sm',
+          ring,
+        )}
+        title={statusTitle(status)}
+      >
+        ▢
+      </div>
+    );
+  }
+  if (status === 'notStarted') {
+    return (
+      <div
+        className={cn(
+          base,
+          'rounded-md border border-gray-200 bg-gray-100 text-gray-400',
+          ring,
+        )}
+        title={statusTitle(status)}
+      >
+        |||
+      </div>
+    );
+  }
+  return (
+    <div
+      className={cn(
+        base,
+        'rounded-md border border-red-200 bg-red-50 text-red-500 shadow-sm',
+        ring,
+      )}
+      title={statusTitle(status)}
+    >
+      ✕
+    </div>
+  );
+}
+
+function ChartTooltip({ active, payload }: { active?: boolean; payload?: any[] }) {
+  if (!active || !payload?.length) return null;
+  const item = payload[0];
+  const minutes: number = item?.payload?.minutes ?? 0;
+  const name: string = item?.payload?.name ?? '';
+  const percent: number = item?.percent ? item.percent * 100 : 0;
+  const hours = minutes / 60;
+  return (
+    <div className="rounded-lg bg-white/95 p-3 text-sm shadow-xl">
+      <div className="font-semibold text-gray-800">{name}</div>
+      <div className="text-gray-600">{hours.toFixed(1)} hours</div>
+      <div className="text-gray-500">{percent.toFixed(1)}%</div>
+    </div>
+  );
+}
+
+export default function TrackingClient({
+  today,
+  timeZone: _timeZone,
+  trackingStart,
+  flavors,
+  subflavors,
+  timeline,
+}: Props) {
+  const [view, setView] = useState<'streaks' | 'time'>('streaks');
+  const [autoConfig, setAutoConfig] = useState<AutoConfig>(() => ({
+    enabled: false,
+    baseDays: 30,
+    anchor: today,
+  }));
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [timeRange, setTimeRange] = useState<string>('7d');
+  const [showSubDistribution, setShowSubDistribution] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const raw = localStorage.getItem(AUTO_STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as Partial<AutoConfig>;
+      if (!parsed) return;
+      setAutoConfig({
+        enabled: !!parsed.enabled,
+        baseDays: clampDays(parsed.baseDays ?? 30),
+        anchor: typeof parsed.anchor === 'string' ? parsed.anchor : today,
+      });
+    } catch {
+      // ignore invalid stored state
+    }
+  }, [today]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const raw = localStorage.getItem(HIDDEN_STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as string[];
+      if (!Array.isArray(parsed)) return;
+      setHidden(new Set(parsed.filter((entry) => typeof entry === 'string')));
+    } catch {
+      // ignore stored errors
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(AUTO_STORAGE_KEY, JSON.stringify(autoConfig));
+  }, [autoConfig]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(HIDDEN_STORAGE_KEY, JSON.stringify(Array.from(hidden)));
+  }, [hidden]);
+
+  const displayDays = useMemo(() => {
+    const base = clampDays(autoConfig.baseDays);
+    if (!autoConfig.enabled) return base;
+    const diff = Math.max(0, diffInDays(autoConfig.anchor, today));
+    return Math.min(365, base + diff);
+  }, [autoConfig, today]);
+
+  const dayLabels = useMemo(() => {
+    const result: string[] = [];
+    for (let i = displayDays - 1; i >= 0; i--) {
+      result.push(shiftDate(today, -i));
+    }
+    return result;
+  }, [displayDays, today]);
+
+  const recordsMap = useMemo(() => {
+    const map = new Map<string, DailyProgressRecord>();
+    for (const record of timeline) {
+      map.set(record.date, record);
+    }
+    return map;
+  }, [timeline]);
+
+  const flavorMap = useMemo(() => {
+    const map = new Map<string, FlavorInfo>();
+    for (const flavor of flavors) map.set(flavor.id, flavor);
+    return map;
+  }, [flavors]);
+
+  const subMap = useMemo(() => {
+    const map = new Map<string, SubflavorInfo>();
+    for (const sub of subflavors) map.set(sub.id, sub);
+    return map;
+  }, [subflavors]);
+
+  const visibleFlavorIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const flavor of flavors) {
+      const key = `f:${flavor.id}`;
+      if (!hidden.has(key)) set.add(flavor.id);
+    }
+    return set;
+  }, [flavors, hidden]);
+
+  const visibleSubIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const sub of subflavors) {
+      const key = `s:${sub.id}`;
+      if (visibleFlavorIds.has(sub.flavorId) && !hidden.has(key)) set.add(sub.id);
+    }
+    return set;
+  }, [subflavors, visibleFlavorIds, hidden]);
+
+  const groupedSubs = useMemo(() => {
+    const map = new Map<string, SubflavorInfo[]>();
+    for (const sub of subflavors) {
+      if (!visibleSubIds.has(sub.id)) continue;
+      if (!map.has(sub.flavorId)) map.set(sub.flavorId, []);
+      map.get(sub.flavorId)!.push(sub);
+    }
+    return map;
+  }, [subflavors, visibleSubIds]);
+
+  const visibleFlavorsList = useMemo(
+    () => flavors.filter((flavor) => visibleFlavorIds.has(flavor.id)),
+    [flavors, visibleFlavorIds],
+  );
+
+  const rangeDays = useMemo(() => {
+    const option = TIME_RANGES.find((opt) => opt.key === timeRange);
+    return option ? option.days : 7;
+  }, [timeRange]);
+
+  const rangeDates = useMemo(() => {
+    const result: string[] = [];
+    for (let i = rangeDays - 1; i >= 0; i--) {
+      result.push(shiftDate(today, -i));
+    }
+    return result;
+  }, [rangeDays, today]);
+
+  function getFlavorStatus(date: string, flavorId: string): StatusType {
+    if (trackingStart && date < trackingStart) return 'notStarted';
+    const record = recordsMap.get(date);
+    if (!record) return 'missed';
+    const entry = record.flavors.find((f) => f.flavorId === flavorId);
+    if (!entry) return 'missed';
+    if (entry.done) return 'done';
+    if (entry.planned) return 'planned';
+    return 'missed';
+  }
+
+  function getSubStatus(date: string, subId: string): StatusType {
+    if (trackingStart && date < trackingStart) return 'notStarted';
+    const record = recordsMap.get(date);
+    if (!record) return 'missed';
+    for (const entry of record.flavors) {
+      const subEntry = entry.subflavors.find((sf) => sf.subflavorId === subId);
+      if (subEntry) {
+        if (subEntry.done) return 'done';
+        if (subEntry.planned) return 'planned';
+        return 'missed';
+      }
+    }
+    return 'missed';
+  }
+
+  const flavorChartData = useMemo(() => {
+    const totals = new Map<string, number>();
+    for (const date of rangeDates) {
+      const record = recordsMap.get(date);
+      if (!record) continue;
+      for (const entry of record.flavors) {
+        if (!visibleFlavorIds.has(entry.flavorId)) continue;
+        totals.set(
+          entry.flavorId,
+          (totals.get(entry.flavorId) ?? 0) + (entry.minutes ?? 0),
+        );
+      }
+    }
+    const items = Array.from(totals.entries())
+      .map(([id, minutes]) => {
+        const flavor = flavorMap.get(id);
+        return {
+          id,
+          name: flavor?.name || 'Flavor',
+          parentName: '',
+          minutes,
+          value: minutes,
+          color: flavor?.color || '#f97316',
+          icon: flavor?.icon || '🍰',
+        };
+      })
+      .filter((item) => item.minutes > 0)
+      .sort((a, b) => b.minutes - a.minutes);
+    return items;
+  }, [rangeDates, recordsMap, visibleFlavorIds, flavorMap]);
+
+  const subChartData = useMemo(() => {
+    const totals = new Map<string, number>();
+    for (const date of rangeDates) {
+      const record = recordsMap.get(date);
+      if (!record) continue;
+      for (const entry of record.flavors) {
+        for (const subEntry of entry.subflavors) {
+          if (!visibleSubIds.has(subEntry.subflavorId)) continue;
+          totals.set(
+            subEntry.subflavorId,
+            (totals.get(subEntry.subflavorId) ?? 0) + (subEntry.minutes ?? 0),
+          );
+        }
+      }
+    }
+    const items = Array.from(totals.entries())
+      .map(([id, minutes]) => {
+        const sub = subMap.get(id);
+        const parent = sub ? flavorMap.get(sub.flavorId) : undefined;
+        return {
+          id,
+          name: sub?.name || 'Subflavor',
+          parentName: parent?.name || '',
+          minutes,
+          value: minutes,
+          color: sub?.color || parent?.color || '#f97316',
+        };
+      })
+      .filter((item) => item.minutes > 0)
+      .sort((a, b) => b.minutes - a.minutes);
+    return items;
+  }, [rangeDates, recordsMap, visibleSubIds, subMap, flavorMap]);
+
+  const pieData = showSubDistribution ? subChartData : flavorChartData;
+  const totalMinutes = useMemo(
+    () => pieData.reduce((sum, item) => sum + (item.minutes ?? 0), 0),
+    [pieData],
+  );
+
+  function toggleFlavorVisibility(id: string) {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      const key = `f:${id}`;
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }
+
+  function toggleSubVisibility(id: string) {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      const key = `s:${id}`;
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  }
+
+  function handleDayOptionChange(value: number) {
+    setAutoConfig((cfg) => ({ ...cfg, baseDays: clampDays(value) }));
+  }
+
+  function toggleAutoExtend() {
+    setAutoConfig((cfg) => {
+      if (cfg.enabled) return { ...cfg, enabled: false };
+      return { enabled: true, baseDays: clampDays(cfg.baseDays), anchor: today };
+    });
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex rounded-full bg-gray-100 p-1 text-sm font-medium">
+          <button
+            type="button"
+            onClick={() => setView('streaks')}
+            className={cn(
+              'rounded-full px-4 py-2 transition-colors',
+              view === 'streaks'
+                ? 'bg-orange-500 text-white shadow-md'
+                : 'text-gray-600 hover:text-gray-900',
+            )}
+          >
+            Streaks
+          </button>
+          <button
+            type="button"
+            onClick={() => setView('time')}
+            className={cn(
+              'rounded-full px-4 py-2 transition-colors',
+              view === 'time'
+                ? 'bg-orange-500 text-white shadow-md'
+                : 'text-gray-600 hover:text-gray-900',
+            )}
+          >
+            Time spent
+          </button>
+        </div>
+        <p className="text-xs text-gray-500">
+          Data reflects flavours attached to your time blocks.
+        </p>
+      </div>
+
+      {view === 'streaks' ? (
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border bg-white/80 p-4 shadow-sm">
+            <div className="flex items-center gap-3 text-sm">
+              <label className="font-semibold text-gray-700" htmlFor="tracking-days">
+                Days to display
+              </label>
+              <select
+                id="tracking-days"
+                value={autoConfig.baseDays}
+                onChange={(e) => handleDayOptionChange(Number(e.target.value))}
+                className="rounded-md border border-gray-200 bg-white px-3 py-1 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-400"
+              >
+                {DAY_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center gap-3 text-sm">
+              <button
+                type="button"
+                onClick={toggleAutoExtend}
+                className={cn(
+                  'rounded-full px-4 py-2 font-semibold transition-colors',
+                  autoConfig.enabled
+                    ? 'bg-orange-500 text-white shadow-md shadow-orange-200'
+                    : 'border border-orange-400 text-orange-600 hover:bg-orange-50',
+                )}
+              >
+                Activate +1
+              </button>
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={() => setFilterOpen((open) => !open)}
+                  className="rounded-full border border-gray-300 px-4 py-2 font-semibold text-gray-700 transition hover:bg-gray-100"
+                >
+                  Hide flavours
+                </button>
+                {filterOpen && (
+                  <div className="absolute right-0 z-20 mt-2 w-72 rounded-xl border bg-white/95 p-4 text-sm shadow-2xl">
+                    <div className="flex items-center justify-between">
+                      <span className="font-semibold text-gray-700">Choose visibility</span>
+                      <button
+                        type="button"
+                        className="text-lg text-gray-400 hover:text-gray-600"
+                        onClick={() => setFilterOpen(false)}
+                        aria-label="Close flavour filter"
+                      >
+                        ×
+                      </button>
+                    </div>
+                    <div className="mt-3 max-h-64 space-y-3 overflow-y-auto pr-1">
+                      {flavors.map((flavor) => {
+                        const flavorKey = `f:${flavor.id}`;
+                        const subs = subflavors.filter((sub) => sub.flavorId === flavor.id);
+                        return (
+                          <div key={flavor.id} className="rounded-lg bg-gray-50/60 px-3 py-2">
+                            <label className="flex items-center gap-2 text-sm font-semibold text-gray-700">
+                              <input
+                                type="checkbox"
+                                checked={!hidden.has(flavorKey)}
+                                onChange={() => toggleFlavorVisibility(flavor.id)}
+                              />
+                              <span className="flex items-center gap-2">
+                                <span className="text-base">{flavor.icon || '🍰'}</span>
+                                <span>{flavor.name || 'Unnamed flavour'}</span>
+                              </span>
+                            </label>
+                            {subs.length > 0 && (
+                              <div className="mt-2 space-y-1 pl-6">
+                                {subs.map((sub) => {
+                                  const subKey = `s:${sub.id}`;
+                                  return (
+                                    <label
+                                      key={sub.id}
+                                      className="flex items-center gap-2 text-xs text-gray-600"
+                                    >
+                                      <input
+                                        type="checkbox"
+                                        checked={!hidden.has(subKey)}
+                                        disabled={hidden.has(flavorKey)}
+                                        onChange={() => toggleSubVisibility(sub.id)}
+                                      />
+                                      <span className="flex items-center gap-2">
+                                        <span>{sub.icon || '•'}</span>
+                                        <span>{sub.name || 'Subflavor'}</span>
+                                      </span>
+                                    </label>
+                                  );
+                                })}
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setFilterOpen(false)}
+                      className="mt-4 w-full rounded-full bg-orange-500 px-4 py-2 text-sm font-semibold text-white shadow-sm shadow-orange-200"
+                    >
+                      Done
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+          <p className="text-xs text-gray-500">
+            Showing the last {displayDays} days.{' '}
+            {autoConfig.enabled
+              ? 'A new day slides in automatically every midnight.'
+              : 'Enable Activate +1 to automatically reveal each new day.'}
+          </p>
+          {visibleFlavorsList.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-orange-200 bg-orange-50/70 p-8 text-center text-sm text-orange-600">
+              Select at least one flavour or subflavour in the filter to light up the grid.
+            </div>
+          ) : (
+            <div className="overflow-x-auto rounded-2xl border bg-white/80 p-4 shadow-lg backdrop-blur-sm">
+              <div
+                className="grid gap-2 text-xs"
+                style={{
+                  gridTemplateColumns: `220px repeat(${dayLabels.length}, minmax(36px, 1fr))`,
+                }}
+              >
+                <div className="text-left text-sm font-semibold uppercase tracking-wide text-gray-500">
+                  Flavour
+                </div>
+                {dayLabels.map((date) => {
+                  const isToday = date === today;
+                  return (
+                    <div
+                      key={date}
+                      className={cn(
+                        'flex flex-col items-center gap-0.5 rounded-md px-1 py-1 text-[11px] font-semibold',
+                        isToday ? 'bg-orange-100 text-orange-700' : 'text-gray-500',
+                      )}
+                    >
+                      <span>{formatWeekday(date)}</span>
+                      <span>{formatDayLabel(date)}</span>
+                    </div>
+                  );
+                })}
+                {visibleFlavorsList.map((flavor) => {
+                  const subs = groupedSubs.get(flavor.id) ?? [];
+                  const color = flavor.color || '#f97316';
+                  return (
+                    <Fragment key={flavor.id}>
+                      <div className="flex items-center gap-3 rounded-xl bg-white/90 px-3 py-3 text-sm font-semibold text-gray-800 shadow-sm">
+                        <span
+                          className="flex h-9 w-9 items-center justify-center rounded-full text-lg"
+                          style={{ backgroundColor: `${color}20`, color: color }}
+                        >
+                          {flavor.icon || '🍰'}
+                        </span>
+                        <div className="flex-1">
+                          <div>{flavor.name || 'Unnamed flavour'}</div>
+                          <div className="text-xs font-normal text-gray-500">
+                            {flavor.description || 'Planned via time blocks'}
+                          </div>
+                        </div>
+                      </div>
+                      {dayLabels.map((date) => (
+                        <div key={`${flavor.id}-${date}`} className="flex items-center justify-center">
+                          <StatusCell
+                            status={getFlavorStatus(date, flavor.id)}
+                            isToday={date === today}
+                          />
+                        </div>
+                      ))}
+                      {subs.map((sub) => {
+                        const subColor = sub.color || color;
+                        return (
+                          <Fragment key={sub.id}>
+                            <div
+                              className="ml-6 flex items-center gap-3 rounded-xl border-l-4 bg-white/80 px-3 py-2 text-xs font-medium text-gray-600"
+                              style={{ borderColor: subColor }}
+                            >
+                              <span className="text-base text-gray-500">{sub.icon || '•'}</span>
+                              <div>
+                                <div>{sub.name || 'Subflavor'}</div>
+                                {sub.description && (
+                                  <div className="text-[10px] text-gray-400">{sub.description}</div>
+                                )}
+                              </div>
+                            </div>
+                            {dayLabels.map((date) => (
+                              <div key={`${sub.id}-${date}`} className="flex items-center justify-center">
+                                <StatusCell
+                                  status={getSubStatus(date, sub.id)}
+                                  isToday={date === today}
+                                />
+                              </div>
+                            ))}
+                          </Fragment>
+                        );
+                      })}
+                    </Fragment>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-5">
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border bg-white/80 p-4 shadow-sm">
+            <div className="flex flex-wrap items-center gap-2">
+              {TIME_RANGES.map((opt) => (
+                <button
+                  key={opt.key}
+                  type="button"
+                  onClick={() => setTimeRange(opt.key)}
+                  className={cn(
+                    'rounded-full px-4 py-2 text-sm font-semibold transition-colors',
+                    timeRange === opt.key
+                      ? 'bg-orange-500 text-white shadow-md shadow-orange-200'
+                      : 'border border-orange-300 text-orange-600 hover:bg-orange-50',
+                  )}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={() => setShowSubDistribution((prev) => !prev)}
+              className={cn(
+                'rounded-full px-4 py-2 text-sm font-semibold transition-colors',
+                showSubDistribution
+                  ? 'bg-purple-500 text-white shadow-md shadow-purple-200'
+                  : 'border border-purple-300 text-purple-600 hover:bg-purple-50',
+              )}
+            >
+              {showSubDistribution ? 'View main flavours' : 'See subflavour distribution'}
+            </button>
+          </div>
+          <p className="text-xs text-gray-500">
+            Hours calculated in your { _timeZone } timezone.
+          </p>
+          {pieData.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-orange-200 bg-orange-50/70 p-10 text-center text-sm text-orange-600">
+              No completed time blocks in this range yet. Tag your activities with flavours to power this view.
+            </div>
+          ) : (
+            <div className="flex flex-col gap-6 lg:flex-row">
+              <div className="h-80 w-full rounded-2xl bg-white/90 p-4 shadow-lg backdrop-blur-sm lg:w-1/2">
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie
+                      data={pieData}
+                      dataKey="value"
+                      nameKey="name"
+                      innerRadius={70}
+                      outerRadius={120}
+                      paddingAngle={2}
+                    >
+                      {pieData.map((entry) => (
+                        <Cell key={entry.id} fill={entry.color || '#f97316'} />
+                      ))}
+                    </Pie>
+                    <Tooltip content={<ChartTooltip />} />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+              <div className="flex-1 space-y-3 rounded-2xl border bg-white/90 p-4 shadow-lg backdrop-blur-sm">
+                {pieData.map((entry) => {
+                  const hours = entry.minutes / 60;
+                  const percent = totalMinutes ? (entry.minutes / totalMinutes) * 100 : 0;
+                  return (
+                    <div
+                      key={entry.id}
+                      className="flex items-center justify-between rounded-xl bg-gray-50 px-3 py-2"
+                    >
+                      <div className="flex items-center gap-3">
+                        <span
+                          className="h-3 w-3 rounded-full"
+                          style={{ backgroundColor: entry.color || '#f97316' }}
+                        />
+                        <div>
+                          <div className="text-sm font-semibold text-gray-800">{entry.name}</div>
+                          {entry.parentName && (
+                            <div className="text-xs text-gray-500">{entry.parentName}</div>
+                          )}
+                        </div>
+                      </div>
+                      <div className="text-right text-sm text-gray-600">
+                        <div>{hours.toFixed(1)} h</div>
+                        <div>{percent.toFixed(1)}%</div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/drizzle/0035_create_progress_snapshots.sql
+++ b/drizzle/0035_create_progress_snapshots.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "progress_snapshots" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "user_id" integer NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "snapshot_date" date NOT NULL,
+  "data" jsonb NOT NULL,
+  "created_at" timestamp DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "progress_snapshots_user_date_unique"
+  ON "progress_snapshots" ("user_id", "snapshot_date");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -226,5 +226,12 @@
       "tag": "0034_add_coach_tone_custom",
       "breakpoints": true
     }
+    ,{
+      "idx": 32,
+      "version": "7",
+      "when": 1756284819565,
+      "tag": "0035_create_progress_snapshots",
+      "breakpoints": true
+    }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -296,6 +296,25 @@ export const profileSnapshots = pgTable(
   }),
 );
 
+export const progressSnapshots = pgTable(
+  'progress_snapshots',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    snapshotDate: date('snapshot_date').notNull(),
+    data: jsonb('data').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserDate: uniqueIndex('progress_snapshots_user_date_unique').on(
+      table.userId,
+      table.snapshotDate,
+    ),
+  }),
+);
+
 export const dailyReports = pgTable(
   'daily_reports',
   {

--- a/lib/flavors-store.ts
+++ b/lib/flavors-store.ts
@@ -91,11 +91,37 @@ async function canView(
   }
 }
 
+export async function canViewerSeeFlavor(
+  viewerId: number | null,
+  ownerId: number,
+  vis: Visibility,
+) {
+  return canView(viewerId, ownerId, vis);
+}
+
 export async function listFlavors(userId: string): Promise<Flavor[]> {
   const id = Number(userId);
   if (Number.isNaN(id)) return [];
   const rows = await db.select().from(flavors).where(eq(flavors.userId, id));
   return sortFlavors(rows.map(toFlavor));
+}
+
+export async function listFlavorsForViewer(
+  userId: string,
+  viewerId: number | null,
+): Promise<Flavor[]> {
+  const id = Number(userId);
+  if (Number.isNaN(id)) return [];
+  const rows = await db.select().from(flavors).where(eq(flavors.userId, id));
+  const result: Flavor[] = [];
+  for (const row of rows) {
+    const vis = (row.visibility as Visibility) ?? 'public';
+    const ownerId = row.userId ?? id;
+    if (await canView(viewerId, ownerId, vis)) {
+      result.push(toFlavor(row));
+    }
+  }
+  return sortFlavors(result);
 }
 
 export async function getFlavor(

--- a/lib/progress-tracking-store.ts
+++ b/lib/progress-tracking-store.ts
@@ -1,0 +1,554 @@
+import { db } from './db';
+import { plans, planBlocks, progressSnapshots } from './db/schema';
+import { and, asc, eq, gte, lte, sql, type SQL } from 'drizzle-orm';
+import type { Flavor } from '@/types/flavor';
+import type { Subflavor } from '@/types/subflavor';
+import { addDays, parseYMD, startOfDay, toYMD } from './clock';
+import { getPlanAt } from './plans-store';
+import { listFlavors } from './flavors-store';
+import { listAllSubflavors } from './subflavors-store';
+
+type BlockRecord = {
+  start: string;
+  end: string;
+  flavorIds: string[];
+  subflavorIds: string[];
+};
+
+export type SubflavorProgress = {
+  subflavorId: string;
+  minutes: number;
+  done: boolean;
+  planned: boolean;
+};
+
+export type FlavorProgress = {
+  flavorId: string;
+  minutes: number;
+  done: boolean;
+  planned: boolean;
+  subflavors: SubflavorProgress[];
+};
+
+export type DailyProgressRecord = {
+  date: string;
+  flavors: FlavorProgress[];
+};
+
+export type StoredProgressSnapshot = DailyProgressRecord & {
+  version: 1;
+  timeZone: string;
+};
+
+function minutesBetween(startIso: string, endIso: string) {
+  const start = new Date(startIso).getTime();
+  const end = new Date(endIso).getTime();
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return 0;
+  return Math.max(0, (end - start) / 60000);
+}
+
+type FlavorState = {
+  minutes: number;
+  done: boolean;
+  planned: boolean;
+  subflavors: Map<string, { minutes: number; done: boolean; planned: boolean }>;
+};
+
+function round2(n: number) {
+  return Math.round(n * 100) / 100;
+}
+
+const VISIBILITIES = new Set(['private', 'friends', 'followers', 'public']);
+
+function toStringValue(value: unknown, fallback = ''): string {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  if (typeof value === 'bigint') return value.toString();
+  if (value instanceof Date) return value.toISOString();
+  if (value === null || value === undefined) return fallback;
+  return fallback;
+}
+
+function toNumberValue(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  if (typeof value === 'bigint') return Number(value);
+  return fallback;
+}
+
+const ISO_FALLBACK = new Date(0).toISOString();
+
+function toIsoString(value: unknown, fallback = ISO_FALLBACK): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+  return fallback;
+}
+
+type VisibilityValue = Flavor['visibility'];
+
+function toVisibilityValue(
+  value: unknown,
+  fallback: VisibilityValue,
+): VisibilityValue {
+  if (typeof value === 'string' && VISIBILITIES.has(value)) {
+    return value as VisibilityValue;
+  }
+  return fallback;
+}
+
+function normalizeFlavorRow(row: any, ownerId: number): Flavor | null {
+  if (!row) return null;
+  const id = toStringValue(row.id ?? row.flavorId ?? row.uuid ?? '');
+  if (!id) return null;
+  const userId = toStringValue(row.userId ?? row.user_id ?? ownerId, String(ownerId));
+  const createdAt = toIsoString(row.createdAt ?? row.created_at);
+  const updatedAt = toIsoString(row.updatedAt ?? row.updated_at);
+  return {
+    id,
+    userId,
+    slug: toStringValue(row.slug ?? ''),
+    name: toStringValue(row.name ?? ''),
+    description: toStringValue(row.description ?? ''),
+    color: toStringValue(row.color ?? '#888888'),
+    icon: toStringValue(row.icon ?? '⭐'),
+    importance: toNumberValue(row.importance ?? row.weight ?? 0, 0),
+    targetMix: toNumberValue(row.targetMix ?? row.target_mix ?? 0, 0),
+    visibility: toVisibilityValue(row.visibility, 'public'),
+    orderIndex: toNumberValue(row.orderIndex ?? row.order_index ?? 0, 0),
+    createdAt,
+    updatedAt,
+  };
+}
+
+function normalizeSubflavorRow(row: any, ownerId: number): Subflavor | null {
+  if (!row) return null;
+  const id = toStringValue(row.id ?? row.subflavorId ?? row.uuid ?? '');
+  const flavorId = toStringValue(row.flavorId ?? row.flavor_id ?? '');
+  if (!id || !flavorId) return null;
+  const userId = toStringValue(row.userId ?? row.user_id ?? ownerId, String(ownerId));
+  const createdAt = toIsoString(row.createdAt ?? row.created_at);
+  const updatedAt = toIsoString(row.updatedAt ?? row.updated_at);
+  return {
+    id,
+    userId,
+    flavorId,
+    slug: toStringValue(row.slug ?? ''),
+    name: toStringValue(row.name ?? ''),
+    description: toStringValue(row.description ?? ''),
+    color: toStringValue(row.color ?? '#888888'),
+    icon: toStringValue(row.icon ?? '⭐'),
+    importance: toNumberValue(row.importance ?? row.weight ?? 0, 0),
+    targetMix: toNumberValue(row.targetMix ?? row.target_mix ?? 0, 0),
+    visibility: toVisibilityValue(row.visibility, 'private'),
+    orderIndex: toNumberValue(row.orderIndex ?? row.order_index ?? 0, 0),
+    createdAt,
+    updatedAt,
+  };
+}
+
+function sortFlavorsBySnapshot(list: Flavor[]): Flavor[] {
+  return list.sort((a, b) => {
+    if (b.importance !== a.importance) return b.importance - a.importance;
+    if (a.orderIndex !== b.orderIndex) return a.orderIndex - b.orderIndex;
+    return (
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    );
+  });
+}
+
+function sortSubflavorsBySnapshot(list: Subflavor[]): Subflavor[] {
+  return list.sort((a, b) => {
+    if (b.importance !== a.importance) return b.importance - a.importance;
+    if (a.orderIndex !== b.orderIndex) return a.orderIndex - b.orderIndex;
+    return (
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    );
+  });
+}
+
+export function normalizeSnapshotFlavors(
+  source: unknown,
+  ownerId: number,
+): Flavor[] {
+  if (!Array.isArray(source)) return [];
+  const results: Flavor[] = [];
+  for (const entry of source) {
+    const normalized = normalizeFlavorRow(entry, ownerId);
+    if (normalized) results.push(normalized);
+  }
+  return sortFlavorsBySnapshot(results);
+}
+
+export function normalizeSnapshotSubflavors(
+  source: unknown,
+  ownerId: number,
+): Subflavor[] {
+  if (!Array.isArray(source)) return [];
+  const results: Subflavor[] = [];
+  for (const entry of source) {
+    const normalized = normalizeSubflavorRow(entry, ownerId);
+    if (normalized) results.push(normalized);
+  }
+  return sortSubflavorsBySnapshot(results);
+}
+
+function buildDailyRecord({
+  date,
+  blocks,
+  flavors,
+  subflavors,
+  at,
+}: {
+  date: string;
+  blocks: BlockRecord[];
+  flavors: Flavor[];
+  subflavors: Subflavor[];
+  at: Date;
+}): DailyProgressRecord {
+  const flavorStates = new Map<string, FlavorState>();
+  const subToFlavor = new Map<string, string>();
+  const subsByFlavor = new Map<string, Subflavor[]>();
+  for (const flavor of flavors) {
+    flavorStates.set(flavor.id, {
+      minutes: 0,
+      done: false,
+      planned: false,
+      subflavors: new Map(),
+    });
+  }
+  for (const sub of subflavors) {
+    subToFlavor.set(sub.id, sub.flavorId);
+    if (!subsByFlavor.has(sub.flavorId)) subsByFlavor.set(sub.flavorId, []);
+    subsByFlavor.get(sub.flavorId)!.push(sub);
+    if (!flavorStates.has(sub.flavorId)) {
+      flavorStates.set(sub.flavorId, {
+        minutes: 0,
+        done: false,
+        planned: false,
+        subflavors: new Map(),
+      });
+    }
+    const parent = flavorStates.get(sub.flavorId)!;
+    parent.subflavors.set(sub.id, { minutes: 0, done: false, planned: false });
+  }
+
+  const atTime = at.getTime();
+
+  for (const block of blocks) {
+    const minutes = minutesBetween(block.start, block.end);
+    if (minutes === 0) continue;
+    const start = new Date(block.start).getTime();
+    const end = new Date(block.end).getTime();
+    if (!Number.isFinite(start) || !Number.isFinite(end)) continue;
+    const done = end <= atTime;
+    const planned = !done && start <= atTime;
+
+    const validSubs = block.subflavorIds.filter((sid) => subToFlavor.has(sid));
+    if (validSubs.length > 0) {
+      const share = minutes / validSubs.length;
+      for (const sid of validSubs) {
+        const flavorId = subToFlavor.get(sid);
+        if (!flavorId) continue;
+        const parent = flavorStates.get(flavorId);
+        if (!parent) continue;
+        const subState = parent.subflavors.get(sid) ?? {
+          minutes: 0,
+          done: false,
+          planned: false,
+        };
+        if (!parent.subflavors.has(sid)) parent.subflavors.set(sid, subState);
+        if (done) {
+          subState.minutes += share;
+          subState.done = true;
+          parent.minutes += share;
+          parent.done = true;
+        } else if (planned) {
+          subState.planned = true;
+          parent.planned = true;
+        } else {
+          parent.planned = true;
+        }
+      }
+    }
+
+    const directFlavors = block.flavorIds.filter((fid) => flavorStates.has(fid));
+    const filteredDirect = directFlavors.filter((fid) =>
+      !validSubs.some((sid) => subToFlavor.get(sid) === fid),
+    );
+    if (filteredDirect.length > 0) {
+      const share = minutes / filteredDirect.length;
+      for (const fid of filteredDirect) {
+        const state = flavorStates.get(fid);
+        if (!state) continue;
+        if (done) {
+          state.minutes += share;
+          state.done = true;
+        } else if (planned) {
+          state.planned = true;
+        } else {
+          state.planned = true;
+        }
+      }
+    }
+  }
+
+  const results: FlavorProgress[] = [];
+  for (const flavor of flavors) {
+    const state = flavorStates.get(flavor.id) ?? {
+      minutes: 0,
+      done: false,
+      planned: false,
+      subflavors: new Map<string, { minutes: number; done: boolean; planned: boolean }>(),
+    };
+    const subs = subsByFlavor.get(flavor.id) ?? [];
+    const subEntries: SubflavorProgress[] = subs.map((sub) => {
+      const subState = state.subflavors.get(sub.id) ?? {
+        minutes: 0,
+        done: false,
+        planned: false,
+      };
+      return {
+        subflavorId: sub.id,
+        minutes: round2(subState.minutes),
+        done: subState.done,
+        planned: !subState.done && subState.planned,
+      };
+    });
+    results.push({
+      flavorId: flavor.id,
+      minutes: round2(state.minutes),
+      done: state.done,
+      planned: !state.done && state.planned,
+      subflavors: subEntries,
+    });
+  }
+
+  return { date, flavors: results };
+}
+
+async function fetchPlanBlocksInRange(
+  userId: number,
+  startDate: string,
+  endDate: string,
+): Promise<Map<string, BlockRecord[]>> {
+  const rows = await db
+    .select({
+      date: plans.date,
+      start: planBlocks.start,
+      end: planBlocks.end,
+      flavorIds: planBlocks.flavorIds,
+      subflavorIds: planBlocks.subflavorIds,
+    })
+    .from(plans)
+    .leftJoin(planBlocks, eq(planBlocks.planId, plans.id))
+    .where(
+      and(
+        eq(plans.userId, userId),
+        gte(plans.date, startDate),
+        lte(plans.date, endDate),
+      ),
+    )
+    .orderBy(asc(plans.date), asc(planBlocks.start));
+
+  const map = new Map<string, BlockRecord[]>();
+  for (const row of rows) {
+    if (!map.has(row.date)) map.set(row.date, []);
+    if (row.start && row.end) {
+      map.get(row.date)!.push({
+        start: row.start.toISOString(),
+        end: row.end.toISOString(),
+        flavorIds: Array.isArray(row.flavorIds)
+          ? row.flavorIds.map(String)
+          : [],
+        subflavorIds: Array.isArray(row.subflavorIds)
+          ? row.subflavorIds.map(String)
+          : [],
+      });
+    }
+  }
+  return map;
+}
+
+export async function createProgressSnapshot(
+  userId: number,
+  snapshotDate: string,
+  tz: string,
+) {
+  const nextDay = addDays(parseYMD(snapshotDate, tz), 1, tz);
+  const plan = await getPlanAt(userId, snapshotDate, nextDay);
+  const allFlavors = await listFlavors(String(userId));
+  const allSubflavors = await listAllSubflavors(String(userId));
+  const record = buildDailyRecord({
+    date: snapshotDate,
+    blocks: plan.blocks.map((blk) => ({
+      start: blk.start,
+      end: blk.end,
+      flavorIds: blk.flavorIds,
+      subflavorIds: blk.subflavorIds,
+    })),
+    flavors: allFlavors,
+    subflavors: allSubflavors,
+    at: nextDay,
+  });
+  const payload: StoredProgressSnapshot = {
+    version: 1,
+    timeZone: tz,
+    ...record,
+  };
+  await db
+    .insert(progressSnapshots)
+    .values({
+      userId,
+      snapshotDate,
+      data: payload,
+    })
+    .onConflictDoUpdate({
+      target: [progressSnapshots.userId, progressSnapshots.snapshotDate],
+      set: { data: payload },
+    });
+}
+
+export async function ensureDailyProgressSnapshot(userId: number, tz: string) {
+  const today = startOfDay(new Date(), tz);
+  const yesterday = addDays(today, -1, tz);
+  const target = toYMD(yesterday, tz);
+  const existing = await db
+    .select({ id: progressSnapshots.id })
+    .from(progressSnapshots)
+    .where(and(eq(progressSnapshots.userId, userId), eq(progressSnapshots.snapshotDate, target)));
+  if (existing.length === 0) {
+    await createProgressSnapshot(userId, target, tz);
+  }
+}
+
+export async function listProgressSnapshots(
+  userId: number,
+  opts: { startDate?: string; endDate?: string } = {},
+): Promise<StoredProgressSnapshot[]> {
+  const clauses: (SQL<unknown> | undefined)[] = [
+    eq(progressSnapshots.userId, userId),
+  ];
+  if (opts.startDate) {
+    clauses.push(gte(progressSnapshots.snapshotDate, opts.startDate));
+  }
+  if (opts.endDate) {
+    clauses.push(lte(progressSnapshots.snapshotDate, opts.endDate));
+  }
+  const activeClauses = clauses.filter(Boolean) as SQL<unknown>[];
+  const whereClause =
+    activeClauses.length === 0
+      ? undefined
+      : activeClauses.length === 1
+        ? activeClauses[0]
+        : and(...activeClauses);
+  const rows = await db
+    .select({ data: progressSnapshots.data })
+    .from(progressSnapshots)
+    .where(whereClause)
+    .orderBy(asc(progressSnapshots.snapshotDate));
+  return rows
+    .map((row) => row.data as StoredProgressSnapshot)
+    .filter((snap) => snap && typeof snap === 'object');
+}
+
+export async function buildProgressTimeline({
+  userId,
+  tz,
+  startDate,
+  endDate,
+  flavors,
+  subflavors,
+  now,
+}: {
+  userId: number;
+  tz: string;
+  startDate: string;
+  endDate: string;
+  flavors: Flavor[];
+  subflavors: Subflavor[];
+  now: Date;
+}): Promise<DailyProgressRecord[]> {
+  const snapshots = await listProgressSnapshots(userId, { startDate, endDate });
+  const snapshotMap = new Map<string, StoredProgressSnapshot>();
+  for (const snap of snapshots) snapshotMap.set(snap.date, snap);
+
+  const planBlocks = await fetchPlanBlocksInRange(userId, startDate, endDate);
+
+  const start = parseYMD(startDate, tz);
+  const end = parseYMD(endDate, tz);
+  const today = toYMD(startOfDay(now, tz), tz);
+  const subsByFlavor = new Map<string, Subflavor[]>();
+  for (const sub of subflavors) {
+    if (!subsByFlavor.has(sub.flavorId)) subsByFlavor.set(sub.flavorId, []);
+    subsByFlavor.get(sub.flavorId)!.push(sub);
+  }
+  const results: DailyProgressRecord[] = [];
+  for (let cursor = start; cursor.getTime() <= end.getTime(); cursor = addDays(cursor, 1, tz)) {
+    const date = toYMD(cursor, tz);
+    const snap = snapshotMap.get(date);
+    if (snap) {
+      const flavorEntries: FlavorProgress[] = [];
+      for (const flavor of flavors) {
+        const original = snap.flavors.find((entry) => entry.flavorId === flavor.id);
+        const subs = subsByFlavor.get(flavor.id) ?? [];
+        const subEntries: SubflavorProgress[] = subs.map((sub) => {
+          const origSub = original?.subflavors.find(
+            (sf) => sf.subflavorId === sub.id,
+          );
+          return {
+            subflavorId: sub.id,
+            minutes: round2(origSub?.minutes ?? 0),
+            done: origSub?.done ?? false,
+            planned: origSub ? !origSub.done && origSub.planned : false,
+          };
+        });
+        flavorEntries.push({
+          flavorId: flavor.id,
+          minutes: round2(original?.minutes ?? 0),
+          done: original?.done ?? false,
+          planned: original ? !original.done && original.planned : false,
+          subflavors: subEntries,
+        });
+      }
+      results.push({ date: snap.date, flavors: flavorEntries });
+      continue;
+    }
+    const blocks = planBlocks.get(date) ?? [];
+    const at = date < today ? addDays(parseYMD(date, tz), 1, tz) : now;
+    results.push(
+      buildDailyRecord({
+        date,
+        blocks,
+        flavors,
+        subflavors,
+        at,
+      }),
+    );
+  }
+  return results;
+}
+
+export async function getTrackingStartDate(userId: number): Promise<string | null> {
+  const [snapshotRow] = await db
+    .select({ minDate: sql<string>`min(${progressSnapshots.snapshotDate})` })
+    .from(progressSnapshots)
+    .where(eq(progressSnapshots.userId, userId));
+  const [planRow] = await db
+    .select({ minDate: sql<string>`min(${plans.date})` })
+    .from(plans)
+    .innerJoin(planBlocks, eq(planBlocks.planId, plans.id))
+    .where(eq(plans.userId, userId));
+  const dates = [snapshotRow?.minDate, planRow?.minDate].filter(
+    (d): d is string => !!d,
+  );
+  if (dates.length === 0) return null;
+  return dates.sort()[0];
+}

--- a/lib/subflavors-store.ts
+++ b/lib/subflavors-store.ts
@@ -64,6 +64,14 @@ async function canView(viewerId: number | null, ownerId: number, vis: Visibility
   }
 }
 
+export async function canViewerSeeSubflavor(
+  viewerId: number | null,
+  ownerId: number,
+  vis: Visibility,
+) {
+  return canView(viewerId, ownerId, vis);
+}
+
 export async function listSubflavors(
   userId: string,
   flavorId: string,
@@ -82,6 +90,24 @@ export async function listAllSubflavors(userId: string): Promise<Subflavor[]> {
   if (Number.isNaN(id)) return [];
   const rows = await db.select().from(subflavors).where(eq(subflavors.userId, id));
   return sortSubflavors(rows.map(toSubflavor));
+}
+
+export async function listSubflavorsForViewer(
+  userId: string,
+  viewerId: number | null,
+): Promise<Subflavor[]> {
+  const id = Number(userId);
+  if (Number.isNaN(id)) return [];
+  const rows = await db.select().from(subflavors).where(eq(subflavors.userId, id));
+  const result: Subflavor[] = [];
+  for (const row of rows) {
+    const vis = (row.visibility as Visibility) ?? 'private';
+    const ownerId = row.userId ?? id;
+    if (await canView(viewerId, ownerId, vis)) {
+      result.push(toSubflavor(row));
+    }
+  }
+  return sortSubflavors(result);
 }
 
 export async function getSubflavor(


### PR DESCRIPTION
## Summary
- normalize flavor and subflavor snapshot data for reuse in progress timelines and tighten snapshot range queries
- expose viewer visibility helpers and update viewer tracking to respect the owner timezone
- add owner and viewer historical tracking pages that reuse the new snapshot timeline plus update the changelog

## Testing
- pnpm lint
- pnpm tsc
- pnpm test *(fails: Playwright browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1674b0c98832aa3a8d223feb857f5