### PR TITLE
fix: rebase imported plans on load

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -308,3 +308,5 @@
 - 2025-10-30: Added ingredient visibility filters to choose which streak rows appear in tracking tables.
 - 2025-10-30: Rendered custom flavor and ingredient icons as images in progress streak filters and tables.
 - 2025-10-30: Hardened AI planning suggestions by enforcing JSON-only responses, normalizing activity times, and giving users feedback when incomplete suggestions are skipped.
+- 2025-10-30: Added "Load planning" workflow to next-day planner with calendar picker, historical snapshot preview, and instant import of past schedules into the current plan.
+- 2025-10-30: Rebases imported next-day plans to the current date so loaded schedules bring along all activity blocks.

--- a/app/(app)/planning/next/actions.ts
+++ b/app/(app)/planning/next/actions.ts
@@ -3,10 +3,19 @@
 import { auth } from '@/lib/auth';
 import { ensureUser } from '@/lib/users';
 import { assertOwner } from '@/lib/profile';
-import { savePlan, getPlanStrict } from '@/lib/plans-store';
-import type { PlanBlockInput } from '@/types/plan';
+import { savePlan, getPlanStrict, getPlanAt } from '@/lib/plans-store';
+import type { Plan, PlanBlockInput } from '@/types/plan';
 import type { ColorPreset } from '@/lib/color-presets';
 import { revalidatePath } from 'next/cache';
+import { getProfileSnapshot } from '@/lib/profile-snapshots';
+import { getUserTimeZone, parseYMD, addDays } from '@/lib/clock';
+
+type LoadPlanResult = {
+  plan: Plan;
+  previewPlan: Plan | null;
+  snapshotCapturedAt: string | null;
+  fromSnapshot: boolean;
+};
 
 export async function savePlanAction(
   date: string,
@@ -75,4 +84,41 @@ export async function addIngredientAction(
   }
   revalidatePath('/planning/next');
   revalidatePath('/planning/live');
+}
+
+export async function loadPlanFromDateAction(date: string): Promise<LoadPlanResult> {
+  const session = await auth();
+  const self = await ensureUser(session);
+  await assertOwner(self.id, self.id);
+
+  const [plan, snapshot] = await Promise.all([
+    getPlanStrict(self.id, date),
+    getProfileSnapshot(self.id, date),
+  ]);
+
+  let previewPlan: Plan | null = null;
+  let fromSnapshot = false;
+  let snapshotCapturedAt: string | null = null;
+
+  if (snapshot) {
+    const tz = getUserTimeZone(self);
+    const day = parseYMD(date, tz);
+    const at = snapshot.createdAt ?? addDays(day, 1, tz);
+    previewPlan = await getPlanAt(self.id, date, at);
+    fromSnapshot = true;
+    snapshotCapturedAt = snapshot.createdAt
+      ? snapshot.createdAt.toISOString()
+      : null;
+  }
+
+  if (!previewPlan) {
+    previewPlan = plan;
+  }
+
+  return {
+    plan,
+    previewPlan,
+    snapshotCapturedAt,
+    fromSnapshot,
+  };
 }

--- a/app/(app)/planning/next/client.tsx
+++ b/app/(app)/planning/next/client.tsx
@@ -11,7 +11,7 @@ import type { Ingredient } from '@/types/ingredient';
 import type { Flavor } from '@/types/flavor';
 import type { Subflavor } from '@/types/subflavor';
 import type { ChatMessage, ChatThread } from '@/types/chat';
