### PR TITLE
feat: add progress tracking dashboard

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -302,3 +302,4 @@
 - 2025-10-30: Forced overview caches to refresh after highlight edits and lit up detail pages with the saved markup so "View in context" immediately shows colored snippets.
 - 2025-10-30: Added custom coach tone saving with completion feedback, fed custom briefs into all rapport prompts, and surfaced the stored tone snapshot on review and planning pages so users (and viewers) see the exact instructions used.
 - 2025-10-30: Added activity block presets with category tagging, save-from-metadata controls, and a custom timeslot library picker in the planner toolbar.
+- 2025-10-30: Launched a progress tracking dashboard with streak visualizations, time-spent charts, flavor visibility controls, and daily progress snapshots for owner and viewer access.

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -3,6 +3,7 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { buildViewContext } from '@/lib/profile';
 import { ensureDailyProfileSnapshot } from '@/lib/profile-snapshots';
+import { ensureDailyProgressSnapshot } from '@/lib/progress-snapshots';
 import { getUserTimeZone } from '@/lib/clock';
 import { cookies } from 'next/headers';
 import { ViewContextProvider } from '@/lib/view-context';
@@ -21,6 +22,7 @@ export default async function AppLayout({
   const cookieStore = await cookies();
   const tz = getUserTimeZone(me as any, { cookies: cookieStore });
   await ensureDailyProfileSnapshot(me.id, tz);
+  await ensureDailyProgressSnapshot(me.id, tz);
   const ctx = buildViewContext({
     ownerId: me.id,
     viewerId: me.id,

--- a/app/(view)/view/[viewId]/flavors/[flavorId]/subflavors/page.tsx
+++ b/app/(view)/view/[viewId]/flavors/[flavorId]/subflavors/page.tsx
@@ -18,7 +18,11 @@ export default async function ViewSubflavorsPage({
   if (!user) notFound();
   const session = await auth();
   const viewer = session ? await ensureUser(session) : null;
-  const subflavors = await listSubflavors(String(user.id), flavorId);
+  const subflavors = await listSubflavors(
+    String(user.id),
+    flavorId,
+    viewer?.id ?? null,
+  );
   const flavor = await getFlavor(String(user.id), flavorId, viewer?.id || null);
   if (!flavor) notFound();
   const viewerFlavors = viewer ? await listFlavors(String(viewer.id)) : [];

--- a/app/(view)/view/[viewId]/progress/tracking/page.tsx
+++ b/app/(view)/view/[viewId]/progress/tracking/page.tsx
@@ -1,12 +1,13 @@
 import { getUserByViewId, ensureUser } from '@/lib/users';
 import { notFound } from 'next/navigation';
 import { auth } from '@/lib/auth';
-import { listFlavors } from '@/lib/flavors-store';
 import { buildViewContext } from '@/lib/profile';
 import { ViewContextProvider } from '@/lib/view-context';
-import { FlavorsHome } from '@/app/(app)/flavors/page';
+import { TrackingHome } from '@/app/progress/tracking/page';
+import { cookies } from 'next/headers';
+import { getUserTimeZone } from '@/lib/clock';
 
-export default async function ViewFlavorsPage({
+export default async function ViewTrackingPage({
   params,
   searchParams,
 }: {
@@ -20,22 +21,19 @@ export default async function ViewFlavorsPage({
   const session = await auth();
   const viewer = session ? await ensureUser(session) : null;
   const viewerId = viewer ? viewer.id : null;
-  const flavors = await listFlavors(String(user.id), viewerId ?? null);
+  if (sp?.at) notFound();
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(user as any, { cookies: cookieStore });
   const ctx = buildViewContext({
     ownerId: user.id,
     viewerId: viewerId ?? null,
-    mode: sp?.at ? 'historical' : 'viewer',
+    mode: 'viewer',
     viewId: user.viewId,
-    snapshotDate: sp?.at,
   });
   return (
     <ViewContextProvider value={ctx}>
-      <section id={`v13w-flav-${user.id}`}>
-        <FlavorsHome
-          userId={String(user.id)}
-          selfId={viewerId ? String(viewerId) : undefined}
-          initialFlavors={flavors}
-        />
+      <section id={`v13w-progress-tracking-${user.id}`}>
+        <TrackingHome ownerId={user.id} viewerId={viewerId ?? null} tz={tz} />
       </section>
     </ViewContextProvider>
   );

--- a/app/(view)/view/[viewId]/subflavors/page.tsx
+++ b/app/(view)/view/[viewId]/subflavors/page.tsx
@@ -23,11 +23,11 @@ export default async function ViewAllSubflavorsPage({
   const session = await auth();
   const viewer = session ? await ensureUser(session) : null;
   const viewerId = viewer ? viewer.id : null;
-  const flavors = await listFlavors(String(user.id));
+  const flavors = await listFlavors(String(user.id), viewerId ?? null);
   const viewerFlavors = viewerId ? await listFlavors(String(viewerId)) : [];
   const groups: { flavor: Flavor; subflavors: Subflavor[] }[] = [];
   for (const f of flavors) {
-    const subs = await listSubflavors(String(user.id), f.id);
+    const subs = await listSubflavors(String(user.id), f.id, viewerId ?? null);
     groups.push({ flavor: f, subflavors: subs });
   }
   const ctx = buildViewContext({

--- a/app/progress/layout.tsx
+++ b/app/progress/layout.tsx
@@ -3,6 +3,7 @@ import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { buildViewContext } from '@/lib/profile';
 import { ensureDailyProfileSnapshot } from '@/lib/profile-snapshots';
+import { ensureDailyProgressSnapshot } from '@/lib/progress-snapshots';
 import { getUserTimeZone } from '@/lib/clock';
 import { cookies } from 'next/headers';
 import { ViewContextProvider } from '@/lib/view-context';
@@ -21,6 +22,7 @@ export default async function ProgressLayout({
   const cookieStore = await cookies();
   const tz = getUserTimeZone(me as any, { cookies: cookieStore });
   await ensureDailyProfileSnapshot(me.id, tz);
+  await ensureDailyProgressSnapshot(me.id, tz);
   const ctx = buildViewContext({
     ownerId: me.id,
     viewerId: me.id,

--- a/app/progress/page.tsx
+++ b/app/progress/page.tsx
@@ -22,6 +22,12 @@ export function ProgressHome() {
         >
           Overview
         </Link>
+        <Link
+          href={hrefFor('/progress/tracking', ctx)}
+          className="bg-orange-500 text-white px-4 py-2 rounded"
+        >
+          Tracking
+        </Link>
       </div>
     </main>
   );

--- a/app/progress/tracking/page.tsx
+++ b/app/progress/tracking/page.tsx
@@ -1,0 +1,33 @@
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { redirect } from 'next/navigation';
+import { cookies } from 'next/headers';
+import { getUserTimeZone } from '@/lib/clock';
+import { buildTrackingDataset } from '@/lib/progress-tracking';
+import TrackingClient from '@/components/progress/tracking-client';
+
+export async function TrackingHome({
+  ownerId,
+  viewerId,
+  tz,
+}: {
+  ownerId: number;
+  viewerId?: number | null;
+  tz: string;
+}) {
+  const dataset = await buildTrackingDataset({ ownerId, viewerId, tz });
+  return (
+    <main className="p-6">
+      <TrackingClient dataset={dataset} />
+    </main>
+  );
+}
+
+export default async function TrackingPage() {
+  const session = await auth();
+  if (!session) redirect('/signin');
+  const me = await ensureUser(session);
+  const cookieStore = await cookies();
+  const tz = getUserTimeZone(me as any, { cookies: cookieStore });
+  return <TrackingHome ownerId={me.id} tz={tz} />;
+}

--- a/components/progress/tracking-client.tsx
+++ b/components/progress/tracking-client.tsx
@@ -1,0 +1,734 @@
+'use client';
+
+import { useMemo, useState, useEffect, Fragment } from 'react';
+import BackButton from '@/components/back-button';
+import { useViewContext } from '@/lib/view-context';
+import { hrefFor } from '@/lib/navigation';
+import type {
+  TrackingDataset,
+  TrackingDailyRecord,
+  TrackingFlavorSummary,
+  TrackingSubflavorSummary,
+} from '@/types/tracking';
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip as RechartsTooltip,
+} from 'recharts';
+
+const dayOptions = [1, 7, 14, 21, 30, 60, 90, 180, 270, 365];
+const timeRangeOptions = [
+  { label: '1 day', value: 1 },
+  { label: '7 days', value: 7 },
+  { label: '1 month', value: 30 },
+  { label: '2 months', value: 60 },
+  { label: 'Half year', value: 182 },
+  { label: '1 year', value: 365 },
+];
+
+type DayState = 'not-started' | 'missed' | 'planned' | 'done';
+
+type ChartDatum = {
+  id: string;
+  label: string;
+  value: number;
+  color: string;
+  percent: number;
+  helper?: string;
+};
+
+function parseYmd(ymd: string): number {
+  const [y, m, d] = ymd.split('-').map(Number);
+  return Date.UTC(y, (m || 1) - 1, d || 1);
+}
+
+function getCurrentYmd(tz: string): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date());
+}
+
+function lightenColor(hex: string, amount = 0.3) {
+  if (!hex) return '#f97316';
+  const normalized = hex.startsWith('#') ? hex.slice(1) : hex;
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) return '#f97316';
+  const num = parseInt(normalized, 16);
+  const r = (num >> 16) & 0xff;
+  const g = (num >> 8) & 0xff;
+  const b = num & 0xff;
+  const tint = (channel: number) =>
+    Math.round(channel + (255 - channel) * amount)
+      .toString(16)
+      .padStart(2, '0');
+  return `#${tint(r)}${tint(g)}${tint(b)}`;
+}
+
+function formatHours(minutes: number) {
+  const hours = minutes / 60;
+  return hours >= 10 ? hours.toFixed(1) : hours.toFixed(2);
+}
+
+function StatusIndicator({
+  state,
+  label,
+}: {
+  state: DayState;
+  label: string;
+}) {
+  switch (state) {
+    case 'done':
+      return (
+        <span
+          className="flex h-7 w-7 items-center justify-center text-lg font-semibold text-green-500"
+          title={`${label}: completed`}
+          aria-label={`${label}: completed`}
+        >
+          ●
+        </span>
+      );
+    case 'missed':
+      return (
+        <span
+          className="flex h-7 w-7 items-center justify-center text-lg font-semibold text-red-500"
+          title={`${label}: not completed`}
+          aria-label={`${label}: not completed`}
+        >
+          ×
+        </span>
+      );
+    case 'planned':
+      return (
+        <span
+          className="flex h-7 w-7 items-center justify-center text-base font-semibold text-orange-500"
+          title={`${label}: planned for today`}
+          aria-label={`${label}: planned for today`}
+        >
+          ■
+        </span>
+      );
+    default:
+      return (
+        <span
+          className="flex h-7 w-7 items-center justify-center text-base font-semibold text-gray-400"
+          title={`${label}: tracking not started`}
+          aria-label={`${label}: tracking not started`}
+        >
+          |||
+        </span>
+      );
+  }
+}
+
+function Legend() {
+  return (
+    <div className="flex flex-wrap gap-4 text-sm text-gray-500">
+      <div className="flex items-center gap-2">
+        <StatusIndicator state="done" label="Completed" />
+        <span>Done</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <StatusIndicator state="missed" label="Missed" />
+        <span>Missed</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <StatusIndicator state="planned" label="Planned" />
+        <span>Planned today</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <StatusIndicator state="not-started" label="Not started" />
+        <span>Tracking not started</span>
+      </div>
+    </div>
+  );
+}
+
+function formatDayLabels(tz: string) {
+  const dayFmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    month: 'short',
+    day: 'numeric',
+  });
+  const weekdayFmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    weekday: 'short',
+  });
+  return (ymd: string) => {
+    const date = new Date(`${ymd}T00:00:00Z`);
+    return {
+      day: dayFmt.format(date),
+      weekday: weekdayFmt.format(date),
+    };
+  };
+}
+
+function computeStatus(
+  record: TrackingDailyRecord,
+  dataset: TrackingDataset,
+  createdAt: string,
+  id: string,
+  type: 'flavor' | 'subflavor',
+): DayState {
+  const createdYmd = createdAt.slice(0, 10);
+  if (record.date < createdYmd) return 'not-started';
+  if (type === 'flavor') {
+    if (record.doneFlavors.includes(id)) return 'done';
+    if (record.date === dataset.today && record.plannedFlavors.includes(id)) {
+      return 'planned';
+    }
+    return 'missed';
+  }
+  if (record.doneSubflavors.includes(id)) return 'done';
+  if (record.date === dataset.today && record.plannedSubflavors.includes(id)) {
+    return 'planned';
+  }
+  return 'missed';
+}
+
+function buildChartData(
+  records: TrackingDailyRecord[],
+  flavors: TrackingFlavorSummary[],
+  subflavors: TrackingSubflavorSummary[],
+  hidden: Set<string>,
+  showSubflavors: boolean,
+) {
+  const flavorTotals = new Map<string, number>();
+  const subTotals = new Map<string, number>();
+  let totalMinutes = 0;
+  for (const record of records) {
+    totalMinutes += record.totalMinutes;
+    for (const [id, minutes] of Object.entries(record.flavorMinutes)) {
+      if (hidden.has(id)) continue;
+      flavorTotals.set(id, (flavorTotals.get(id) ?? 0) + minutes);
+    }
+    for (const [id, minutes] of Object.entries(record.subflavorMinutes)) {
+      if (hidden.has(id)) continue;
+      subTotals.set(id, (subTotals.get(id) ?? 0) + minutes);
+    }
+  }
+  const flavorData: ChartDatum[] = flavors
+    .filter((f) => !hidden.has(f.id))
+    .map((f) => ({
+      id: f.id,
+      label: f.name,
+      value: flavorTotals.get(f.id) ?? 0,
+      color: f.color || '#f97316',
+      percent: 0,
+    }))
+    .filter((d) => d.value > 0)
+    .sort((a, b) => b.value - a.value);
+  const subData: ChartDatum[] = subflavors
+    .filter((sf) => !hidden.has(sf.id) && !hidden.has(sf.flavorId))
+    .map((sf) => ({
+      id: sf.id,
+      label: sf.name,
+      value: subTotals.get(sf.id) ?? 0,
+      color: lightenColor(sf.color || '#f97316', 0.45),
+      percent: 0,
+      helper: sf.flavorId,
+    }))
+    .filter((d) => d.value > 0)
+    .sort((a, b) => b.value - a.value);
+  const working = showSubflavors ? subData : flavorData;
+  const total = working.reduce((sum, item) => sum + item.value, 0);
+  if (total > 0) {
+    for (const item of working) {
+      item.percent = Number(((item.value / total) * 100).toFixed(2));
+    }
+  }
+  return { data: working, totalMinutes: totalMinutes, focusTotal: total };
+}
+
+function TrackingTooltip({ active, payload }: any) {
+  if (!active || !payload?.length) return null;
+  const entry = payload[0]?.payload as ChartDatum | undefined;
+  if (!entry) return null;
+  return (
+    <div className="rounded-md border bg-white px-3 py-2 text-sm shadow">
+      <div className="font-semibold text-gray-900">{entry.label}</div>
+      <div className="text-gray-600">{formatHours(entry.value)} hrs</div>
+      <div className="text-gray-500">{entry.percent.toFixed(2)}%</div>
+    </div>
+  );
+}
+
+export default function TrackingClient({ dataset }: { dataset: TrackingDataset }) {
+  const ctx = useViewContext();
+  const backHref = hrefFor('/progress', ctx);
+  const [view, setView] = useState<'streaks' | 'time'>('streaks');
+  const [selectedDays, setSelectedDays] = useState(() => {
+    const initial = Math.min(14, dataset.records.length || 1);
+    return initial > 0 ? initial : 1;
+  });
+  const [autoExtend, setAutoExtend] = useState(false);
+  const [autoDays, setAutoDays] = useState(0);
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [timeRange, setTimeRange] = useState(() =>
+    Math.min(7, dataset.records.length || 1),
+  );
+  const [showSubDistribution, setShowSubDistribution] = useState(false);
+  const [activeSlice, setActiveSlice] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!autoExtend) {
+      setAutoDays(0);
+      return;
+    }
+    const update = () => {
+      const current = getCurrentYmd(dataset.timezone);
+      const diff = Math.max(0, Math.round((parseYmd(current) - parseYmd(dataset.today)) / 86400000));
+      setAutoDays(diff);
+    };
+    update();
+    const id = setInterval(update, 60_000);
+    return () => clearInterval(id);
+  }, [autoExtend, dataset.timezone, dataset.today]);
+
+  const maxSelectableDays = Math.max(dataset.records.length, 1);
+  const resolvedDayCount = useMemo(() => {
+    const base = Math.max(1, Math.min(selectedDays, maxSelectableDays));
+    const extra = autoExtend ? autoDays : 0;
+    return Math.max(1, Math.min(base + extra, maxSelectableDays));
+  }, [selectedDays, autoExtend, autoDays, maxSelectableDays]);
+
+  const visibleRecords = useMemo(() => {
+    return dataset.records.slice(-resolvedDayCount);
+  }, [dataset.records, resolvedDayCount]);
+
+  const formatDay = useMemo(() => formatDayLabels(dataset.timezone), [dataset.timezone]);
+
+  const flavorTree = useMemo(() => {
+    const map = new Map<string, TrackingSubflavorSummary[]>();
+    for (const sf of dataset.subflavors) {
+      if (!map.has(sf.flavorId)) map.set(sf.flavorId, []);
+      map.get(sf.flavorId)!.push(sf);
+    }
+    for (const list of map.values()) {
+      list.sort((a, b) => a.orderIndex - b.orderIndex || a.name.localeCompare(b.name));
+    }
+    return dataset.flavors.map((flavor) => ({
+      flavor,
+      subflavors: map.get(flavor.id) ?? [],
+    }));
+  }, [dataset.flavors, dataset.subflavors]);
+
+  const visibleRowCount = useMemo(() => {
+    let count = 0;
+    for (const { flavor, subflavors } of flavorTree) {
+      if (hidden.has(flavor.id)) continue;
+      count += 1;
+      for (const sf of subflavors) {
+        if (!hidden.has(sf.id)) count += 1;
+      }
+    }
+    return count;
+  }, [flavorTree, hidden]);
+
+  const chartRecords = useMemo(() => {
+    const range = Math.max(1, Math.min(timeRange, dataset.records.length));
+    return dataset.records.slice(-range);
+  }, [dataset.records, timeRange]);
+
+  const chartData = useMemo(() => {
+    return buildChartData(
+      chartRecords,
+      dataset.flavors,
+      dataset.subflavors,
+      hidden,
+      showSubDistribution,
+    );
+  }, [chartRecords, dataset.flavors, dataset.subflavors, hidden, showSubDistribution]);
+
+  const availableRange = Math.max(dataset.records.length, 1);
+  const rangeDays = chartRecords.length || timeRange;
+  const totalHours = formatHours(chartData.totalMinutes);
+  const focusHours = formatHours(chartData.focusTotal);
+
+  const activeDetails = useMemo(() => {
+    const lookup = new Map(chartData.data.map((item) => [item.id, item]));
+    if (activeSlice && lookup.has(activeSlice)) {
+      return lookup.get(activeSlice)!;
+    }
+    return chartData.data[0];
+  }, [chartData.data, activeSlice]);
+
+  const handleToggleFlavor = (id: string, parentId?: string) => {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+        if (!parentId) {
+          for (const sf of dataset.subflavors) {
+            if (sf.flavorId === id) next.delete(sf.id);
+          }
+        }
+      } else {
+        next.add(id);
+        if (!parentId) {
+          for (const sf of dataset.subflavors) {
+            if (sf.flavorId === id) next.add(sf.id);
+          }
+        }
+      }
+      return next;
+    });
+  };
+
+  const handleShowAll = () => {
+    setHidden(new Set());
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 border-b border-orange-100 pb-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <BackButton href={backHref} />
+            <h1 className="text-3xl font-semibold text-gray-900">Progress Tracking</h1>
+            <p className="text-gray-600">
+              Visualise your streaks and time investment across every flavor and subflavor.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 rounded-full bg-orange-50 p-1 text-sm font-medium text-orange-600">
+            <button
+              type="button"
+              onClick={() => setView('streaks')}
+              className={`rounded-full px-4 py-2 transition ${
+                view === 'streaks'
+                  ? 'bg-white shadow-sm text-orange-600'
+                  : 'text-orange-500 hover:text-orange-600'
+              }`}
+            >
+              Streaks
+            </button>
+            <button
+              type="button"
+              onClick={() => setView('time')}
+              className={`rounded-full px-4 py-2 transition ${
+                view === 'time'
+                  ? 'bg-white shadow-sm text-orange-600'
+                  : 'text-orange-500 hover:text-orange-600'
+              }`}
+            >
+              Time spent
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {view === 'streaks' ? (
+        <section className="space-y-6">
+          <div className="flex flex-wrap items-center gap-4">
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <span className="font-medium">Days shown</span>
+              <select
+                className="rounded-md border border-gray-200 px-3 py-1 text-sm"
+                value={selectedDays}
+                onChange={(event) => setSelectedDays(Number(event.target.value) || 1)}
+              >
+                {dayOptions
+                  .filter((opt) => opt <= maxSelectableDays)
+                  .map((opt) => (
+                    <option key={opt} value={opt}>
+                      Last {opt} days
+                    </option>
+                  ))}
+                {!dayOptions.includes(maxSelectableDays) && (
+                  <option value={maxSelectableDays}>All ({maxSelectableDays})</option>
+                )}
+              </select>
+            </label>
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={autoExtend}
+                onChange={(event) => setAutoExtend(event.target.checked)}
+              />
+              <span>Activate +1 day automatically</span>
+            </label>
+            <div className="relative">
+              <button
+                type="button"
+                className="rounded-full border border-orange-200 px-4 py-2 text-sm font-medium text-orange-600 shadow-sm transition hover:bg-orange-50"
+                onClick={() => setFilterOpen((prev) => !prev)}
+              >
+                {filterOpen ? 'Close filters' : 'Hide flavors'}
+              </button>
+              {filterOpen && (
+                <div className="absolute right-0 z-20 mt-2 w-72 rounded-2xl border border-orange-100 bg-white p-4 shadow-lg">
+                  <div className="mb-3 flex items-center justify-between">
+                    <h3 className="text-sm font-semibold text-gray-800">Visible flavors</h3>
+                    <button
+                      type="button"
+                      className="text-xs font-medium text-orange-600 hover:text-orange-500"
+                      onClick={handleShowAll}
+                    >
+                      Show all
+                    </button>
+                  </div>
+                  <div className="max-h-72 space-y-3 overflow-y-auto pr-1 text-sm">
+                    {flavorTree.map(({ flavor, subflavors }) => (
+                      <div key={flavor.id} className="space-y-2">
+                        <label className="flex items-center gap-2 font-medium text-gray-800">
+                          <input
+                            type="checkbox"
+                            checked={!hidden.has(flavor.id)}
+                            onChange={() => handleToggleFlavor(flavor.id)}
+                          />
+                          <span>
+                            <span className="mr-1 text-lg">{flavor.icon}</span>
+                            {flavor.name}
+                          </span>
+                        </label>
+                        {subflavors.length > 0 && (
+                          <div className="ml-5 space-y-1 border-l border-dashed border-orange-200 pl-3 text-gray-600">
+                            {subflavors.map((sf) => (
+                              <label key={sf.id} className="flex items-center gap-2">
+                                <input
+                                  type="checkbox"
+                                  checked={!hidden.has(sf.id) && !hidden.has(flavor.id)}
+                                  onChange={() => handleToggleFlavor(sf.id, flavor.id)}
+                                  disabled={hidden.has(flavor.id)}
+                                />
+                                <span>
+                                  <span className="mr-1 text-lg">{sf.icon}</span>
+                                  {sf.name}
+                                </span>
+                              </label>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                    {flavorTree.length === 0 && (
+                      <p className="text-sm text-gray-500">No flavors available yet.</p>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <Legend />
+
+          <div className="overflow-x-auto rounded-3xl border border-orange-100 bg-white shadow-sm">
+            <table className="min-w-full border-separate border-spacing-y-2">
+              <thead>
+                <tr>
+                  <th className="sticky left-0 z-10 bg-white/95 px-4 py-3 text-left text-sm font-semibold text-gray-600 backdrop-blur">
+                    Flavor
+                  </th>
+                  {visibleRecords.map((record) => {
+                    const { day, weekday } = formatDay(record.date);
+                    return (
+                      <th
+                        key={record.date}
+                        className="px-3 py-2 text-center text-xs font-medium uppercase tracking-wide text-gray-500"
+                      >
+                        <div>{weekday}</div>
+                        <div className="text-gray-700">{day}</div>
+                      </th>
+                    );
+                  })}
+                </tr>
+              </thead>
+              <tbody>
+                {flavorTree.map(({ flavor, subflavors }) => {
+                  if (hidden.has(flavor.id)) return null;
+                  return (
+                    <Fragment key={flavor.id}>
+                      <tr className="align-middle">
+                        <td className="sticky left-0 z-10 bg-white/95 px-4 py-3 text-sm font-semibold text-gray-800 backdrop-blur">
+                          <div className="flex items-center gap-3">
+                            <span
+                              className="flex h-9 w-9 items-center justify-center rounded-full text-xl"
+                              style={{ backgroundColor: `${flavor.color}22` }}
+                            >
+                              {flavor.icon}
+                            </span>
+                            <span>{flavor.name}</span>
+                          </div>
+                        </td>
+                        {visibleRecords.map((record) => (
+                          <td key={`${flavor.id}-${record.date}`} className="px-3 py-2 text-center">
+                            <StatusIndicator
+                              state={computeStatus(record, dataset, flavor.createdAt, flavor.id, 'flavor')}
+                              label={`${flavor.name} on ${record.date}`}
+                            />
+                          </td>
+                        ))}
+                      </tr>
+                        {subflavors.map((sf) => {
+                          if (hidden.has(sf.id)) return null;
+                          return (
+                            <tr key={sf.id} className="align-middle">
+                            <td className="sticky left-0 z-10 bg-white/95 px-4 py-2 text-sm text-gray-700 backdrop-blur">
+                              <div className="ml-8 flex items-center gap-3 border-l border-dashed border-orange-200 pl-4">
+                                <span
+                                  className="flex h-8 w-8 items-center justify-center rounded-full text-lg"
+                                  style={{ backgroundColor: `${sf.color}1f` }}
+                                >
+                                  {sf.icon}
+                                </span>
+                                <span>{sf.name}</span>
+                              </div>
+                            </td>
+                            {visibleRecords.map((record) => (
+                              <td key={`${sf.id}-${record.date}`} className="px-3 py-2 text-center">
+                                <StatusIndicator
+                                  state={computeStatus(record, dataset, sf.createdAt, sf.id, 'subflavor')}
+                                  label={`${sf.name} on ${record.date}`}
+                                />
+                              </td>
+                            ))}
+                            </tr>
+                          );
+                        })}
+                    </Fragment>
+                  );
+                })}
+                {visibleRowCount === 0 && (
+                  <tr>
+                    <td
+                      colSpan={visibleRecords.length + 1}
+                      className="px-6 py-8 text-center text-sm text-gray-500"
+                    >
+                      Add flavors and subflavors to start tracking your streaks.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ) : (
+        <section className="space-y-6">
+          <div className="flex flex-wrap items-center gap-4">
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <span className="font-medium">Time range</span>
+              <select
+                className="rounded-md border border-gray-200 px-3 py-1 text-sm"
+                value={timeRange}
+                onChange={(event) => setTimeRange(Number(event.target.value) || 1)}
+              >
+                {timeRangeOptions
+                  .filter((opt) => opt.value <= availableRange)
+                  .map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                {!timeRangeOptions.some((opt) => opt.value === dataset.records.length) &&
+                  dataset.records.length > 0 && (
+                  <option value={dataset.records.length}>
+                    Entire history ({dataset.records.length} days)
+                  </option>
+                )}
+              </select>
+            </label>
+            <button
+              type="button"
+              onClick={() => setShowSubDistribution((prev) => !prev)}
+              className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                showSubDistribution
+                  ? 'bg-orange-500 text-white shadow'
+                  : 'border border-orange-200 text-orange-600 hover:bg-orange-50'
+              }`}
+            >
+              {showSubDistribution ? 'Show main flavor mix' : 'See subflavor distribution'}
+            </button>
+          </div>
+
+          <p className="text-sm text-gray-600">
+            {chartData.data.length === 0
+              ? `No time logged in the last ${rangeDays} day${rangeDays === 1 ? '' : 's'} for this view yet.`
+              : `Logged ${totalHours} hrs in the last ${rangeDays} day${rangeDays === 1 ? '' : 's'}. ` +
+                (showSubDistribution
+                  ? `Detailed subflavor tags account for ${focusHours} hrs of that total.`
+                  : 'Every tracked flavor is represented below.')}
+          </p>
+
+          <div className="grid gap-6 lg:grid-cols-[1.6fr,1fr]">
+            <div className="rounded-3xl border border-orange-100 bg-white p-6 shadow-sm">
+              {chartData.data.length === 0 ? (
+                <div className="flex h-72 items-center justify-center text-sm text-gray-500">
+                  Tag your time blocks with flavors to see time distribution.
+                </div>
+              ) : (
+                <ResponsiveContainer width="100%" height={320}>
+                  <PieChart>
+                    <Pie
+                      data={chartData.data}
+                      innerRadius={80}
+                      outerRadius={120}
+                      paddingAngle={2}
+                      dataKey="value"
+                      onMouseEnter={(_: unknown, index: number) =>
+                        setActiveSlice(chartData.data[index]?.id ?? null)
+                      }
+                      onMouseLeave={() => setActiveSlice(null)}
+                    >
+                      {chartData.data.map((entry) => (
+                        <Cell key={entry.id} fill={entry.color || '#f97316'} />
+                      ))}
+                    </Pie>
+                    <RechartsTooltip content={<TrackingTooltip />} />
+                  </PieChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+            <div className="rounded-3xl border border-orange-100 bg-white p-6 shadow-sm">
+              <h3 className="mb-4 text-lg font-semibold text-gray-900">
+                {showSubDistribution ? 'Subflavor insights' : 'Flavor insights'}
+              </h3>
+              <div className="space-y-3">
+                {chartData.data.length === 0 ? (
+                  <p className="text-sm text-gray-500">
+                    Once you start logging activities, this panel will highlight where your time is going.
+                  </p>
+                ) : (
+                  chartData.data.map((item) => {
+                    const isActive = activeDetails?.id === item.id;
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onMouseEnter={() => setActiveSlice(item.id)}
+                        onFocus={() => setActiveSlice(item.id)}
+                        className={`w-full rounded-xl border px-4 py-3 text-left transition ${
+                          isActive
+                            ? 'border-orange-300 bg-orange-50 shadow-sm'
+                            : 'border-transparent hover:border-orange-200 hover:bg-orange-50'
+                        }`}
+                      >
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <div className="text-sm font-semibold text-gray-900">{item.label}</div>
+                            {showSubDistribution && item.helper && (
+                              <div className="text-xs text-gray-500">
+                                Within {dataset.flavors.find((f) => f.id === item.helper)?.name}
+                              </div>
+                            )}
+                          </div>
+                          <div className="text-right text-sm font-medium text-gray-700">
+                            <div>{formatHours(item.value)} hrs</div>
+                            <div className="text-xs text-gray-500">{item.percent.toFixed(2)}%</div>
+                          </div>
+                        </div>
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/drizzle/0035_create_progress_snapshots.sql
+++ b/drizzle/0035_create_progress_snapshots.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS progress_snapshots (
+  id serial PRIMARY KEY,
+  user_id integer REFERENCES users(id) NOT NULL,
+  snapshot_date date NOT NULL,
+  data jsonb NOT NULL,
+  created_at timestamp DEFAULT now(),
+  CONSTRAINT progress_snapshots_user_date_unique UNIQUE(user_id, snapshot_date)
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1756284819564,
       "tag": "0034_add_coach_tone_custom",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1756284819565,
+      "tag": "0035_create_progress_snapshots",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -296,6 +296,25 @@ export const profileSnapshots = pgTable(
   }),
 );
 
+export const progressSnapshots = pgTable(
+  'progress_snapshots',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    snapshotDate: date('snapshot_date').notNull(),
+    data: jsonb('data').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserDate: uniqueIndex('progress_snapshots_user_date_unique').on(
+      table.userId,
+      table.snapshotDate,
+    ),
+  }),
+);
+
 export const dailyReports = pgTable(
   'daily_reports',
   {

--- a/lib/flavors-store.ts
+++ b/lib/flavors-store.ts
@@ -91,11 +91,24 @@ async function canView(
   }
 }
 
-export async function listFlavors(userId: string): Promise<Flavor[]> {
+export async function listFlavors(
+  userId: string,
+  viewerId?: number | null,
+): Promise<Flavor[]> {
   const id = Number(userId);
   if (Number.isNaN(id)) return [];
   const rows = await db.select().from(flavors).where(eq(flavors.userId, id));
-  return sortFlavors(rows.map(toFlavor));
+  if (viewerId === undefined) {
+    return sortFlavors(rows.map(toFlavor));
+  }
+  const visible: Flavor[] = [];
+  for (const row of rows) {
+    const vis = (row.visibility as Visibility) ?? 'public';
+    if (await canView(viewerId, row.userId ?? 0, vis)) {
+      visible.push(toFlavor(row));
+    }
+  }
+  return sortFlavors(visible);
 }
 
 export async function getFlavor(

--- a/lib/progress-snapshots.ts
+++ b/lib/progress-snapshots.ts
@@ -1,0 +1,112 @@
+import { db } from './db';
+import { plans, planBlocks, progressSnapshots } from './db/schema';
+import { eq, and } from 'drizzle-orm';
+import { startOfDay, addDays, toYMD } from './clock';
+import { listFlavors } from './flavors-store';
+import { listAllSubflavors } from './subflavors-store';
+
+function minutesBetween(start: Date, end: Date) {
+  const delta = end.getTime() - start.getTime();
+  return delta > 0 ? delta / 60000 : 0;
+}
+
+export async function createProgressSnapshot(
+  userId: number,
+  snapshotDate: string,
+) {
+  const [flavors, subflavors] = await Promise.all([
+    listFlavors(String(userId)),
+    listAllSubflavors(String(userId)),
+  ]);
+  const allowedFlavors = new Set(flavors.map((f) => f.id));
+  const allowedSubflavors = new Set(subflavors.map((s) => s.id));
+  const subById = new Map(subflavors.map((s) => [s.id, s]));
+  const rows = await db
+    .select({
+      start: planBlocks.start,
+      end: planBlocks.end,
+      flavorIds: planBlocks.flavorIds,
+      subflavorIds: planBlocks.subflavorIds,
+    })
+    .from(planBlocks)
+    .innerJoin(plans, eq(planBlocks.planId, plans.id))
+    .where(and(eq(plans.userId, userId), eq(plans.date, snapshotDate)));
+  const flavorMinutes: Record<string, number> = {};
+  const subflavorMinutes: Record<string, number> = {};
+  const doneFlavors = new Set<string>();
+  const doneSubflavors = new Set<string>();
+  let totalMinutes = 0;
+  for (const row of rows) {
+    const start = new Date(row.start);
+    const end = new Date(row.end);
+    const duration = minutesBetween(start, end);
+    if (duration <= 0) continue;
+    const directFlavors = Array.isArray(row.flavorIds)
+      ? row.flavorIds.filter((id): id is string =>
+          typeof id === 'string' && allowedFlavors.has(id),
+        )
+      : [];
+    const directSubs = Array.isArray(row.subflavorIds)
+      ? row.subflavorIds.filter((id): id is string =>
+          typeof id === 'string' && allowedSubflavors.has(id),
+        )
+      : [];
+    const parentsFromSub = directSubs
+      .map((sid) => subById.get(sid)?.flavorId)
+      .filter((fid): fid is string => !!fid && allowedFlavors.has(fid));
+    const flavorSet = new Set<string>([...directFlavors, ...parentsFromSub]);
+    if (flavorSet.size === 0 && directSubs.length === 0) continue;
+    totalMinutes += duration;
+    for (const fid of flavorSet) doneFlavors.add(fid);
+    for (const sid of directSubs) doneSubflavors.add(sid);
+    if (flavorSet.size > 0) {
+      const share = duration / flavorSet.size;
+      for (const fid of flavorSet) {
+        flavorMinutes[fid] = (flavorMinutes[fid] ?? 0) + share;
+      }
+    }
+    if (directSubs.length > 0) {
+      const share = duration / directSubs.length;
+      for (const sid of directSubs) {
+        subflavorMinutes[sid] = (subflavorMinutes[sid] ?? 0) + share;
+      }
+    }
+  }
+  await db
+    .insert(progressSnapshots)
+    .values({
+      userId,
+      snapshotDate,
+      data: {
+        totalMinutes,
+        flavorMinutes,
+        subflavorMinutes,
+        doneFlavorIds: Array.from(doneFlavors),
+        doneSubflavorIds: Array.from(doneSubflavors),
+      },
+    })
+    .onConflictDoNothing();
+}
+
+export async function ensureDailyProgressSnapshot(userId: number, tz: string) {
+  const today = startOfDay(new Date(), tz);
+  const yesterday = addDays(today, -1, tz);
+  const yIso = toYMD(yesterday, tz);
+  const existing = await db
+    .select({ id: progressSnapshots.id })
+    .from(progressSnapshots)
+    .where(and(eq(progressSnapshots.userId, userId), eq(progressSnapshots.snapshotDate, yIso)))
+    .limit(1);
+  if (existing.length === 0) {
+    await createProgressSnapshot(userId, yIso);
+  }
+}
+
+export async function getProgressSnapshot(userId: number, snapshotDate: string) {
+  const [row] = await db
+    .select()
+    .from(progressSnapshots)
+    .where(and(eq(progressSnapshots.userId, userId), eq(progressSnapshots.snapshotDate, snapshotDate)));
+  if (!row) return null;
+  return { ...(row.data as any), createdAt: row.createdAt };
+}

--- a/lib/progress-tracking.ts
+++ b/lib/progress-tracking.ts
@@ -1,0 +1,181 @@
+import { db } from './db';
+import { plans, planBlocks } from './db/schema';
+import { eq, and, gte, lte } from 'drizzle-orm';
+import { listFlavors } from './flavors-store';
+import { listAllSubflavors } from './subflavors-store';
+import { addDays, getNow, startOfDay, toYMD } from './clock';
+import type { TrackingDataset, TrackingDailyRecord } from '@/types/tracking';
+
+type BuildOptions = {
+  ownerId: number;
+  viewerId?: number | null;
+  tz: string;
+  maxDays?: number;
+};
+
+function minutesBetween(start: Date, end: Date) {
+  const delta = end.getTime() - start.getTime();
+  return delta > 0 ? delta / 60000 : 0;
+}
+
+function toDateString(value: unknown): string {
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  return String(value).slice(0, 10);
+}
+
+function addUnique(list: string[], id: string) {
+  if (!list.includes(id)) list.push(id);
+}
+
+export async function buildTrackingDataset({
+  ownerId,
+  viewerId,
+  tz,
+  maxDays = 370,
+}: BuildOptions): Promise<TrackingDataset> {
+  const { now } = getNow(tz);
+  const today = startOfDay(now, tz);
+  const todayStr = toYMD(today, tz);
+  const start = addDays(today, -(maxDays - 1), tz);
+  const startStr = toYMD(start, tz);
+  const flavorPromise =
+    viewerId === undefined
+      ? listFlavors(String(ownerId))
+      : listFlavors(String(ownerId), viewerId);
+  const subflavorPromise =
+    viewerId === undefined
+      ? listAllSubflavors(String(ownerId))
+      : listAllSubflavors(String(ownerId), viewerId);
+  const [flavors, subflavors, rows] = await Promise.all([
+    flavorPromise,
+    subflavorPromise,
+    db
+      .select({
+        date: plans.date,
+        start: planBlocks.start,
+        end: planBlocks.end,
+        flavorIds: planBlocks.flavorIds,
+        subflavorIds: planBlocks.subflavorIds,
+      })
+      .from(planBlocks)
+      .innerJoin(plans, eq(planBlocks.planId, plans.id))
+      .where(
+        and(
+          eq(plans.userId, ownerId),
+          gte(plans.date, startStr),
+          lte(plans.date, todayStr),
+        ),
+      ),
+  ]);
+  const allowedFlavors = new Set(flavors.map((f) => f.id));
+  const visibleSubflavors = subflavors.filter((sf) => allowedFlavors.has(sf.flavorId));
+  const allowedSubflavors = new Set(visibleSubflavors.map((s) => s.id));
+  const subById = new Map(visibleSubflavors.map((s) => [s.id, s]));
+  const records: TrackingDailyRecord[] = [];
+  const recordMap = new Map<string, TrackingDailyRecord>();
+  for (let i = 0; i < maxDays; i++) {
+    const current = addDays(start, i, tz);
+    if (current.getTime() > today.getTime()) break;
+    const date = toYMD(current, tz);
+    const record: TrackingDailyRecord = {
+      date,
+      totalMinutes: 0,
+      flavorMinutes: {},
+      subflavorMinutes: {},
+      doneFlavors: [],
+      plannedFlavors: [],
+      doneSubflavors: [],
+      plannedSubflavors: [],
+    };
+    records.push(record);
+    recordMap.set(date, record);
+  }
+  const nowMs = now.getTime();
+  for (const row of rows) {
+    const dateStr = toDateString(row.date);
+    const record = recordMap.get(dateStr);
+    if (!record) continue;
+    const startAt = new Date(row.start);
+    const endAt = new Date(row.end);
+    const duration = minutesBetween(startAt, endAt);
+    if (duration <= 0) continue;
+    const directFlavors = Array.isArray(row.flavorIds)
+      ? row.flavorIds.filter(
+          (fid): fid is string => typeof fid === 'string' && allowedFlavors.has(fid),
+        )
+      : [];
+    const directSubflavors = Array.isArray(row.subflavorIds)
+      ? row.subflavorIds.filter(
+          (sid): sid is string => typeof sid === 'string' && allowedSubflavors.has(sid),
+        )
+      : [];
+    const parentsFromSub = directSubflavors
+      .map((sid) => subById.get(sid)?.flavorId)
+      .filter((fid): fid is string => !!fid && allowedFlavors.has(fid));
+    const flavorSet = new Set<string>([...directFlavors, ...parentsFromSub]);
+    if (flavorSet.size === 0 && directSubflavors.length === 0) continue;
+    record.totalMinutes += duration;
+    if (flavorSet.size > 0) {
+      const share = duration / flavorSet.size;
+      for (const fid of flavorSet) {
+        record.flavorMinutes[fid] = (record.flavorMinutes[fid] ?? 0) + share;
+      }
+    }
+    if (directSubflavors.length > 0) {
+      const share = duration / directSubflavors.length;
+      for (const sid of directSubflavors) {
+        record.subflavorMinutes[sid] = (record.subflavorMinutes[sid] ?? 0) + share;
+      }
+    }
+    if (dateStr < todayStr) {
+      for (const fid of flavorSet) addUnique(record.doneFlavors, fid);
+      for (const sid of directSubflavors) addUnique(record.doneSubflavors, sid);
+    } else if (dateStr === todayStr) {
+      if (startAt.getTime() <= nowMs) {
+        for (const fid of flavorSet) addUnique(record.doneFlavors, fid);
+        for (const sid of directSubflavors) addUnique(record.doneSubflavors, sid);
+      } else {
+        for (const fid of flavorSet) addUnique(record.plannedFlavors, fid);
+        for (const sid of directSubflavors) addUnique(record.plannedSubflavors, sid);
+      }
+    }
+  }
+  for (const record of records) {
+    if (record.plannedFlavors.length) {
+      record.plannedFlavors = record.plannedFlavors.filter(
+        (id) => !record.doneFlavors.includes(id),
+      );
+    }
+    if (record.plannedSubflavors.length) {
+      record.plannedSubflavors = record.plannedSubflavors.filter(
+        (id) => !record.doneSubflavors.includes(id),
+      );
+    }
+  }
+  return {
+    timezone: tz,
+    today: todayStr,
+    now: now.toISOString(),
+    maxDays: records.length,
+    flavors: flavors.map((f) => ({
+      id: f.id,
+      name: f.name,
+      icon: f.icon,
+      color: f.color,
+      createdAt: f.createdAt,
+      orderIndex: f.orderIndex,
+    })),
+    subflavors: visibleSubflavors.map((sf) => ({
+      id: sf.id,
+      flavorId: sf.flavorId,
+      name: sf.name,
+      icon: sf.icon,
+      color: sf.color,
+      createdAt: sf.createdAt,
+      orderIndex: sf.orderIndex,
+    })),
+    records,
+  };
+}

--- a/lib/subflavors-store.ts
+++ b/lib/subflavors-store.ts
@@ -67,6 +67,7 @@ async function canView(viewerId: number | null, ownerId: number, vis: Visibility
 export async function listSubflavors(
   userId: string,
   flavorId: string,
+  viewerId?: number | null,
 ): Promise<Subflavor[]> {
   const id = Number(userId);
   if (Number.isNaN(id)) return [];
@@ -74,14 +75,37 @@ export async function listSubflavors(
     .select()
     .from(subflavors)
     .where(and(eq(subflavors.userId, id), eq(subflavors.flavorId, flavorId)));
-  return sortSubflavors(rows.map(toSubflavor));
+  if (viewerId === undefined) {
+    return sortSubflavors(rows.map(toSubflavor));
+  }
+  const list: Subflavor[] = [];
+  for (const row of rows) {
+    const vis = (row.visibility as Visibility) ?? 'private';
+    if (await canView(viewerId, row.userId ?? 0, vis)) {
+      list.push(toSubflavor(row));
+    }
+  }
+  return sortSubflavors(list);
 }
 
-export async function listAllSubflavors(userId: string): Promise<Subflavor[]> {
+export async function listAllSubflavors(
+  userId: string,
+  viewerId?: number | null,
+): Promise<Subflavor[]> {
   const id = Number(userId);
   if (Number.isNaN(id)) return [];
   const rows = await db.select().from(subflavors).where(eq(subflavors.userId, id));
-  return sortSubflavors(rows.map(toSubflavor));
+  if (viewerId === undefined) {
+    return sortSubflavors(rows.map(toSubflavor));
+  }
+  const list: Subflavor[] = [];
+  for (const row of rows) {
+    const vis = (row.visibility as Visibility) ?? 'private';
+    if (await canView(viewerId, row.userId ?? 0, vis)) {
+      list.push(toSubflavor(row));
+    }
+  }
+  return sortSubflavors(list);
 }
 
 export async function getSubflavor(

--- a/types/tracking.ts
+++ b/types/tracking.ts
@@ -1,0 +1,39 @@
+export interface TrackingFlavorSummary {
+  id: string;
+  name: string;
+  icon: string;
+  color: string;
+  createdAt: string;
+  orderIndex: number;
+}
+
+export interface TrackingSubflavorSummary {
+  id: string;
+  flavorId: string;
+  name: string;
+  icon: string;
+  color: string;
+  createdAt: string;
+  orderIndex: number;
+}
+
+export interface TrackingDailyRecord {
+  date: string;
+  totalMinutes: number;
+  flavorMinutes: Record<string, number>;
+  subflavorMinutes: Record<string, number>;
+  doneFlavors: string[];
+  plannedFlavors: string[];
+  doneSubflavors: string[];
+  plannedSubflavors: string[];
+}
+
+export interface TrackingDataset {
+  timezone: string;
+  today: string;
+  now: string;
+  maxDays: number;
+  flavors: TrackingFlavorSummary[];
+  subflavors: TrackingSubflavorSummary[];
+  records: TrackingDailyRecord[];
+}


### PR DESCRIPTION
## Summary
- add a progress tracking route with streak visualisation, flavour filters, and viewer support
- add a time-spent pie chart view powered by a new tracking client component
- record daily progress snapshots and update flavour visibility helpers for viewer mode

## Testing
- pnpm tsc
- pnpm lint
- pnpm test *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1674b0c98832aa3a8d223feb857f5