### PR TITLE
Add manual streak overrides and ingredient visibility toggle

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -304,3 +304,5 @@
 - 2025-10-30: Added activity block presets with category tagging, save-from-metadata controls, and a custom timeslot library picker in the planner toolbar.
 - 2025-10-30: Launched a progress tracking dashboard with streak visualizations, time-spent charts, flavor visibility controls, and daily progress snapshots for owner and viewer access.
 - 2025-10-30: Extended progress tracking with ingredient streak tables and a focused subflavor time diagram with dedicated view toggles.
+
+- 2025-10-30: Added manual streak overrides with persistent toggles and an ingredient visibility switch on the progress tracking dashboard.

--- a/app/api/progress/tracking/override/route.ts
+++ b/app/api/progress/tracking/override/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidatePath } from 'next/cache';
+import { auth } from '@/lib/auth';
+import { ensureUser } from '@/lib/users';
+import { saveTrackingOverride } from '@/lib/tracking-overrides-store';
+import type {
+  TrackingOverrideState,
+  TrackingOverrideTarget,
+} from '@/types/tracking';
+
+const TARGET_TYPES: TrackingOverrideTarget[] = [
+  'flavor',
+  'subflavor',
+  'ingredient',
+];
+
+const STATES: TrackingOverrideState[] = ['done', 'missed'];
+
+function isValidDate(date: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(date);
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const user = await ensureUser(session);
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const { date, targetType, targetId, state } = payload as Record<string, unknown>;
+
+  if (typeof date !== 'string' || !isValidDate(date)) {
+    return NextResponse.json({ error: 'Invalid date' }, { status: 400 });
+  }
+
+  if (!TARGET_TYPES.includes(targetType as TrackingOverrideTarget)) {
+    return NextResponse.json({ error: 'Invalid target type' }, { status: 400 });
+  }
+
+  if (typeof targetId !== 'string' || !targetId.trim()) {
+    return NextResponse.json({ error: 'Invalid target id' }, { status: 400 });
+  }
+
+  if (!STATES.includes(state as TrackingOverrideState)) {
+    return NextResponse.json({ error: 'Invalid state' }, { status: 400 });
+  }
+
+  try {
+    const override = await saveTrackingOverride({
+      userId: user.id,
+      date,
+      targetType: targetType as TrackingOverrideTarget,
+      targetId: targetId.trim(),
+      state: state as TrackingOverrideState,
+    });
+
+    revalidatePath('/progress/tracking');
+    revalidatePath('/view/[viewId]/progress/tracking');
+
+    return NextResponse.json({ override });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to save override';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/components/progress/tracking-client.tsx
+++ b/components/progress/tracking-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, useEffect, Fragment } from 'react';
+import { useMemo, useState, useEffect, Fragment, useCallback } from 'react';
 import BackButton from '@/components/back-button';
 import { useViewContext } from '@/lib/view-context';
 import { hrefFor } from '@/lib/navigation';
@@ -8,6 +8,9 @@ import type {
   TrackingDataset,
   TrackingDailyRecord,
   TrackingFlavorSummary,
+  TrackingOverride,
+  TrackingOverrideState,
+  TrackingOverrideTarget,
   TrackingSubflavorSummary,
 } from '@/types/tracking';
 import {
@@ -38,6 +41,27 @@ type ChartDatum = {
   percent: number;
   helper?: string;
 };
+
+type OverrideKey = string;
+
+function makeOverrideKey(
+  date: string,
+  type: TrackingOverrideTarget,
+  id: string,
+): OverrideKey {
+  return `${date}|${type}:${id}`;
+}
+
+function buildOverrideMap(overrides: TrackingOverride[]) {
+  const map = new Map<OverrideKey, TrackingOverrideState>();
+  for (const override of overrides) {
+    map.set(
+      makeOverrideKey(override.date, override.targetType, override.targetId),
+      override.state,
+    );
+  }
+  return map;
+}
 
 function parseYmd(ymd: string): number {
   const [y, m, d] = ymd.split('-').map(Number);
@@ -76,52 +100,57 @@ function formatHours(minutes: number) {
 function StatusIndicator({
   state,
   label,
+  manual = false,
+  className = '',
+  ariaHidden = false,
+  showTitle = true,
 }: {
   state: DayState;
   label: string;
+  manual?: boolean;
+  className?: string;
+  ariaHidden?: boolean;
+  showTitle?: boolean;
 }) {
+  let symbol = '|||';
+  let stateClass = 'text-gray-400 text-base';
+  let announce = `${label}: tracking not started`;
   switch (state) {
     case 'done':
-      return (
-        <span
-          className="flex h-7 w-7 items-center justify-center text-lg font-semibold text-green-500"
-          title={`${label}: completed`}
-          aria-label={`${label}: completed`}
-        >
-          ●
-        </span>
-      );
+      symbol = '●';
+      stateClass = 'text-green-500 text-lg';
+      announce = `${label}: completed`;
+      break;
     case 'missed':
-      return (
-        <span
-          className="flex h-7 w-7 items-center justify-center text-lg font-semibold text-red-500"
-          title={`${label}: not completed`}
-          aria-label={`${label}: not completed`}
-        >
-          ×
-        </span>
-      );
+      symbol = '×';
+      stateClass = 'text-red-500 text-lg';
+      announce = `${label}: not completed`;
+      break;
     case 'planned':
-      return (
-        <span
-          className="flex h-7 w-7 items-center justify-center text-base font-semibold text-orange-500"
-          title={`${label}: planned for today`}
-          aria-label={`${label}: planned for today`}
-        >
-          ■
-        </span>
-      );
+      symbol = '■';
+      stateClass = 'text-orange-500 text-base';
+      announce = `${label}: planned for today`;
+      break;
     default:
-      return (
-        <span
-          className="flex h-7 w-7 items-center justify-center text-base font-semibold text-gray-400"
-          title={`${label}: tracking not started`}
-          aria-label={`${label}: tracking not started`}
-        >
-          |||
-        </span>
-      );
+      symbol = '|||';
+      stateClass = 'text-gray-400 text-base';
+      announce = `${label}: tracking not started`;
+      break;
   }
+  const manualClass = manual
+    ? 'ring-2 ring-orange-400 ring-offset-2 ring-offset-white shadow-sm'
+    : '';
+  const tooltip = showTitle ? announce : undefined;
+  return (
+    <span
+      className={`pointer-events-none flex h-7 w-7 items-center justify-center rounded-full font-semibold transition ${stateClass} ${manualClass} ${className}`.trim()}
+      title={tooltip}
+      aria-label={ariaHidden ? undefined : announce}
+      aria-hidden={ariaHidden || undefined}
+    >
+      {symbol}
+    </span>
+  );
 }
 
 function Legend() {
@@ -142,6 +171,10 @@ function Legend() {
       <div className="flex items-center gap-2">
         <StatusIndicator state="not-started" label="Not started" />
         <span>Tracking not started</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <StatusIndicator state="done" label="Manual override" manual />
+        <span>Manual override saved</span>
       </div>
     </div>
   );
@@ -172,7 +205,11 @@ function computeStatus(
   createdAt: string,
   id: string,
   type: 'flavor' | 'subflavor' | 'ingredient',
+  override?: TrackingOverrideState | null,
 ): DayState {
+  if (override) {
+    return override === 'done' ? 'done' : 'missed';
+  }
   const createdYmd = createdAt.slice(0, 10);
   if (record.date < createdYmd) return 'not-started';
   if (type === 'flavor') {
@@ -283,6 +320,167 @@ export default function TrackingClient({ dataset }: { dataset: TrackingDataset }
   const [chartMode, setChartMode] = useState<'flavor' | 'subflavor'>('flavor');
   const [focusedFlavor, setFocusedFlavor] = useState<string | null>(null);
   const [activeSlice, setActiveSlice] = useState<string | null>(null);
+  const [showIngredients, setShowIngredients] = useState(true);
+  const [overrideMap, setOverrideMap] = useState(() =>
+    buildOverrideMap(dataset.overrides),
+  );
+  const [pendingOverrides, setPendingOverrides] = useState<Set<OverrideKey>>(
+    () => new Set(),
+  );
+  const [overrideError, setOverrideError] = useState<string | null>(null);
+  const [overrideStatus, setOverrideStatus] = useState<string | null>(null);
+
+  useEffect(() => {
+    setOverrideMap(buildOverrideMap(dataset.overrides));
+  }, [dataset.overrides]);
+
+  useEffect(() => {
+    if (!overrideStatus) return;
+    const timeout = window.setTimeout(() => setOverrideStatus(null), 4000);
+    return () => window.clearTimeout(timeout);
+  }, [overrideStatus]);
+
+  const handleToggleStatus = useCallback(
+    async ({
+      date,
+      targetType,
+      targetId,
+      currentState,
+    }: {
+      date: string;
+      targetType: TrackingOverrideTarget;
+      targetId: string;
+      currentState: DayState;
+    }) => {
+      if (!ctx.editable) return;
+      if (currentState !== 'done' && currentState !== 'missed') return;
+      const key = makeOverrideKey(date, targetType, targetId);
+      if (pendingOverrides.has(key)) return;
+      const previous = overrideMap.get(key);
+      const nextState: TrackingOverrideState =
+        currentState === 'done' ? 'missed' : 'done';
+
+      setOverrideError(null);
+      setOverrideStatus(null);
+      setOverrideMap((prev) => {
+        const next = new Map(prev);
+        next.set(key, nextState);
+        return next;
+      });
+      setPendingOverrides((prev) => {
+        const next = new Set(prev);
+        next.add(key);
+        return next;
+      });
+
+      try {
+        const res = await fetch('/api/progress/tracking/override', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            date,
+            targetType,
+            targetId,
+            state: nextState,
+          }),
+        });
+        if (!res.ok) {
+          const data = await res.json().catch(() => null);
+          const message =
+            data && typeof data.error === 'string'
+              ? data.error
+              : 'Failed to save override';
+          throw new Error(message);
+        }
+        setOverrideStatus(
+          `Marked as ${
+            nextState === 'done' ? 'done' : 'missed'
+          }. We'll remember this override.`,
+        );
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Failed to save override';
+        setOverrideError(message);
+        setOverrideMap((prev) => {
+          const next = new Map(prev);
+          if (previous) {
+            next.set(key, previous);
+          } else {
+            next.delete(key);
+          }
+          return next;
+        });
+      } finally {
+        setPendingOverrides((prev) => {
+          const next = new Set(prev);
+          next.delete(key);
+          return next;
+        });
+      }
+    },
+    [ctx.editable, overrideMap, pendingOverrides],
+  );
+
+  const renderStatusButton = (
+    record: TrackingDailyRecord,
+    targetType: TrackingOverrideTarget,
+    targetId: string,
+    createdAt: string,
+    label: string,
+  ) => {
+    const key = makeOverrideKey(record.date, targetType, targetId);
+    const overrideState = overrideMap.get(key) ?? null;
+    const status = computeStatus(
+      record,
+      dataset,
+      createdAt,
+      targetId,
+      targetType,
+      overrideState,
+    );
+    const manual = overrideMap.has(key);
+    const pending = pendingOverrides.has(key);
+    const toggleable = ctx.editable && (status === 'done' || status === 'missed');
+    const disabled = !toggleable || pending;
+    const baseLabel = manual ? `${label} — manual override saved.` : label;
+    const nextWord = status === 'done' ? 'missed' : 'done';
+    const title = disabled
+      ? baseLabel
+      : `${baseLabel} Click to mark as ${nextWord}.`;
+    const ariaLabel = disabled
+      ? baseLabel
+      : `${baseLabel} Activate to mark as ${nextWord}.`;
+    return (
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() =>
+          handleToggleStatus({
+            date: record.date,
+            targetType,
+            targetId,
+            currentState: status,
+          })
+        }
+        className={`mx-auto flex h-10 w-10 items-center justify-center rounded-full transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-500 disabled:cursor-not-allowed disabled:opacity-60 ${
+          !disabled ? 'hover:bg-orange-50' : ''
+        } ${manual ? 'bg-orange-50/40' : ''}`}
+        title={title}
+        aria-label={ariaLabel}
+      >
+        <StatusIndicator
+          state={status}
+          label={label}
+          manual={manual}
+          ariaHidden
+          showTitle={false}
+          className={pending ? 'animate-pulse opacity-70' : ''}
+        />
+      </button>
+    );
+  };
 
   useEffect(() => {
     if (!autoExtend) {
@@ -540,6 +738,14 @@ export default function TrackingClient({ dataset }: { dataset: TrackingDataset }
               />
               <span>Activate +1 day automatically</span>
             </label>
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={showIngredients}
+                onChange={(event) => setShowIngredients(event.target.checked)}
+              />
+              <span>Show ingredient streaks</span>
+            </label>
             <div className="relative">
               <button
                 type="button"
@@ -605,6 +811,29 @@ export default function TrackingClient({ dataset }: { dataset: TrackingDataset }
 
           <Legend />
 
+          {ctx.editable && (
+            <p className="text-xs text-gray-500">
+              Click a done or missed day to flip it. Manual overrides glow so you
+              always know what&apos;s locked in.
+            </p>
+          )}
+          {overrideStatus && (
+            <div
+              role="status"
+              className="rounded-xl border border-emerald-100 bg-emerald-50 px-4 py-2 text-xs text-emerald-700"
+            >
+              {overrideStatus}
+            </div>
+          )}
+          {overrideError && (
+            <div
+              role="alert"
+              className="rounded-xl border border-red-100 bg-red-50 px-4 py-2 text-xs text-red-600"
+            >
+              {overrideError}
+            </div>
+          )}
+
           <div className="overflow-x-auto rounded-3xl border border-orange-100 bg-white shadow-sm">
             <table className="min-w-full border-separate border-spacing-y-2">
               <thead>
@@ -645,10 +874,13 @@ export default function TrackingClient({ dataset }: { dataset: TrackingDataset }
                         </td>
                         {visibleRecords.map((record) => (
                           <td key={`${flavor.id}-${record.date}`} className="px-3 py-2 text-center">
-                            <StatusIndicator
-                              state={computeStatus(record, dataset, flavor.createdAt, flavor.id, 'flavor')}
-                              label={`${flavor.name} on ${record.date}`}
-                            />
+                            {renderStatusButton(
+                              record,
+                              'flavor',
+                              flavor.id,
+                              flavor.createdAt,
+                              `${flavor.name} on ${record.date}`,
+                            )}
                           </td>
                         ))}
                       </tr>
@@ -669,10 +901,13 @@ export default function TrackingClient({ dataset }: { dataset: TrackingDataset }
                             </td>
                             {visibleRecords.map((record) => (
                               <td key={`${sf.id}-${record.date}`} className="px-3 py-2 text-center">
-                                <StatusIndicator
-                                  state={computeStatus(record, dataset, sf.createdAt, sf.id, 'subflavor')}
-                                  label={`${sf.name} on ${record.date}`}
-                                />
+                                {renderStatusButton(
+                                  record,
+                                  'subflavor',
+                                  sf.id,
+                                  sf.createdAt,
+                                  `${sf.name} on ${record.date}`,
+                                )}
                               </td>
                             ))}
                             </tr>
@@ -694,71 +929,70 @@ export default function TrackingClient({ dataset }: { dataset: TrackingDataset }
               </tbody>
             </table>
           </div>
-          <div className="space-y-3">
-            <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
-              <h3 className="text-lg font-semibold text-gray-900">Ingredient streaks</h3>
-              <span className="text-xs text-gray-500">
-                Ingredients don&apos;t add to time totals—just streak accountability.
-              </span>
-            </div>
-            <div className="overflow-x-auto rounded-3xl border border-orange-100 bg-white shadow-sm">
-              {dataset.ingredients.length === 0 ? (
-                <div className="px-6 py-8 text-center text-sm text-gray-500">
-                  Add ingredients to track how consistently you bring your habits into play.
-                </div>
-              ) : (
-                <table className="min-w-full border-separate border-spacing-y-2">
-                  <thead>
-                    <tr>
-                      <th className="sticky left-0 z-10 bg-white/95 px-4 py-3 text-left text-sm font-semibold text-gray-600 backdrop-blur">
-                        Ingredient
-                      </th>
-                      {visibleRecords.map((record) => {
-                        const { day, weekday } = formatDay(record.date);
-                        return (
-                          <th
-                            key={`ingredient-head-${record.date}`}
-                            className="px-3 py-2 text-center text-xs font-medium uppercase tracking-wide text-gray-500"
-                          >
-                            <div>{weekday}</div>
-                            <div className="text-gray-700">{day}</div>
-                          </th>
-                        );
-                      })}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {dataset.ingredients.map((ingredient) => (
-                      <tr key={ingredient.id} className="align-middle">
-                        <td className="sticky left-0 z-10 bg-white/95 px-4 py-3 text-sm font-semibold text-gray-800 backdrop-blur">
-                          <div className="flex items-center gap-3">
-                            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-orange-100 text-lg">
-                              {ingredient.icon}
-                            </span>
-                            <span>{ingredient.title}</span>
-                          </div>
-                        </td>
-                        {visibleRecords.map((record) => (
-                          <td key={`${ingredient.id}-${record.date}`} className="px-3 py-2 text-center">
-                            <StatusIndicator
-                              state={computeStatus(
-                                record,
-                                dataset,
-                                ingredient.createdAt,
-                                ingredient.id,
-                                'ingredient',
-                              )}
-                              label={`${ingredient.title} on ${record.date}`}
-                            />
-                          </td>
-                        ))}
+          {showIngredients && (
+            <div className="space-y-3">
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                <h3 className="text-lg font-semibold text-gray-900">Ingredient streaks</h3>
+                <span className="text-xs text-gray-500">
+                  Ingredients don&apos;t add to time totals—just streak accountability.
+                </span>
+              </div>
+              <div className="overflow-x-auto rounded-3xl border border-orange-100 bg-white shadow-sm">
+                {dataset.ingredients.length === 0 ? (
+                  <div className="px-6 py-8 text-center text-sm text-gray-500">
+                    Add ingredients to track how consistently you bring your habits into play.
+                  </div>
+                ) : (
+                  <table className="min-w-full border-separate border-spacing-y-2">
+                    <thead>
+                      <tr>
+                        <th className="sticky left-0 z-10 bg-white/95 px-4 py-3 text-left text-sm font-semibold text-gray-600 backdrop-blur">
+                          Ingredient
+                        </th>
+                        {visibleRecords.map((record) => {
+                          const { day, weekday } = formatDay(record.date);
+                          return (
+                            <th
+                              key={`ingredient-head-${record.date}`}
+                              className="px-3 py-2 text-center text-xs font-medium uppercase tracking-wide text-gray-500"
+                            >
+                              <div>{weekday}</div>
+                              <div className="text-gray-700">{day}</div>
+                            </th>
+                          );
+                        })}
                       </tr>
-                    ))}
-                  </tbody>
-                </table>
-              )}
+                    </thead>
+                    <tbody>
+                      {dataset.ingredients.map((ingredient) => (
+                        <tr key={ingredient.id} className="align-middle">
+                          <td className="sticky left-0 z-10 bg-white/95 px-4 py-3 text-sm font-semibold text-gray-800 backdrop-blur">
+                            <div className="flex items-center gap-3">
+                              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-orange-100 text-lg">
+                                {ingredient.icon}
+                              </span>
+                              <span>{ingredient.title}</span>
+                            </div>
+                          </td>
+                          {visibleRecords.map((record) => (
+                            <td key={`${ingredient.id}-${record.date}`} className="px-3 py-2 text-center">
+                              {renderStatusButton(
+                                record,
+                                'ingredient',
+                                ingredient.id,
+                                ingredient.createdAt,
+                                `${ingredient.title} on ${record.date}`,
+                              )}
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </div>
             </div>
-          </div>
+          )}
         </section>
       ) : (
         <section className="space-y-6">

--- a/drizzle/0036_create_tracking_overrides.sql
+++ b/drizzle/0036_create_tracking_overrides.sql
@@ -1,0 +1,17 @@
+CREATE TYPE tracking_override_target AS ENUM ('flavor', 'subflavor', 'ingredient');
+CREATE TYPE tracking_override_state AS ENUM ('done', 'missed');
+
+CREATE TABLE IF NOT EXISTS tracking_overrides (
+  id serial PRIMARY KEY,
+  user_id integer REFERENCES users(id) NOT NULL,
+  target_type tracking_override_target NOT NULL,
+  target_id text NOT NULL,
+  date date NOT NULL,
+  state tracking_override_state NOT NULL,
+  created_at timestamp DEFAULT now(),
+  updated_at timestamp DEFAULT now(),
+  CONSTRAINT tracking_overrides_user_target_date_unique UNIQUE (user_id, target_type, target_id, date)
+);
+
+CREATE INDEX tracking_overrides_user_date_idx
+  ON tracking_overrides (user_id, date);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1756284819565,
       "tag": "0035_create_progress_snapshots",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1756284819566,
+      "tag": "0036_create_tracking_overrides",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -40,6 +40,16 @@ export const reportHighlightTypeEnum = pgEnum('report_highlight_type', [
   'yearly',
 ]);
 
+export const trackingOverrideTargetEnum = pgEnum(
+  'tracking_override_target',
+  ['flavor', 'subflavor', 'ingredient'],
+);
+
+export const trackingOverrideStateEnum = pgEnum(
+  'tracking_override_state',
+  ['done', 'missed'],
+);
+
 export const users = pgTable('users', {
   id: serial('id').primaryKey(),
   handle: varchar('handle', { length: 50 }).notNull().unique(),
@@ -311,6 +321,31 @@ export const progressSnapshots = pgTable(
     uniqueUserDate: uniqueIndex('progress_snapshots_user_date_unique').on(
       table.userId,
       table.snapshotDate,
+    ),
+  }),
+);
+
+export const trackingOverrides = pgTable(
+  'tracking_overrides',
+  {
+    id: serial('id').primaryKey(),
+    userId: integer('user_id')
+      .references(() => users.id)
+      .notNull(),
+    targetType: trackingOverrideTargetEnum('target_type').notNull(),
+    targetId: text('target_id').notNull(),
+    date: date('date').notNull(),
+    state: trackingOverrideStateEnum('state').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+    updatedAt: timestamp('updated_at').defaultNow(),
+  },
+  (table) => ({
+    uniqueUserTargetDate: uniqueIndex(
+      'tracking_overrides_user_target_date_unique',
+    ).on(table.userId, table.targetType, table.targetId, table.date),
+    userDateIdx: index('tracking_overrides_user_date_idx').on(
+      table.userId,
+      table.date,
     ),
   }),
 );

--- a/lib/progress-tracking.ts
+++ b/lib/progress-tracking.ts
@@ -5,7 +5,12 @@ import { listFlavors } from './flavors-store';
 import { listAllSubflavors } from './subflavors-store';
 import { listIngredients } from './ingredients-store';
 import { addDays, getNow, startOfDay, toYMD } from './clock';
-import type { TrackingDataset, TrackingDailyRecord } from '@/types/tracking';
+import type {
+  TrackingDataset,
+  TrackingDailyRecord,
+  TrackingOverride,
+} from '@/types/tracking';
+import { listTrackingOverrides } from './tracking-overrides-store';
 
 type BuildOptions = {
   ownerId: number;
@@ -57,29 +62,32 @@ export async function buildTrackingDataset({
     viewerId === undefined
       ? listIngredients(String(ownerId), ownerId)
       : listIngredients(String(ownerId), viewerId ?? null);
-  const [flavors, subflavors, ingredients, rows] = await Promise.all([
-    flavorPromise,
-    subflavorPromise,
-    ingredientPromise,
-    db
-      .select({
-        date: plans.date,
-        start: planBlocks.start,
-        end: planBlocks.end,
-        flavorIds: planBlocks.flavorIds,
-        subflavorIds: planBlocks.subflavorIds,
-        ingredientIds: planBlocks.ingredientIds,
-      })
-      .from(planBlocks)
-      .innerJoin(plans, eq(planBlocks.planId, plans.id))
-      .where(
-        and(
-          eq(plans.userId, ownerId),
-          gte(plans.date, startStr),
-          lte(plans.date, todayStr),
+  const overridesPromise = listTrackingOverrides(ownerId, startStr, todayStr);
+  const [flavors, subflavors, ingredients, rows, overrides] =
+    await Promise.all([
+      flavorPromise,
+      subflavorPromise,
+      ingredientPromise,
+      db
+        .select({
+          date: plans.date,
+          start: planBlocks.start,
+          end: planBlocks.end,
+          flavorIds: planBlocks.flavorIds,
+          subflavorIds: planBlocks.subflavorIds,
+          ingredientIds: planBlocks.ingredientIds,
+        })
+        .from(planBlocks)
+        .innerJoin(plans, eq(planBlocks.planId, plans.id))
+        .where(
+          and(
+            eq(plans.userId, ownerId),
+            gte(plans.date, startStr),
+            lte(plans.date, todayStr),
+          ),
         ),
-      ),
-  ]);
+      overridesPromise,
+    ]);
   const allowedFlavors = new Set(flavors.map((f) => f.id));
   const visibleSubflavors = subflavors.filter((sf) => allowedFlavors.has(sf.flavorId));
   const allowedSubflavors = new Set(visibleSubflavors.map((s) => s.id));
@@ -171,6 +179,42 @@ export async function buildTrackingDataset({
       }
     }
   }
+  function applyOverride(record: TrackingDailyRecord, override: TrackingOverride) {
+    let doneList: string[];
+    let plannedList: string[];
+    switch (override.targetType) {
+      case 'flavor':
+        doneList = record.doneFlavors;
+        plannedList = record.plannedFlavors;
+        break;
+      case 'subflavor':
+        doneList = record.doneSubflavors;
+        plannedList = record.plannedSubflavors;
+        break;
+      case 'ingredient':
+      default:
+        doneList = record.doneIngredients;
+        plannedList = record.plannedIngredients;
+        break;
+    }
+    if (override.state === 'done') {
+      addUnique(doneList, override.targetId);
+      const index = plannedList.indexOf(override.targetId);
+      if (index >= 0) plannedList.splice(index, 1);
+    } else {
+      const doneIdx = doneList.indexOf(override.targetId);
+      if (doneIdx >= 0) doneList.splice(doneIdx, 1);
+      const plannedIdx = plannedList.indexOf(override.targetId);
+      if (plannedIdx >= 0) plannedList.splice(plannedIdx, 1);
+    }
+  }
+
+  for (const override of overrides) {
+    const record = recordMap.get(override.date);
+    if (!record) continue;
+    applyOverride(record, override);
+  }
+
   for (const record of records) {
     if (record.plannedFlavors.length) {
       record.plannedFlavors = record.plannedFlavors.filter(
@@ -218,5 +262,6 @@ export async function buildTrackingDataset({
       createdAt: ing.createdAt,
     })),
     records,
+    overrides,
   };
 }

--- a/lib/tracking-overrides-store.ts
+++ b/lib/tracking-overrides-store.ts
@@ -1,0 +1,102 @@
+import { and, eq, gte, lte } from 'drizzle-orm';
+import { db } from './db';
+import { trackingOverrides } from './db/schema';
+import type {
+  TrackingOverride,
+  TrackingOverrideState,
+  TrackingOverrideTarget,
+} from '@/types/tracking';
+
+function normalizeDate(value: string): string {
+  if (typeof value !== 'string') {
+    throw new Error('Invalid date value');
+  }
+  const trimmed = value.trim().slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    throw new Error('Invalid date format');
+  }
+  return trimmed;
+}
+
+function toOverride(
+  row: typeof trackingOverrides.$inferSelect,
+): TrackingOverride {
+  const rawDate = row.date instanceof Date ? row.date : new Date(row.date ?? '');
+  const date = Number.isNaN(rawDate.getTime())
+    ? normalizeDate(String(row.date ?? ''))
+    : rawDate.toISOString().slice(0, 10);
+  return {
+    date,
+    targetType: row.targetType as TrackingOverrideTarget,
+    targetId: row.targetId ?? '',
+    state: row.state as TrackingOverrideState,
+  };
+}
+
+export async function listTrackingOverrides(
+  userId: number,
+  start: string,
+  end: string,
+): Promise<TrackingOverride[]> {
+  const startDate = normalizeDate(start);
+  const endDate = normalizeDate(end);
+  const [from, to] = startDate <= endDate ? [startDate, endDate] : [endDate, startDate];
+  const rows = await db
+    .select()
+    .from(trackingOverrides)
+    .where(
+      and(
+        eq(trackingOverrides.userId, userId),
+        gte(trackingOverrides.date, from),
+        lte(trackingOverrides.date, to),
+      ),
+    );
+  return rows.map(toOverride);
+}
+
+export async function saveTrackingOverride({
+  userId,
+  date,
+  targetType,
+  targetId,
+  state,
+}: {
+  userId: number;
+  date: string;
+  targetType: TrackingOverrideTarget;
+  targetId: string;
+  state: TrackingOverrideState;
+}): Promise<TrackingOverride> {
+  const normalizedDate = normalizeDate(date);
+  const normalizedTarget = targetId.trim();
+  if (!normalizedTarget) {
+    throw new Error('Target id is required');
+  }
+  const now = new Date();
+  const [row] = await db
+    .insert(trackingOverrides)
+    .values({
+      userId,
+      date: normalizedDate,
+      targetType,
+      targetId: normalizedTarget,
+      state,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        trackingOverrides.userId,
+        trackingOverrides.targetType,
+        trackingOverrides.targetId,
+        trackingOverrides.date,
+      ],
+      set: {
+        state,
+        updatedAt: now,
+      },
+    })
+    .returning();
+
+  return toOverride(row);
+}

--- a/types/tracking.ts
+++ b/types/tracking.ts
@@ -25,6 +25,16 @@ export interface TrackingIngredientSummary {
   createdAt: string;
 }
 
+export type TrackingOverrideTarget = 'flavor' | 'subflavor' | 'ingredient';
+export type TrackingOverrideState = 'done' | 'missed';
+
+export interface TrackingOverride {
+  date: string;
+  targetType: TrackingOverrideTarget;
+  targetId: string;
+  state: TrackingOverrideState;
+}
+
 export interface TrackingDailyRecord {
   date: string;
   totalMinutes: number;
@@ -47,4 +57,5 @@ export interface TrackingDataset {
   subflavors: TrackingSubflavorSummary[];
   ingredients: TrackingIngredientSummary[];
   records: TrackingDailyRecord[];
+  overrides: TrackingOverride[];
 }


### PR DESCRIPTION
## Summary
- add a tracking_overrides table and Drizzle store to persist manual streak state
- wire a secured API endpoint plus dataset builder updates so streak tables respect overrides
- update the progress tracking UI with manual toggle buttons, saved status messaging, and an ingredient visibility switch

## Testing
- pnpm lint
- pnpm test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d17cefb7f4832a95a8a3061d19992a