-import { savePlanAction } from './actions';
+import { savePlanAction, loadPlanFromDateAction } from './actions';
 import { cn } from '@/lib/utils';
 import ColorPresetPicker from '@/components/color-preset-picker';
 import {
@@ -38,6 +38,7 @@ import type {
 } from '@/types/report';
 import type { Todo } from '@/types/todo';
 import { getCoachTone, getCoachTonePrompt } from '@/lib/ai/coach-tone';
+import LoadPlanningModal from './load-planning-modal';
 
 const COLORS = [
   '#F87171',
@@ -65,6 +66,60 @@ const MAX_MINUTES = 24 * 60; // minutes in a day
 const DEFAULT_START = 5 * 60; // 05:00
 const DEFAULT_END = 22 * 60; // 22:00
 const Z_BASE = 10000;
+
+type LoadPlanSnapshot = {
+  date: string;
+  plan: Plan;
+  previewPlan: Plan | null;
+  fromSnapshot: boolean;
+  snapshotCapturedAt: string | null;
+};
+
+function normalizePlan(plan: Plan): Plan {
+  return {
+    ...plan,
+    blocks: (plan.blocks ?? []).map((b) => ({
+      ...b,
+      ingredientIds: b.ingredientIds ?? [],
+      flavorIds: b.flavorIds ?? [],
+      subflavorIds: b.subflavorIds ?? [],
+      colorPreset: b.colorPreset ?? '',
+    })),
+    dailyAim: plan.dailyAim ?? '',
+    dailyIngredientIds: plan.dailyIngredientIds ?? [],
+    colorPresets: plan.colorPresets ?? [],
+    planningChat: plan.planningChat ?? { chatId: '', messages: [] },
+    liveChat: plan.liveChat ?? { chatId: '', messages: [] },
+  };
+}
+
+function normalizePlanOrNull(plan: Plan | null): Plan | null {
+  if (!plan) return null;
+  return normalizePlan(plan);
+}
+
+function rebasePlanToDate(plan: Plan, sourceDate: string, targetDate: string): Plan {
+  if (sourceDate === targetDate) {
+    return plan;
+  }
+
+  const sourceMidnight = new Date(`${sourceDate}T00:00:00`);
+  const targetMidnight = new Date(`${targetDate}T00:00:00`);
+  const shiftTime = (iso: string) => {
+    const offset = new Date(iso).getTime() - sourceMidnight.getTime();
+    return new Date(targetMidnight.getTime() + offset).toISOString();
+  };
+
+  return {
+    ...plan,
+    date: targetDate,
+    blocks: plan.blocks.map((block) => ({
+      ...block,
+      start: shiftTime(block.start),
+      end: shiftTime(block.end),
+    })),
+  };
+}
 
 function getTextColor(hex: string) {
   if (!hex.startsWith('#') || (hex.length !== 7 && hex.length !== 4)) {
@@ -95,6 +150,7 @@ interface Props {
   live?: boolean;
   review?: boolean;
   initialShowDailyAim?: boolean;
+  snapshotDates?: string[];
   reportContext?: {
     heading: HeadingReport | null;
     daily: Pick<DailyReport, 'date' | 'bad' | 'observations'>[];
@@ -122,6 +178,7 @@ export default function EditorClient({
   live = false,
   review = false,
   initialShowDailyAim = false,
+  snapshotDates: initialSnapshotDates = [],
   reportContext,
 }: Props) {
   const {
@@ -149,14 +206,26 @@ export default function EditorClient({
     if (editable && typeof window !== 'undefined') {
       try {
         const raw = window.localStorage.getItem(storageKey);
-        if (raw)
-          return (JSON.parse(raw) as PlanBlock[]).map((b) => ({
-            ...b,
-            ingredientIds: b.ingredientIds ?? [],
-            flavorIds: b.flavorIds ?? [],
-            subflavorIds: b.subflavorIds ?? [],
-            colorPreset: b.colorPreset ?? '',
-          }));
+        if (raw) {
+          const parsed = JSON.parse(raw) as
+            | PlanBlock[]
+            | {
+                blocks?: PlanBlock[];
+              };
+          const stored = Array.isArray(parsed)
+            ? parsed
+            : Array.isArray(parsed?.blocks)
+              ? parsed.blocks
+              : null;
+          if (stored)
+            return stored.map((b) => ({
+              ...b,
+              ingredientIds: b.ingredientIds ?? [],
+              flavorIds: b.flavorIds ?? [],
+              subflavorIds: b.subflavorIds ?? [],
+              colorPreset: b.colorPreset ?? '',
+            }));
+        }
       } catch {
         // ignore malformed data
       }
@@ -215,6 +284,39 @@ export default function EditorClient({
       day: 'numeric',
     },
   );
+  const ingredientMap = useMemo(() => {
+    const map = new Map<number, Ingredient>();
+    for (const ing of initialIngredients) {
+      map.set(ing.id, ing);
+    }
+    return map;
+  }, [initialIngredients]);
+  const flavorMap = useMemo(() => {
+    const map = new Map<string, Flavor>();
+    for (const fl of initialFlavors) {
+      map.set(fl.id, fl);
+    }
+    return map;
+  }, [initialFlavors]);
+  const subflavorMap = useMemo(() => {
+    const map = new Map<string, Subflavor>();
+    for (const sf of initialSubflavors) {
+      map.set(sf.id, sf);
+    }
+    return map;
+  }, [initialSubflavors]);
+  const [loadModalOpen, setLoadModalOpen] = useState(false);
+  const [loadModalStep, setLoadModalStep] = useState<'calendar' | 'preview'>(
+    'calendar',
+  );
+  const [loadSelectedDate, setLoadSelectedDate] = useState<string | null>(null);
+  const [loadBusyAction, setLoadBusyAction] = useState<
+    'preview' | 'select' | 'add' | null
+  >(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadResult, setLoadResult] = useState<LoadPlanSnapshot | null>(null);
+  const [loadBanner, setLoadBanner] = useState<string | null>(null);
+  const loadBannerTimer = useRef<number | null>(null);
   useEffect(() => {
     if (!initialShowDailyAim) return;
     setShowDailyAim(true);
@@ -233,6 +335,23 @@ export default function EditorClient({
       // ignore
     }
   }, [initialShowDailyAim, storageKey]);
+
+  useEffect(() => {
+    if (!loadModalOpen || typeof document === 'undefined') return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [loadModalOpen]);
+
+  useEffect(() => {
+    return () => {
+      if (loadBannerTimer.current != null) {
+        clearTimeout(loadBannerTimer.current);
+      }
+    };
+  }, []);
 
   const [aiOpen, setAiOpen] = useState(false);
   const welcome: ChatMessage = {
@@ -460,6 +579,194 @@ export default function EditorClient({
       }
     };
   }, [closeMeta]);
+
+  const formatDateLabel = useCallback(
+    (ymd: string) =>
+      new Date(`${ymd}T00:00:00`).toLocaleDateString('en-US', {
+        timeZone: tz,
+        weekday: 'long',
+        month: 'long',
+        day: 'numeric',
+        year: 'numeric',
+      }),
+    [tz],
+  );
+
+  const showLoadBanner = useCallback(
+    (message: string) => {
+      setLoadBanner(message);
+      if (loadBannerTimer.current != null) {
+        clearTimeout(loadBannerTimer.current);
+      }
+      if (typeof window !== 'undefined') {
+        loadBannerTimer.current = window.setTimeout(() => {
+          setLoadBanner(null);
+        }, 4000);
+      }
+    },
+    [],
+  );
+
+  const handleOpenLoadModal = useCallback(() => {
+    const fallback =
+      initialSnapshotDates.find((d) => d < date) ??
+      initialSnapshotDates.find((d) => d !== date) ??
+      initialSnapshotDates[0] ??
+      null;
+    setLoadSelectedDate(fallback);
+    setLoadError(null);
+    setLoadModalStep('calendar');
+    setLoadResult(null);
+    setLoadBusyAction(null);
+    setLoadModalOpen(true);
+  }, [initialSnapshotDates, date]);
+
+  const handleCloseLoadModal = useCallback(() => {
+    setLoadModalOpen(false);
+    setLoadModalStep('calendar');
+    setLoadSelectedDate(null);
+    setLoadBusyAction(null);
+    setLoadError(null);
+    setLoadResult(null);
+  }, []);
+
+  const handlePreviewDate = useCallback(async (targetDate: string) => {
+    if (!targetDate) return;
+    setLoadBusyAction('preview');
+    setLoadError(null);
+    try {
+      const payload = await loadPlanFromDateAction(targetDate);
+      const snapshot: LoadPlanSnapshot = {
+        date: targetDate,
+        plan: normalizePlan(payload.plan),
+        previewPlan: normalizePlanOrNull(payload.previewPlan),
+        fromSnapshot: payload.fromSnapshot,
+        snapshotCapturedAt: payload.snapshotCapturedAt,
+      };
+      setLoadResult(snapshot);
+      setLoadModalStep('preview');
+    } catch (err) {
+      console.error(err);
+      setLoadError('We couldn’t open that planning day. Try another date.');
+    } finally {
+      setLoadBusyAction(null);
+    }
+  }, []);
+
+  const handlePreviewBack = useCallback(() => {
+    setLoadModalStep('calendar');
+    setLoadBusyAction(null);
+    setLoadError(null);
+  }, []);
+
+  const applyPlanFrom = useCallback(
+    (planToApply: Plan, sourceDate: string, meta: {
+      fromSnapshot: boolean;
+      snapshotCapturedAt: string | null;
+    }) => {
+      if (!editable) return;
+      const normalized = normalizePlan(planToApply);
+      const rebased = rebasePlanToDate(normalized, sourceDate, date);
+      setBlocks(rebased.blocks);
+      setDailyAim(rebased.dailyAim);
+      setDailyIngredientIds(rebased.dailyIngredientIds);
+      closeMeta();
+      setShowPresetLibrary(false);
+      setShowBlockPresetMenu(false);
+      setShowPresetPicker(false);
+      setShowSavePresetDialog(false);
+      setSelectIngredient(false);
+      setSelectFlavor(false);
+      setSelectDailyIngredient(false);
+      setLoadModalOpen(false);
+      setLoadModalStep('calendar');
+      setLoadSelectedDate(null);
+      setLoadResult(null);
+      setLoadError(null);
+      const parts = [`Loaded planning from ${formatDateLabel(sourceDate)}`];
+      if (meta.fromSnapshot) {
+        if (meta.snapshotCapturedAt) {
+          const captured = new Date(meta.snapshotCapturedAt).toLocaleString(
+            'en-US',
+            {
+              timeZone: tz,
+              month: 'short',
+              day: 'numeric',
+              hour: 'numeric',
+              minute: '2-digit',
+            },
+          );
+          parts.push(`(snapshot captured ${captured})`);
+        } else {
+          parts.push('(snapshot)');
+        }
+      }
+      showLoadBanner(parts.join(' '));
+      if (typeof window !== 'undefined') {
+        try {
+          window.localStorage.setItem(
+            storageKey,
+            JSON.stringify({
+              blocks: rebased.blocks,
+              dailyAim: rebased.dailyAim,
+              dailyIngredientIds: rebased.dailyIngredientIds,
+            }),
+          );
+        } catch {
+          // ignore local storage errors
+        }
+      }
+    },
+    [
+      editable,
+      closeMeta,
+      formatDateLabel,
+      showLoadBanner,
+      tz,
+      storageKey,
+      date,
+    ],
+  );
+
+  const copyPlanFromDate = useCallback(
+    async (targetDate: string, reason: 'select' | 'add') => {
+      if (!editable || !targetDate) return;
+      setLoadBusyAction(reason);
+      setLoadError(null);
+      try {
+        let snapshot =
+          loadResult && loadResult.date === targetDate ? loadResult : null;
+        if (!snapshot) {
+          const payload = await loadPlanFromDateAction(targetDate);
+          snapshot = {
+            date: targetDate,
+            plan: normalizePlan(payload.plan),
+            previewPlan: normalizePlanOrNull(payload.previewPlan),
+            fromSnapshot: payload.fromSnapshot,
+            snapshotCapturedAt: payload.snapshotCapturedAt,
+          };
+        }
+        applyPlanFrom(snapshot.plan, targetDate, {
+          fromSnapshot: snapshot.fromSnapshot,
+          snapshotCapturedAt: snapshot.snapshotCapturedAt,
+        });
+      } catch (err) {
+        console.error(err);
+        setLoadError('We couldn’t load that planning day. Try another date.');
+      } finally {
+        setLoadBusyAction(null);
+      }
+    },
+    [editable, loadResult, applyPlanFrom],
+  );
+
+  const activeLoadResult = useMemo(
+    () =>
+      loadResult && loadSelectedDate && loadResult.date === loadSelectedDate
+        ? loadResult
+        : null,
+    [loadResult, loadSelectedDate],
+  );
   const draggingRef = useRef(false);
   const [startMinute, setStartMinute] = useState(DEFAULT_START);
   const [endMinute, setEndMinute] = useState(DEFAULT_END);
@@ -1931,6 +2238,11 @@ export default function EditorClient({
                 )}
               </div>
             ) : null}
+            {loadBanner ? (
+              <div className="w-full rounded-md border border-orange-200 bg-orange-50 px-3 py-2 text-sm text-orange-700 shadow-sm">
+                {loadBanner}
+              </div>
+            ) : null}
             {!review &&
               (editable ? (
                 <button
@@ -2006,6 +2318,16 @@ export default function EditorClient({
             >
               {live ? 'Live AI' : 'AI planning'}
             </button>
+            {!live && !review && editable && !snapshotDate && (
+              <Button
+                id={`p1an-load-plan-${userId}`}
+                variant="outline"
+                className="border-2 border-orange-400 bg-orange-50 px-3 py-2 text-orange-600 shadow-sm hover:bg-orange-100"
+                onClick={handleOpenLoadModal}
+              >
+                Load planning
+              </Button>
+            )}
             <Button
               id={`p1an-daily-aim-${userId}`}
               variant="outline"
@@ -3659,6 +3981,38 @@ export default function EditorClient({
           </div>
         </div>
       )}
+      <LoadPlanningModal
+        open={loadModalOpen}
+        onClose={handleCloseLoadModal}
+        step={loadModalStep}
+        selectedDate={loadSelectedDate}
+        onDateChange={(next) => {
+          setLoadSelectedDate(next);
+          setLoadError(null);
+        }}
+        onPreview={handlePreviewDate}
+        onSelect={(next) => copyPlanFromDate(next, 'select')}
+        onAddNow={(next) => copyPlanFromDate(next, 'add')}
+        onBack={handlePreviewBack}
+        loadingAction={loadBusyAction}
+        error={loadError}
+        snapshotDates={initialSnapshotDates}
+        previewPlan={activeLoadResult?.previewPlan ?? null}
+        previewMeta={
+          activeLoadResult
+            ? {
+                fromSnapshot: activeLoadResult.fromSnapshot,
+                snapshotCapturedAt: activeLoadResult.snapshotCapturedAt,
+              }
+            : null
+        }
+        tz={tz}
+        ingredientMap={ingredientMap}
+        flavorMap={flavorMap}
+        subflavorMap={subflavorMap}
+        currentPlanDate={date}
+        planningDateLabel={planningDateText}
+      />
       {aiOpen && (
         <div className="fixed inset-0 z-[1000000] flex items-center justify-center bg-black/20 backdrop-blur-md">
           <div className="flex w-[90%] max-w-2xl max-h-[90vh] flex-col rounded bg-white p-6 shadow-lg">

--- a/app/(app)/planning/next/load-planning-modal.tsx
+++ b/app/(app)/planning/next/load-planning-modal.tsx
@@ -1,0 +1,414 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { Plan } from '@/types/plan';
+import type { Ingredient } from '@/types/ingredient';
+import type { Flavor } from '@/types/flavor';
+import type { Subflavor } from '@/types/subflavor';
+
+interface PreviewMeta {
+  fromSnapshot: boolean;
+  snapshotCapturedAt: string | null;
+}
+
+interface LoadPlanningModalProps {
+  open: boolean;
+  onClose: () => void;
+  step: 'calendar' | 'preview';
+  selectedDate: string | null;
+  onDateChange: (date: string) => void;
+  onPreview: (date: string) => void;
+  onSelect: (date: string) => void;
+  onAddNow: (date: string) => void;
+  onBack: () => void;
+  loadingAction: 'preview' | 'select' | 'add' | null;
+  error: string | null;
+  snapshotDates: string[];
+  previewPlan: Plan | null;
+  previewMeta: PreviewMeta | null;
+  tz: string;
+  ingredientMap: Map<number, Ingredient>;
+  flavorMap: Map<string, Flavor>;
+  subflavorMap: Map<string, Subflavor>;
+  currentPlanDate: string;
+  planningDateLabel: string;
+}
+
+function formatDateLabel(date: string, tz: string) {
+  return new Date(`${date}T00:00:00`).toLocaleDateString('en-US', {
+    timeZone: tz,
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatTime(iso: string, tz: string) {
+  return new Date(iso).toLocaleTimeString([], {
+    timeZone: tz,
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function toMonth(date?: string) {
+  const base = date ? new Date(`${date}T00:00:00`) : new Date();
+  base.setDate(1);
+  return base;
+}
+
+export default function LoadPlanningModal({
+  open,
+  onClose,
+  step,
+  selectedDate,
+  onDateChange,
+  onPreview,
+  onSelect,
+  onAddNow,
+  onBack,
+  loadingAction,
+  error,
+  snapshotDates,
+  previewPlan,
+  previewMeta,
+  tz,
+  ingredientMap,
+  flavorMap,
+  subflavorMap,
+  currentPlanDate,
+  planningDateLabel,
+}: LoadPlanningModalProps) {
+  const [month, setMonth] = useState(() => toMonth(selectedDate || undefined));
+  const snapshotSet = useMemo(() => new Set(snapshotDates), [snapshotDates]);
+
+  useEffect(() => {
+    if (!open) return;
+    setMonth(toMonth(selectedDate || undefined));
+  }, [open, selectedDate]);
+
+  const monthStart = new Date(month.getFullYear(), month.getMonth(), 1);
+  const monthEnd = new Date(month.getFullYear(), month.getMonth() + 1, 0);
+  const start = new Date(monthStart);
+  start.setDate(start.getDate() - start.getDay());
+  const end = new Date(monthEnd);
+  end.setDate(end.getDate() + (6 - end.getDay()));
+
+  const days: Date[] = [];
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    days.push(new Date(d));
+  }
+
+  const monthLabel = month.toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+  });
+
+  const weekDays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+  if (!open) return null;
+
+  const isPreviewing = loadingAction === 'preview';
+  const isSelecting = loadingAction === 'select';
+  const isAdding = loadingAction === 'add';
+
+  const sortedBlocks = previewPlan
+    ? [...previewPlan.blocks].sort(
+        (a, b) => new Date(a.start).getTime() - new Date(b.start).getTime(),
+      )
+    : [];
+
+  const dailyIngredientNames = previewPlan
+    ? (previewPlan.dailyIngredientIds ?? []).map(
+        (id) => ingredientMap.get(id)?.title ?? `Ingredient #${id}`,
+      )
+    : [];
+
+  const previewDateLabel = selectedDate
+    ? formatDateLabel(selectedDate, tz)
+    : '';
+
+  const snapshotDetail = previewMeta?.snapshotCapturedAt
+    ? new Date(previewMeta.snapshotCapturedAt).toLocaleString('en-US', {
+        timeZone: tz,
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+    : null;
+
+  return (
+    <div className="fixed inset-0 z-[12000] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4" onClick={onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="relative w-full max-w-3xl overflow-hidden rounded-2xl bg-white shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-orange-100 bg-orange-50 px-6 py-4">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-orange-500">
+              Planning for next day
+            </p>
+            <h2 className="text-lg font-semibold text-orange-700">
+              {planningDateLabel}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-orange-200 px-2 py-1 text-orange-600 hover:bg-orange-100"
+            aria-label="Close load planning"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="max-h-[75vh] overflow-y-auto px-6 py-5">
+          {step === 'calendar' ? (
+            <div className="space-y-4">
+              <p className="text-sm text-zinc-600">
+                Pick a past date to reuse its planning. Days with captured
+                snapshots glow in orange — perfect for quickly loading a tried
+                and true schedule.
+              </p>
+              <div className="rounded-2xl border border-orange-100 bg-white/80 p-4 shadow-inner">
+                <div className="mb-3 flex items-center justify-between">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="border-orange-200 text-orange-600"
+                    onClick={() =>
+                      setMonth((prev) => {
+                        const next = new Date(prev);
+                        next.setMonth(prev.getMonth() - 1);
+                        return next;
+                      })
+                    }
+                  >
+                    ❮
+                  </Button>
+                  <div className="text-sm font-semibold text-orange-600">
+                    {monthLabel}
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="border-orange-200 text-orange-600"
+                    onClick={() =>
+                      setMonth((prev) => {
+                        const next = new Date(prev);
+                        next.setMonth(prev.getMonth() + 1);
+                        return next;
+                      })
+                    }
+                  >
+                    ❯
+                  </Button>
+                </div>
+                <div className="grid grid-cols-7 gap-2 text-center text-xs text-zinc-500">
+                  {weekDays.map((day) => (
+                    <div key={day} className="font-semibold">
+                      {day}
+                    </div>
+                  ))}
+                  {days.map((day) => {
+                    const iso = day.toLocaleDateString('en-CA');
+                    const isSelected = iso === selectedDate;
+                    const hasSnapshot = snapshotSet.has(iso);
+                    const isCurrentPlan = iso === currentPlanDate;
+                    const isToday = day.toDateString() === new Date().toDateString();
+                    return (
+                      <button
+                        type="button"
+                        key={day.toISOString()}
+                        onClick={() => onDateChange(iso)}
+                        className={cn(
+                          'rounded-lg border px-1 py-2 text-sm transition',
+                          hasSnapshot
+                            ? 'border-orange-300 bg-orange-50 text-orange-700'
+                            : 'border-transparent bg-white',
+                          isSelected &&
+                            'border-orange-500 bg-orange-500 text-white shadow-md',
+                          !hasSnapshot && !isSelected &&
+                            'text-zinc-500 hover:border-orange-200 hover:bg-orange-50 hover:text-orange-700',
+                          isCurrentPlan && !isSelected && 'border-dashed border-orange-400',
+                          isToday && !isSelected && 'ring-1 ring-orange-400',
+                        )}
+                      >
+                        <div className="text-base font-semibold">{day.getDate()}</div>
+                        <div className="mt-1 text-[10px] uppercase tracking-wide text-orange-500">
+                          {hasSnapshot ? 'Snap' : ''}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              {error ? (
+                <p className="text-sm text-red-600">{error}</p>
+              ) : null}
+              <div className="flex flex-wrap justify-between gap-3">
+                <Button variant="outline" onClick={onClose} className="border-zinc-200">
+                  Cancel
+                </Button>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => selectedDate && onPreview(selectedDate)}
+                    disabled={!selectedDate || isPreviewing}
+                    className="border-orange-300 text-orange-600"
+                  >
+                    {isPreviewing ? 'Loading…' : 'Preview'}
+                  </Button>
+                  <Button
+                    onClick={() => selectedDate && onSelect(selectedDate)}
+                    disabled={!selectedDate || isSelecting}
+                    className="bg-orange-500 text-white shadow hover:bg-orange-600"
+                  >
+                    {isSelecting ? 'Loading…' : 'Select'}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="rounded-2xl border border-orange-100 bg-orange-50/60 p-4 shadow-inner">
+                <p className="text-xs uppercase tracking-wide text-orange-500">
+                  Previewing
+                </p>
+                <h3 className="text-xl font-semibold text-orange-700">
+                  {previewDateLabel}
+                </h3>
+                {previewMeta?.fromSnapshot ? (
+                  <p className="text-sm text-orange-600">
+                    Showing the historical snapshot
+                    {snapshotDetail ? ` captured ${snapshotDetail}` : ''}.
+                  </p>
+                ) : (
+                  <p className="text-sm text-orange-600">
+                    No snapshot for this day — previewing the latest saved plan.
+                  </p>
+                )}
+              </div>
+              {previewPlan?.dailyAim ? (
+                <div className="rounded-xl border border-orange-100 bg-white/90 p-4 shadow">
+                  <h4 className="text-sm font-semibold text-orange-700">Daily aim</h4>
+                  <p className="mt-1 whitespace-pre-wrap text-sm text-zinc-700">
+                    {previewPlan.dailyAim}
+                  </p>
+                </div>
+              ) : null}
+              {dailyIngredientNames.length > 0 ? (
+                <div className="rounded-xl border border-orange-100 bg-white/90 p-4 shadow">
+                  <h4 className="text-sm font-semibold text-orange-700">
+                    Daily ingredients
+                  </h4>
+                  <ul className="mt-2 space-y-1 text-sm text-zinc-700">
+                    {dailyIngredientNames.map((name, idx) => (
+                      <li key={`${name}-${idx}`}>• {name}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              <div className="rounded-2xl border border-orange-100 bg-white/90 p-4 shadow">
+                <h4 className="text-sm font-semibold text-orange-700">
+                  Schedule blocks
+                </h4>
+                <div className="mt-3 max-h-[280px] space-y-3 overflow-y-auto pr-1">
+                  {sortedBlocks.length === 0 ? (
+                    <p className="text-sm text-zinc-500">
+                      No activities were saved for this day.
+                    </p>
+                  ) : (
+                    sortedBlocks.map((block) => {
+                      const ingredientNames = (block.ingredientIds ?? [])
+                        .map((id) => ingredientMap.get(id)?.title)
+                        .filter(Boolean) as string[];
+                      const flavorNames = (block.flavorIds ?? [])
+                        .map((id) => flavorMap.get(id)?.name)
+                        .filter(Boolean) as string[];
+                      const subflavorNames = (block.subflavorIds ?? [])
+                        .map((id) => subflavorMap.get(id)?.name)
+                        .filter(Boolean) as string[];
+                      return (
+                        <div
+                          key={`${block.id}-${block.start}`}
+                          className="rounded-xl border border-orange-100 bg-orange-50/60 p-3 shadow-sm"
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <span className="text-sm font-semibold text-orange-700">
+                              {block.title || 'Untitled activity'}
+                            </span>
+                            <span className="text-xs font-medium text-orange-500">
+                              {formatTime(block.start, tz)} – {formatTime(block.end, tz)}
+                            </span>
+                          </div>
+                          {block.description ? (
+                            <p className="mt-2 whitespace-pre-wrap text-sm text-zinc-700">
+                              {block.description}
+                            </p>
+                          ) : null}
+                          {flavorNames.length > 0 || subflavorNames.length > 0 ? (
+                            <div className="mt-2 flex flex-wrap gap-1 text-[11px] text-orange-600">
+                              {[...flavorNames, ...subflavorNames].map((name) => (
+                                <span
+                                  key={`${block.id}-${name}`}
+                                  className="rounded-full bg-white/80 px-2 py-1 shadow"
+                                >
+                                  {name}
+                                </span>
+                              ))}
+                            </div>
+                          ) : null}
+                          {ingredientNames.length > 0 ? (
+                            <p className="mt-2 text-xs text-orange-500">
+                              Ingredients: {ingredientNames.join(', ')}
+                            </p>
+                          ) : null}
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+              </div>
+              {error ? (
+                <p className="text-sm text-red-600">{error}</p>
+              ) : null}
+              <div className="flex flex-wrap justify-between gap-3">
+                <Button
+                  variant="outline"
+                  onClick={onBack}
+                  className="border-orange-200 text-orange-600"
+                  disabled={isAdding}
+                >
+                  Choose another date
+                </Button>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => selectedDate && onSelect(selectedDate)}
+                    disabled={!selectedDate || isSelecting || isAdding}
+                    className="border-orange-300 text-orange-600"
+                  >
+                    {isSelecting ? 'Loading…' : 'Select'}
+                  </Button>
+                  <Button
+                    onClick={() => selectedDate && onAddNow(selectedDate)}
+                    disabled={!selectedDate || isAdding}
+                    className="bg-orange-500 text-white shadow hover:bg-orange-600"
+                  >
+                    {isAdding ? 'Adding…' : 'Add now'}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(app)/planning/next/page.tsx
+++ b/app/(app)/planning/next/page.tsx
@@ -14,6 +14,7 @@ import { listDailyReports } from '@/lib/daily-report-store';
 import { listWeeklyReports } from '@/lib/weekly-report-store';
 import { listMonthlyReports } from '@/lib/monthly-report-store';
 import { listTodos } from '@/lib/todos-store';
+import { listProfileSnapshotDates } from '@/lib/profile-snapshots';
 
 export const revalidate = 0;
 
@@ -48,6 +49,7 @@ export default async function PlanningNextPage({
     weeklyReports,
     monthlyReports,
     todos,
+    snapshotDates,
   ] = await Promise.all([
     getOrCreatePlan(me.id, dateStr),
     listIngredients(String(me.id), me.id),
@@ -58,6 +60,7 @@ export default async function PlanningNextPage({
     listWeeklyReports(me.id),
     listMonthlyReports(me.id),
     listTodos(String(me.id), me.id),
+    listProfileSnapshotDates(me.id),
   ]);
   const reportContext = {
     heading,
@@ -94,6 +97,7 @@ export default async function PlanningNextPage({
         flavors={flavors}
         subflavors={subflavors}
         todos={todos}
+        snapshotDates={snapshotDates}
         reportContext={reportContext}
         initialShowDailyAim={showDailyAim}
       />


### PR DESCRIPTION
## Summary
- add a server action to fetch past plans with snapshot-aware preview metadata
- introduce a load planning modal with calendar selection, snapshot preview, and plan import flow for next-day planning
- surface snapshot dates to the planner client, show success feedback, and update the changelog
- rebase imported next-day plans to the current date so loaded schedules include their activity blocks

## Testing
- pnpm lint
- pnpm exec tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68da8b3dcf14832ab861e708e054f326